### PR TITLE
adding fullnode and miner devnet to support boost itests and development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ ux/index.js
 ux/node_modules
 ux/package-lock.json
 filestore/_test/a/b/c/d/existing.txt
+dev.gen
+localnet.json
+lotus-daemon.log
+lotus-miner.log

--- a/cmd/devnet/main.go
+++ b/cmd/devnet/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/filecoin-project/boost/devnet"
+)
+
+func main() {
+	devnet.Main()
+}

--- a/devnet/README.md
+++ b/devnet/README.md
@@ -5,10 +5,18 @@ Runs a Lotus daemon and miner to be used for boost integration tests.
 To run it locally, install ./cmd/devnet and the lotus binaries into your $PATH, and
 simply run one of the integration tests - it should start devnet automatically.
 
-### Building and installing Lotus
+### Building and installing Lotus-related binaries
 
 	git clone https://github.com/filecoin-project/lotus
 	cd lotus
 	git checkout master # or whichever version
 	make debug
-	sudo make install # or "cp lotus lotus-*" into your $PATH
+	sudo make install
+	install -C ./lotus-seed /usr/local/bin/lotus-seed
+
+### Clean up state directories
+
+Make sure your $LOTUS_PATH and $LOTUS_MINER_PATH are clean before running devnet:
+
+	rm -rf ~/.lotus
+	rm -rf ~/.lotusminer

--- a/devnet/README.md
+++ b/devnet/README.md
@@ -1,0 +1,14 @@
+# devnet
+
+Runs a Lotus daemon and miner to be used for boost integration tests.
+
+To run it locally, install ./cmd/devnet and the lotus binaries into your $PATH, and
+simply run one of the integration tests - it should start devnet automatically.
+
+### Building and installing Lotus
+
+	git clone https://github.com/filecoin-project/lotus
+	cd lotus
+	git checkout master # or whichever version
+	make debug
+	sudo make install # or "cp lotus lotus-*" into your $PATH

--- a/devnet/devnet.go
+++ b/devnet/devnet.go
@@ -1,0 +1,174 @@
+package devnet
+
+import (
+	"context"
+	"log"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+)
+
+func runCmdsWithLog(ctx context.Context, name string, commands [][]string) {
+	logFile, err := os.Create(name + ".log")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer logFile.Close()
+
+	for _, cmdArgs := range commands {
+		log.Printf("command for %s: %s", name, strings.Join(cmdArgs, " "))
+		cmd := exec.CommandContext(ctx, cmdArgs[0], cmdArgs[1:]...)
+		cmd.Stdout = logFile
+		cmd.Stderr = logFile
+		// If ctx.Err()!=nil, we cancelled the command via SIGINT.
+		if err := cmd.Run(); err != nil && ctx.Err() == nil {
+			log.Printf("%s; check %s for details", err, logFile.Name())
+			break
+		}
+	}
+}
+
+func runLotusDaemon(ctx context.Context, home string) {
+	cmds := [][]string{
+		{"lotus-seed", "genesis", "new", "localnet.json"},
+		{"lotus-seed", "pre-seal", "--sector-size=2048", "--num-sectors=10"},
+		{"lotus-seed", "genesis", "add-miner", "localnet.json",
+			filepath.Join(home, ".genesis-sectors", "pre-seal-t01000.json")},
+		{"lotus", "daemon", "--lotus-make-genesis=dev.gen",
+			"--genesis-template=localnet.json", "--bootstrap=false"},
+	}
+
+	runCmdsWithLog(ctx, "lotus-daemon", cmds)
+}
+
+func runLotusMiner(ctx context.Context, home string) {
+	cmds := [][]string{
+		{"lotus", "wait-api"}, // wait for lotus node to run
+
+		{"lotus", "wallet", "import",
+			filepath.Join(home, ".genesis-sectors", "pre-seal-t01000.key")},
+		{"lotus-miner", "init", "--genesis-miner", "--actor=t01000", "--sector-size=2048",
+			"--pre-sealed-sectors=" + filepath.Join(home, ".genesis-sectors"),
+			"--pre-sealed-metadata=" + filepath.Join(home, ".genesis-sectors", "pre-seal-t01000.json"),
+			"--nosync"},
+
+		// Starting in network version 13,
+		// pre-commits are batched by default,
+		// and commits are aggregated by default.
+		// This means deals could sit at StorageDealAwaitingPreCommit or
+		// StorageDealSealing for a while, going past our 10m test timeout.
+		//{"sed", "-ri",
+		//"-e", `s/#(\s*BatchPreCommits\s*=\s*)true/ \1false/`,
+		//"-e", `s/#(\s*AggregateCommits\s*=\s*)true/ \1false/`,
+		//filepath.Join(home, ".lotusminer", "config.toml")},
+
+		{"lotus-miner", "run", "--nosync"},
+	}
+
+	runCmdsWithLog(ctx, "lotus-miner", cmds)
+}
+
+func publishDealsPeriodicallyCmd(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(5 * time.Second):
+		}
+
+		cmd := exec.CommandContext(ctx, "lotus-miner",
+			"storage-deals", "pending-publish", "--publish-now")
+		cmd.Run() // we ignore errors
+	}
+}
+
+func setDefaultWalletCmd(ctx context.Context) {
+	// TODO: do this without a shell
+	setDefaultWalletCmd := "lotus wallet list | grep t3 | awk '{print $1}' | xargs lotus wallet set-default"
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(5 * time.Second):
+		}
+
+		cmd := exec.CommandContext(ctx, "sh", "-c", setDefaultWalletCmd)
+		_, err := cmd.CombinedOutput()
+		if err != nil {
+			continue
+		}
+		// TODO: stop once we've set the default wallet once.
+	}
+}
+
+func Main() {
+	var wg sync.WaitGroup
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// The parameter files can be as large as 1GiB.
+	// If this is the first time lotus runs,
+	// and the machine doesn't have particularly fast internet,
+	// we don't want devnet to seemingly stall for many minutes.
+	// Instead, show the download progress explicitly.
+	// fetch-params will exit in about a second if all files are up to date.
+	// The command is also pretty verbose, so reduce its verbosity.
+	{
+		// Ten minutes should be enough for practically any machine.
+		ctx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+
+		log.Println("Running 'lotus fetch-params 2048'...")
+		cmd := exec.CommandContext(ctx, "lotus", "fetch-params", "2048")
+		cmd.Env = append(os.Environ(), "GOLOG_LOG_LEVEL=error")
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			log.Fatal(err)
+		}
+		cancel()
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	wg.Add(4)
+	go func() {
+		runLotusDaemon(ctx, home)
+		wg.Done()
+	}()
+
+	go func() {
+		runLotusMiner(ctx, home)
+		wg.Done()
+	}()
+
+	go func() {
+		publishDealsPeriodicallyCmd(ctx)
+		wg.Done()
+	}()
+
+	go func() {
+		setDefaultWalletCmd(ctx)
+		wg.Done()
+	}()
+
+	// setup a signal handler to cancel the context
+	interrupt := make(chan os.Signal, 1)
+	signal.Notify(interrupt, syscall.SIGTERM, syscall.SIGINT)
+	select {
+	case <-interrupt:
+		log.Println("closing as we got interrupt")
+		cancel()
+	case <-ctx.Done():
+	}
+
+	wg.Wait()
+}

