### PR TITLE
fix SectorBlocks dependency injection issue

### DIFF
--- a/node/impl/boost.go
+++ b/node/impl/boost.go
@@ -49,7 +49,7 @@ type BoostAPI struct {
 	//SectorAccessor    retrievalmarket.SectorAccessor    `optional:"true"`
 	//DataTransfer      dtypes.ProviderDataTransfer       `optional:"true"`
 	//DealPublisher     *storageadapter.DealPublisher     `optional:"true"`
-	SectorBlocks *sectorblocks.SectorBlocks
+	SectorBlocks *sectorblocks.SectorBlocks `optional:"true"`
 	//Host              host.Host                         `optional:"true"`
 	//DAGStore          *dagstore.DAGStore                `optional:"true"`
 


### PR DESCRIPTION
Resolves the following error on startup:
```
2021-11-15T16:43:22.250+0100    FATAL   boost   boost/main.go:47        creating node: starting node: could not build arguments for function "reflect".makeFuncStub (/Users/dirk/go/go1.16.9/src/reflect/asm_amd64.s:14): failed to build *sectorblocks.SectorBlocks: missing dependencies for function "reflect".makeFuncStub (/Users/dirk/go/go1.16.9/src/reflect/asm_amd64.s:14): missing type: dtypes.MetadataDS (did you mean dtypes.MetadataDS?)
Exiting.
```