### PR TITLE
add two wallets as required when initialising boost

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,11 @@ rm -rf ~/.lotus ~/.lotusminer
 2. Create Boost repository
 
 ```
-FULLNODE_API_INFO=/ip4/127.0.0.1/tcp/1234/http boost --vv init --api-sector-index=`lotus-miner auth api-info --perm=admin`
+FULLNODE_API_INFO=/ip4/127.0.0.1/tcp/1234/http \
+boost --vv init \
+      --api-sector-index=`lotus-miner auth api-info --perm=admin` \
+      --wallet-publish-storage-deals=`lotus wallet new bls` \
+      --wallet-collateral-pledge=`lotus wallet new bls`
 ```
 
 3. Run Boost service

--- a/cmd/boost/init.go
+++ b/cmd/boost/init.go
@@ -8,6 +8,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/boost/node/repo"
+	"github.com/filecoin-project/go-address"
 
 	cliutil "github.com/filecoin-project/boost/cli/util"
 	"github.com/filecoin-project/boost/node/config"
@@ -26,6 +27,16 @@ var initCmd = &cli.Command{
 			Usage:    "miner sector index API info",
 			Required: true,
 		},
+		&cli.StringFlag{
+			Name:     "wallet-publish-storage-deals",
+			Usage:    "wallet to be used for PublishStorageDeals messages",
+			Required: true,
+		},
+		&cli.StringFlag{
+			Name:     "wallet-collateral-pledge",
+			Usage:    "wallet to be used for pledging collateral",
+			Required: true,
+		},
 	},
 	Before: before,
 	Action: func(cctx *cli.Context) error {
@@ -34,6 +45,28 @@ var initCmd = &cli.Command{
 		ctx := lcli.ReqContext(cctx)
 
 		log.Debug("Trying to connect to full node RPC")
+
+		var walletPSD address.Address
+		if wPSD := cctx.String("wallet-publish-storage-deals"); wPSD != "" {
+			var err error
+			walletPSD, err = address.NewFromString(wPSD)
+			if err != nil {
+				return err
+			}
+		}
+
+		var walletCP address.Address
+		if wCP := cctx.String("wallet-collateral-pledge"); wCP != "" {
+			var err error
+			walletCP, err = address.NewFromString(wCP)
+			if err != nil {
+				return err
+			}
+		}
+
+		if walletPSD.String() == walletCP.String() {
+			return xerrors.Errorf("wallets for PublishStorageDeals and pledging collateral must be different")
+		}
 
 		if err := checkV1ApiSupport(ctx, cctx); err != nil {
 			return err
@@ -103,6 +136,8 @@ var initCmd = &cli.Command{
 				}
 				rcfg.SectorIndexApiInfo = ai
 
+				rcfg.Wallets.Miner = walletCP
+				rcfg.Wallets.PublishStorageDeals = walletPSD
 			})
 			if cerr != nil {
 				return cerr

--- a/cmd/boost/init.go
+++ b/cmd/boost/init.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/urfave/cli/v2"
@@ -46,22 +47,14 @@ var initCmd = &cli.Command{
 
 		log.Debug("Trying to connect to full node RPC")
 
-		var walletPSD address.Address
-		if wPSD := cctx.String("wallet-publish-storage-deals"); wPSD != "" {
-			var err error
-			walletPSD, err = address.NewFromString(wPSD)
-			if err != nil {
-				return err
-			}
+		walletPSD, err := address.NewFromString(cctx.String("wallet-publish-storage-deals"))
+		if err != nil {
+			return fmt.Errorf("failed to parse wallet-publish-storage-deals: %s; err: %w", cctx.String("wallet-publish-storage-deals"), err)
 		}
 
-		var walletCP address.Address
-		if wCP := cctx.String("wallet-collateral-pledge"); wCP != "" {
-			var err error
-			walletCP, err = address.NewFromString(wCP)
-			if err != nil {
-				return err
-			}
+		walletCP, err := address.NewFromString(cctx.String("wallet-collateral-pledge"))
+		if err != nil {
+			return fmt.Errorf("failed to parse wallet-collateral-pledge: %s; err: %w", cctx.String("wallet-collateral-pledge"), err)
 		}
 
 		if walletPSD.String() == walletCP.String() {

--- a/cmd/boost/init.go
+++ b/cmd/boost/init.go
@@ -136,8 +136,8 @@ var initCmd = &cli.Command{
 				}
 				rcfg.SectorIndexApiInfo = ai
 
-				rcfg.Wallets.Miner = walletCP
-				rcfg.Wallets.PublishStorageDeals = walletPSD
+				rcfg.Wallets.Miner = walletCP.String()
+				rcfg.Wallets.PublishStorageDeals = walletPSD.String()
 			})
 			if cerr != nil {
 				return cerr

--- a/cmd/devnet/main.go
+++ b/cmd/devnet/main.go
@@ -8,7 +8,13 @@ import (
 	"syscall"
 
 	"github.com/filecoin-project/boost/pkg/devnet"
+
+	logging "github.com/ipfs/go-log/v2"
 )
+
+func init() {
+	_ = logging.SetLogLevel("devnet", "DEBUG")
+}
 
 func main() {
 	ctx, cancel := context.WithCancel(context.Background())

--- a/node/builder.go
+++ b/node/builder.go
@@ -3,6 +3,7 @@ package node
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/filecoin-project/boost/db"
@@ -354,11 +355,11 @@ func ConfigBoost(c interface{}) Option {
 
 	walletPSD, err := address.NewFromString(cfg.Wallets.PublishStorageDeals)
 	if err != nil {
-		return Error(err)
+		return Error(fmt.Errorf("failed to parse cfg.Wallets.PublishStorageDeals: %s; err: %w", cfg.Wallets.PublishStorageDeals, err))
 	}
 	walletMiner, err := address.NewFromString(cfg.Wallets.Miner)
 	if err != nil {
-		return Error(err)
+		return Error(fmt.Errorf("failed to parse cfg.Wallets.Miner: %s; err: %w", cfg.Wallets.Miner, err))
 	}
 
 	return Options(

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/ipfs/go-cid"
 )
@@ -39,9 +38,9 @@ type Boost struct {
 
 type WalletsConfig struct {
 	// The "owner" address of the miner
-	Miner address.Address
+	Miner string
 	// The wallet used to send PublishStorageDeals messages
-	PublishStorageDeals address.Address
+	PublishStorageDeals string
 }
 
 type DAGStoreConfig struct {


### PR DESCRIPTION
Fixes: https://github.com/filecoin-project/boost/issues/33

TODO:
- [x] update README.md for starting `devnet` with exact commands to create a second wallet, send funds from first wallet to second (so that both wallets have funds) and pass these wallets to `boost init`