--- a/devnet/devnet.go
+++ b/devnet/devnet.go
@@ -62,10 +62,10 @@ func runLotusMiner(ctx context.Context, home string) {
 		// and commits are aggregated by default.
 		// This means deals could sit at StorageDealAwaitingPreCommit or
 		// StorageDealSealing for a while, going past our 10m test timeout.
-		//{"sed", "-ri",
-		//"-e", `s/#(\s*BatchPreCommits\s*=\s*)true/ \1false/`,
-		//"-e", `s/#(\s*AggregateCommits\s*=\s*)true/ \1false/`,
-		//filepath.Join(home, ".lotusminer", "config.toml")},
+		{"sed", "-ri",
+			"-e", `s/#(\s*BatchPreCommits\s*=\s*)true/ \1false/`,
+			"-e", `s/#(\s*AggregateCommits\s*=\s*)true/ \1false/`,
+			filepath.Join(home, ".lotusminer", "config.toml")},
 
 		{"lotus-miner", "run", "--nosync"},
 	}

--- a/devnet/devnet.go
+++ b/devnet/devnet.go
@@ -84,7 +84,7 @@ func publishDealsPeriodicallyCmd(ctx context.Context) {
 
 		cmd := exec.CommandContext(ctx, "lotus-miner",
 			"storage-deals", "pending-publish", "--publish-now")
-		cmd.Run() // we ignore errors
+		_ = cmd.Run() // we ignore errors
 	}
 }
 

--- a/devnet/devnet.go
+++ b/devnet/devnet.go
@@ -62,9 +62,10 @@ func runLotusMiner(ctx context.Context, home string) {
 		// and commits are aggregated by default.
 		// This means deals could sit at StorageDealAwaitingPreCommit or
 		// StorageDealSealing for a while, going past our 10m test timeout.
-		{"sed", "-ri",
-			"-e", `s/#(\s*BatchPreCommits\s*=\s*)true/ \1false/`,
-			"-e", `s/#(\s*AggregateCommits\s*=\s*)true/ \1false/`,
+		{"sed", "-ri", "-e", "s/#BatchPreCommits\\ =\\ true/BatchPreCommits=false/",
+			filepath.Join(home, ".lotusminer", "config.toml")},
+
+		{"sed", "-ri", "-e", "s/#AggregateCommits\\ =\\ true/AggregateCommits=false/",
 			filepath.Join(home, ".lotusminer", "config.toml")},
 
 		{"lotus-miner", "run", "--nosync"},


### PR DESCRIPTION
This PR is adding a devnet command, so that we can easily start a fullnode and a miner, and get `boost` to connect to the miner in order to run end-to-end itests.