### PR TITLE
chore: remove improvement label

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -40,9 +40,6 @@
 - name: kind/feature
   color: FFF3B8
   description: "Kind: Feature"
-- name: kind/improvement
-  color: FFF5BA
-  description: "Kind: Improvement"
 - name: kind/test
   color: FFF8BD
   description: "Kind: Test"


### PR DESCRIPTION
We don't need it and the enhancement label, those are redundant. 
Also, I need to trigger a run of the workflow, due to order of operations problems here setting the workflow up.