### PR TITLE
chore: port over some labels from Lotus

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -61,13 +61,13 @@
 #
 - name: dif/trivial
   color: b2b7ff
-  description: "Can be confidently tackled by newcomers, who are widely unfamiliar with lotus"
+  description: "Can be confidently tackled by newcomers, who are widely unfamiliar with Boost"
 - name: dif/easy
   color: 7886d7
-  description: "An existing lotus user should be able to pick this up"
+  description: "An existing Boost user should be able to pick this up"
 - name: dif/medium
   color: 6574cd
-  description: "Prior development experience with lotus is likely helpful"
+  description: "Prior development experience with Boost is likely helpful"
 - name: dif/hard
   color: 5661b3
   description: "Suggests that having worked on the specific component affected by this issue is important"

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,196 @@
+###
+### Special magic GitHub labels
+### https://help.github.com/en/github/building-a-strong-community/encouraging-helpful-contributions-to-your-project-with-labels
+#
+- name: "good first issue"
+  color: 7057ff
+  description: "Good for newcomers"
+- name: "help wanted"
+  color: 008672
+  description: "Extra attention is needed"
+
+###
+### Areas
+#
+- name: area/ux
+  color: 00A4E0
+  description: "Area: UX"
+- name: area/storage
+  color: 00A4E2
+  description: "Area: Storage"
+- name: area/retrieval
+  color: 00A4E4
+  description: "Area: Retrieval"
+- name: area/deals
+  color: 00A4E6
+  description: "Area: Deals"
+- name: area/funds
+  color: 00A4E8
+  description: "Area: Funds"
+
+###
+### Kinds
+#
+- name: kind/bug
+  color: c92712
+  description: "Kind: Bug"
+- name: kind/chore
+  color: fcf0b5
+  description: "Kind: Chore"
+- name: kind/feature
+  color: FFF3B8
+  description: "Kind: Feature"
+- name: kind/improvement
+  color: FFF5BA
+  description: "Kind: Improvement"
+- name: kind/test
+  color: FFF8BD
+  description: "Kind: Test"
+- name: kind/question
+  color: FFFDC2
+  description: "Kind: Question"
+- name: kind/enhancement
+  color: FFFFC5
+  description: "Kind: Enhancement"
+- name: kind/discussion
+  color: FFFFC7
+  description: "Kind: Discussion"
+
+###
+### Difficulties
+#
+- name: dif/trivial
+  color: b2b7ff
+  description: "Can be confidently tackled by newcomers, who are widely unfamiliar with lotus"
+- name: dif/easy
+  color: 7886d7
+  description: "An existing lotus user should be able to pick this up"
+- name: dif/medium
+  color: 6574cd
+  description: "Prior development experience with lotus is likely helpful"
+- name: dif/hard
+  color: 5661b3
+  description: "Suggests that having worked on the specific component affected by this issue is important"
+- name: dif/expert
+  color: 2f365f
+  description: "Requires extensive knowledge of the history, implications, ramifications of the issue"
+
+###
+### Efforts
+#
+- name: effort/minutes
+  color: e8fffe
+  description: "Effort: Minutes"
+- name: effort/hours
+  color: a0f0ed
+  description: "Effort: Hours"
+- name: effort/day
+  color: 64d5ca
+  description: "Effort: One Day"
+- name: effort/days
+  color: 4dc0b5
+  description: "Effort: Multiple Days"
+- name: effort/week
+  color: 38a89d
+  description: "Effort: One Week"
+- name: effort/weeks
+  color: 20504f
+  description: "Effort: Multiple Weeks"
+
+###
+### Impacts
+#
+- name: impact/regression
+  color: f1f5f8
+  description: "Impact: Regression"
+- name: impact/api-breakage
+  color: ECF0F3
+  description: "Impact: API Breakage"
+- name: impact/quality
+  color: E7EBEE
+  description: "Impact: Quality"
+- name: impact/dx
+  color: E2E6E9
+  description: "Impact: Developer Experience"
+- name: impact/test-flakiness
+  color: DDE1E4
+  description: "Impact: Test Flakiness"
+
+###
+### Topics
+#
+- name: topic/docs
+  color: D9298D
+  description: "Topic: Documentation"
+- name: topic/architecture
+  color: E53599
+  description: "Topic: Architecture"
+
+###
+### Priorities
+###
+- name: P0
+  color: dd362a
+  description: "P0: Critical Blocker"
+- name: P1
+  color: ce8048
+  description: "P1: Must be resolved"
+- name: P2
+  color: dbd81a
+  description: "P2: Should be resolved"
+- name: P3
+  color: 9fea8f
+  description: "P3: Might get resolved"
+
+###
+### Hints
+#
+- name: hint/needs-decision
+  color: 33B9A5
+  description: "Hint: Needs Decision"
+- name: hint/needs-triage
+  color: 1AA08C
+  description: "Hint: Needs Triage"
+- name: hint/needs-analysis
+  color: 26AC98
+  description: "Hint: Needs Analysis"
+- name: hint/needs-author-input
+  color: 33B9A5
+  description: "Hint: Needs Author Input"
+- name: hint/needs-team-input
+  color: 40C6B2
+  description: "Hint: Needs Team Input"
+- name: hint/needs-community-input
+  color: 4DD3BF
+  description: "Hint: Needs Community Input"
+- name: hint/needs-review
+  color: 5AE0CC
+  description: "Hint: Needs Review"
+
+###
+### Statuses
+#
+- name: status/done
+  color: edb3a6
+  description: "Status: Done"
+- name: status/deferred
+  color: E0A699
+  description: "Status: Deferred"
+- name: status/in-progress
+  color: D49A8D
+  description: "Status: In Progress"
+- name: status/blocked
+  color: C78D80
+  description: "Status: Blocked"
+- name: status/inactive
+  color: BA8073
+  description: "Status: Inactive"
+- name: status/waiting
+  color: AD7366
+  description: "Status: Waiting"
+- name: status/rotten
+  color: 7A4033
+  description: "Status: Rotten"
+- name: status/discarded
+  color: 6D3326
+  description: "Status: Discarded / Won't fix"


### PR DESCRIPTION
This copies over labels from Lotus to help with organizing a bit better.
I've simplified the area labels and made them contextual to Boost.

I started setting up some MIlestones and wanted to add some additional issues for
tracking based on what we're shooting for in those milestones, so having these would
be nice for helping to organize a bit more.