### PR TITLE
initial dummydeal itest for boost with a devnet

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,80 +71,33 @@ jobs:
 
   test:
     description: |
-      Run tests with gotestsum.
+      Run go tests
     parameters: &test-params
       executor:
         type: executor
         default: golang
       go-test-flags:
         type: string
-        default: "-timeout 30m"
+        default: "-v -timeout 5m"
         description: Flags passed to go test.
       target:
         type: string
         default: "./..."
         description: Import paths of packages to be tested.
-      proofs-log-test:
-        type: string
-        default: "0"
-      suite:
-        type: string
-        default: unit
-        description: Test suite name to report to CircleCI.
-      gotestsum-format:
-        type: string
-        default: standard-verbose
-        description: gotestsum format. https://github.com/gotestyourself/gotestsum#format
-      coverage:
-        type: string
-        default: -coverprofile=coverage.txt -coverpkg=github.com/filecoin-project/boost/...
-        description: Coverage flag. Set to the empty string to disable.
-      codecov-upload:
-        type: boolean
-        default: true
-        description: |
-          Upload coverage report to https://codecov.io/. Requires the codecov API token to be
-          set as an environment variable for private projects.
     executor: << parameters.executor >>
     steps:
       - install-deps
       - prepare
       - run:
-          command: make deps boost
+          command: make build
           no_output_timeout: 30m
-      - go/install-gotestsum:
-          gobin: $HOME/.local/bin
-          version: 0.5.2
       - run:
           name: go test
-          environment:
-            TEST_RUSTPROOFS_LOGS: << parameters.proofs-log-test >>
-            SKIP_CONFORMANCE: "1"
           command: |
-            mkdir -p /tmp/test-reports/<< parameters.suite >>
-            mkdir -p /tmp/test-artifacts
-            gotestsum \
-              --format << parameters.gotestsum-format >> \
-              --junitfile /tmp/test-reports/<< parameters.suite >>/junit.xml \
-              --jsonfile /tmp/test-artifacts/<< parameters.suite >>.json \
-              -- \
-              << parameters.coverage >> \
+            go test -v \
               << parameters.go-test-flags >> \
               << parameters.target >>
           no_output_timeout: 30m
-      - store_test_results:
-          path: /tmp/test-reports
-      - store_artifacts:
-          path: /tmp/test-artifacts/<< parameters.suite >>.json
-      - when:
-          condition: << parameters.codecov-upload >>
-          steps:
-            - go/install: {package: bash}
-            - go/install: {package: curl}
-            - run:
-                shell: /bin/bash -eo pipefail
-                command: |
-                  bash <(curl -s https://codecov.io/bash)
 
   build-macos:
     description: build darwin boost binary
@@ -269,3 +222,4 @@ workflows:
             tags:
               only:
                 - /^v\d+\.\d+\.\d+(-rc\d+)?$/
+      - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,4 +222,3 @@ workflows:
             tags:
               only:
                 - /^v\d+\.\d+\.\d+(-rc\d+)?$/
-      - test

--- a/cmd/boost/run.go
+++ b/cmd/boost/run.go
@@ -3,10 +3,12 @@ package main
 import (
 	"fmt"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/filecoin-project/boost/api"
 	"github.com/filecoin-project/boost/node"
 	"github.com/filecoin-project/boost/node/modules/dtypes"
 	"github.com/filecoin-project/boost/node/repo"
+	lrepo "github.com/filecoin-project/lotus/node/repo"
 
 	lapi "github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/api/v0api"
@@ -27,6 +29,15 @@ var runCmd = &cli.Command{
 			return xerrors.Errorf("getting full node api: %w", err)
 		}
 		defer ncloser()
+
+		//ctx := context.Background()
+		addr, headers, err := lcli.GetRawAPI(cctx, lrepo.FullNode, "v1")
+		if err != nil {
+			panic(err)
+		}
+
+		spew.Dump(addr)
+		spew.Dump(headers)
 
 		ctx := lcli.DaemonContext(cctx)
 

--- a/cmd/boost/run.go
+++ b/cmd/boost/run.go
@@ -3,12 +3,10 @@ package main
 import (
 	"fmt"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/filecoin-project/boost/api"
 	"github.com/filecoin-project/boost/node"
 	"github.com/filecoin-project/boost/node/modules/dtypes"
 	"github.com/filecoin-project/boost/node/repo"
-	lrepo "github.com/filecoin-project/lotus/node/repo"
 
 	lapi "github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/api/v0api"
@@ -29,15 +27,6 @@ var runCmd = &cli.Command{
 			return xerrors.Errorf("getting full node api: %w", err)
 		}
 		defer ncloser()
-
-		//ctx := context.Background()
-		addr, headers, err := lcli.GetRawAPI(cctx, lrepo.FullNode, "v1")
-		if err != nil {
-			panic(err)
-		}
-
-		spew.Dump(addr)
-		spew.Dump(headers)
 
 		ctx := lcli.DaemonContext(cctx)
 

--- a/cmd/devnet/main.go
+++ b/cmd/devnet/main.go
@@ -1,9 +1,31 @@
 package main
 
 import (
+	"context"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+
 	"github.com/filecoin-project/boost/pkg/devnet"
 )
 
 func main() {
-	devnet.Main()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go devnet.Run(ctx, done)
+
+	// setup a signal handler to cancel the context
+	interrupt := make(chan os.Signal, 1)
+	signal.Notify(interrupt, syscall.SIGTERM, syscall.SIGINT)
+	select {
+	case <-interrupt:
+		log.Println("closing as we got interrupt")
+		cancel()
+	case <-ctx.Done():
+	}
+
+	<-done
 }

--- a/go.mod
+++ b/go.mod
@@ -88,6 +88,7 @@ require (
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.1
 	github.com/ipfs/go-cidutil v0.0.2
 	github.com/ipfs/go-ipfs-chunker v0.0.5
 	github.com/ipfs/go-ipfs-exchange-offline v0.0.1

--- a/gql/server.go
+++ b/gql/server.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"path/filepath"
+	"runtime"
 
 	logging "github.com/ipfs/go-log/v2"
 
@@ -41,7 +43,13 @@ func (s *Server) Serve(ctx context.Context) error {
 	http.HandleFunc("/graphiql", graphiql(httpPort))
 
 	// Init graphQL schema
-	schemaText, err := ioutil.ReadFile("/Users/nonsense/code/src/github.com/filecoin-project/boost/gql/schema.graphql")
+	_, currentDir, _, ok := runtime.Caller(0)
+	if !ok {
+		return fmt.Errorf("couldnt call runtime.Caller")
+	}
+	fpath := filepath.Join(filepath.Dir(currentDir), "schema.graphql")
+
+	schemaText, err := ioutil.ReadFile(fpath)
 	if err != nil {
 		return err
 	}

--- a/gql/server.go
+++ b/gql/server.go
@@ -41,7 +41,7 @@ func (s *Server) Serve(ctx context.Context) error {
 	http.HandleFunc("/graphiql", graphiql(httpPort))
 
 	// Init graphQL schema
-	schemaText, err := ioutil.ReadFile("gql/schema.graphql")
+	schemaText, err := ioutil.ReadFile("/Users/nonsense/code/src/github.com/filecoin-project/boost/gql/schema.graphql")
 	if err != nil {
 		return err
 	}

--- a/itests/dummydeal_test.go
+++ b/itests/dummydeal_test.go
@@ -1,0 +1,99 @@
+package itests
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/filecoin-project/boost/api"
+	"github.com/filecoin-project/boost/node"
+	"github.com/filecoin-project/boost/node/modules/dtypes"
+	"github.com/filecoin-project/boost/node/repo"
+	"github.com/filecoin-project/boost/pkg/devnet"
+	"golang.org/x/xerrors"
+)
+
+func TestDummydeal(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go devnet.Run(ctx, done)
+
+	time.Sleep(45 * time.Second)
+
+	err := runBoost()
+	if err != nil {
+		panic(err)
+	}
+
+	<-done
+}
+
+func runBoost() error {
+	//fullnodeApi, ncloser, err := lcli.GetFullNodeAPIV1(cctx)
+	//if err != nil {
+	//return xerrors.Errorf("getting full node api: %w", err)
+	//}
+	//defer ncloser()
+
+	r := repo.NewMemory(nil)
+
+	ctx := context.Background()
+
+	shutdownChan := make(chan struct{})
+
+	var boostApi api.Boost
+	stop, err := node.New(ctx,
+		node.Boost(&boostApi),
+		node.Override(new(dtypes.ShutdownChan), shutdownChan),
+		node.Base(),
+		node.Repo(r),
+		//node.Override(new(v1api.FullNode), fullnodeApi),
+	)
+	if err != nil {
+		return xerrors.Errorf("creating node: %w", err)
+	}
+
+	// Bootstrap with full node
+	//remoteAddrs, err := fullnodeApi.NetAddrsListen(ctx)
+	//if err != nil {
+	//return xerrors.Errorf("getting full node libp2p address: %w", err)
+	//}
+
+	//log.Debugw("Bootstrapping boost libp2p network with full node", "maadr", remoteAddrs)
+
+	//if err := boostApi.NetConnect(ctx, remoteAddrs); err != nil {
+	//return xerrors.Errorf("connecting to full node (libp2p): %w", err)
+	//}
+
+	// Instantiate the boost service JSON RPC handler.
+	handler, err := node.BoostHandler(boostApi, true)
+	if err != nil {
+		return xerrors.Errorf("failed to instantiate rpc handler: %w", err)
+	}
+
+	//log.Debugw("Boost JSON RPC server is listening", "endpoint", endpoint)
+
+	endpoint, err := r.APIEndpoint()
+	if err != nil {
+		return xerrors.Errorf("getting API endpoint: %w", err)
+	}
+
+	// Serve the RPC.
+	rpcStopper, err := node.ServeRPC(handler, "boost", endpoint)
+	if err != nil {
+		return fmt.Errorf("failed to start json-rpc endpoint: %s", err)
+	}
+
+	// Monitor for shutdown.
+	finishCh := node.MonitorShutdown(shutdownChan,
+		node.ShutdownHandler{Component: "rpc server", StopFunc: rpcStopper},
+		node.ShutdownHandler{Component: "boost", StopFunc: stop},
+	)
+
+	<-finishCh
+
+	return nil
+}

--- a/itests/dummydeal_test.go
+++ b/itests/dummydeal_test.go
@@ -6,15 +6,26 @@ import (
 	"testing"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/filecoin-project/boost/api"
 	"github.com/filecoin-project/boost/node"
+	"github.com/filecoin-project/boost/node/config"
 	"github.com/filecoin-project/boost/node/modules/dtypes"
 	"github.com/filecoin-project/boost/node/repo"
 	"github.com/filecoin-project/boost/pkg/devnet"
+	"github.com/filecoin-project/lotus/api/client"
+	"github.com/filecoin-project/lotus/api/v1api"
+	logging "github.com/ipfs/go-log/v2"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/xerrors"
 )
 
+var log = logging.Logger("boosttest")
+
 func TestDummydeal(t *testing.T) {
+	_ = logging.SetLogLevel("boosttest", "DEBUG")
+	_ = logging.SetLogLevel("devnet", "DEBUG")
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -23,24 +34,47 @@ func TestDummydeal(t *testing.T) {
 
 	time.Sleep(45 * time.Second)
 
-	err := runBoost()
-	if err != nil {
-		panic(err)
-	}
+	err := runBoost(t)
+	require.NoError(t, err)
+
+	cancel()
 
 	<-done
 }
 
-func runBoost() error {
-	//fullnodeApi, ncloser, err := lcli.GetFullNodeAPIV1(cctx)
-	//if err != nil {
-	//return xerrors.Errorf("getting full node api: %w", err)
-	//}
-	//defer ncloser()
+func runBoost(t *testing.T) error {
+	ctx := context.Background()
+	addr := "ws://127.0.0.1:1234/rpc/v1"
+
+	fullnodeApi, closer, err := client.NewFullNodeRPCV1(ctx, addr, nil)
+	require.NoError(t, err)
+	defer closer()
 
 	r := repo.NewMemory(nil)
 
-	ctx := context.Background()
+	creds, err := devnet.GetMinerEndpoint(ctx)
+	require.NoError(t, err)
+
+	lr, err := r.Lock(repo.Boost)
+	require.NoError(t, err)
+
+	c, err := lr.Config()
+	require.NoError(t, err)
+
+	cfg, ok := c.(*config.Boost)
+	if !ok {
+		t.Fatalf("invalid config from repo, got: %T", c)
+	}
+	cfg.SectorIndexApiInfo = creds
+
+	err = lr.SetConfig(func(raw interface{}) {
+		rcfg := raw.(*config.Boost)
+		*rcfg = *cfg
+	})
+	require.NoError(t, err)
+
+	err = lr.Close()
+	require.NoError(t, err)
 
 	shutdownChan := make(chan struct{})
 
@@ -50,23 +84,23 @@ func runBoost() error {
 		node.Override(new(dtypes.ShutdownChan), shutdownChan),
 		node.Base(),
 		node.Repo(r),
-		//node.Override(new(v1api.FullNode), fullnodeApi),
+		node.Override(new(v1api.FullNode), fullnodeApi),
 	)
 	if err != nil {
 		return xerrors.Errorf("creating node: %w", err)
 	}
 
 	// Bootstrap with full node
-	//remoteAddrs, err := fullnodeApi.NetAddrsListen(ctx)
-	//if err != nil {
-	//return xerrors.Errorf("getting full node libp2p address: %w", err)
-	//}
+	remoteAddrs, err := fullnodeApi.NetAddrsListen(ctx)
+	if err != nil {
+		return xerrors.Errorf("getting full node libp2p address: %w", err)
+	}
 
-	//log.Debugw("Bootstrapping boost libp2p network with full node", "maadr", remoteAddrs)
+	log.Debugw("Bootstrapping boost libp2p network with full node", "maadr", remoteAddrs)
 
-	//if err := boostApi.NetConnect(ctx, remoteAddrs); err != nil {
-	//return xerrors.Errorf("connecting to full node (libp2p): %w", err)
-	//}
+	if err := boostApi.NetConnect(ctx, remoteAddrs); err != nil {
+		return xerrors.Errorf("connecting to full node (libp2p): %w", err)
+	}
 
 	// Instantiate the boost service JSON RPC handler.
 	handler, err := node.BoostHandler(boostApi, true)
@@ -74,12 +108,14 @@ func runBoost() error {
 		return xerrors.Errorf("failed to instantiate rpc handler: %w", err)
 	}
 
-	//log.Debugw("Boost JSON RPC server is listening", "endpoint", endpoint)
+	log.Debug("Getting API endpoint of boost node")
 
 	endpoint, err := r.APIEndpoint()
 	if err != nil {
 		return xerrors.Errorf("getting API endpoint: %w", err)
 	}
+
+	log.Debugw("Boost JSON RPC server is listening", "endpoint", endpoint)
 
 	// Serve the RPC.
 	rpcStopper, err := node.ServeRPC(handler, "boost", endpoint)
@@ -87,13 +123,22 @@ func runBoost() error {
 		return fmt.Errorf("failed to start json-rpc endpoint: %s", err)
 	}
 
+	log.Debugw("Monitoring for shutdown")
+
 	// Monitor for shutdown.
 	finishCh := node.MonitorShutdown(shutdownChan,
 		node.ShutdownHandler{Component: "rpc server", StopFunc: rpcStopper},
 		node.ShutdownHandler{Component: "boost", StopFunc: stop},
 	)
 
-	<-finishCh
+	res, err := boostApi.MarketDummyDeal(ctx)
+	require.NoError(t, err)
+
+	log.Debugw("Got response from MarketDummyDeal", "res", spew.Sdump(res))
+
+	go func() { shutdownChan <- struct{}{} }()
+
+	go func() { stop(ctx); <-finishCh }()
 
 	return nil
 }

--- a/itests/dummydeal_test.go
+++ b/itests/dummydeal_test.go
@@ -127,7 +127,7 @@ func runBoost(t *testing.T) (api.Boost, func()) {
 
 	return api, func() {
 		shutdownChan <- struct{}{}
-		stop(ctx)
+		_ = stop(ctx)
 		<-finishCh
 		closer()
 	}

--- a/pkg/devnet/devnet.go
+++ b/pkg/devnet/devnet.go
@@ -5,13 +5,69 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"os/signal"
 	"path/filepath"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 )
+
+func Run(ctx context.Context, done chan struct{}) {
+	var wg sync.WaitGroup
+
+	// The parameter files can be as large as 1GiB.
+	// If this is the first time lotus runs,
+	// and the machine doesn't have particularly fast internet,
+	// we don't want devnet to seemingly stall for many minutes.
+	// Instead, show the download progress explicitly.
+	// fetch-params will exit in about a second if all files are up to date.
+	// The command is also pretty verbose, so reduce its verbosity.
+	{
+		// Ten minutes should be enough for practically any machine.
+		ctx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+
+		log.Println("Running 'lotus fetch-params 2048'...")
+		cmd := exec.CommandContext(ctx, "lotus", "fetch-params", "2048")
+		cmd.Env = append(os.Environ(), "GOLOG_LOG_LEVEL=error")
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			log.Fatal(err)
+		}
+		cancel()
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	wg.Add(4)
+	go func() {
+		runLotusDaemon(ctx, home)
+		log.Println("shut down lotus daemon")
+		wg.Done()
+	}()
+
+	go func() {
+		runLotusMiner(ctx, home)
+		log.Println("shut down lotus miner")
+		wg.Done()
+	}()
+
+	go func() {
+		publishDealsPeriodicallyCmd(ctx)
+		wg.Done()
+	}()
+
+	go func() {
+		setDefaultWalletCmd(ctx)
+		wg.Done()
+	}()
+
+	wg.Wait()
+
+	done <- struct{}{}
+}
 
 func runCmdsWithLog(ctx context.Context, name string, commands [][]string) {
 	logFile, err := os.Create(name + ".log")
@@ -106,70 +162,4 @@ func setDefaultWalletCmd(ctx context.Context) {
 		}
 		// TODO: stop once we've set the default wallet once.
 	}
-}
-
-func Main() {
-	var wg sync.WaitGroup
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	// The parameter files can be as large as 1GiB.
-	// If this is the first time lotus runs,
-	// and the machine doesn't have particularly fast internet,
-	// we don't want devnet to seemingly stall for many minutes.
-	// Instead, show the download progress explicitly.
-	// fetch-params will exit in about a second if all files are up to date.
-	// The command is also pretty verbose, so reduce its verbosity.
-	{
-		// Ten minutes should be enough for practically any machine.
-		ctx, cancel := context.WithTimeout(ctx, 10*time.Minute)
-
-		log.Println("Running 'lotus fetch-params 2048'...")
-		cmd := exec.CommandContext(ctx, "lotus", "fetch-params", "2048")
-		cmd.Env = append(os.Environ(), "GOLOG_LOG_LEVEL=error")
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		if err := cmd.Run(); err != nil {
-			log.Fatal(err)
-		}
-		cancel()
-	}
-
-	home, err := os.UserHomeDir()
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	wg.Add(4)
-	go func() {
-		runLotusDaemon(ctx, home)
-		wg.Done()
-	}()
-
-	go func() {
-		runLotusMiner(ctx, home)
-		wg.Done()
-	}()
-
-	go func() {
-		publishDealsPeriodicallyCmd(ctx)
-		wg.Done()
-	}()
-
-	go func() {
-		setDefaultWalletCmd(ctx)
-		wg.Done()
-	}()
-
-	// setup a signal handler to cancel the context
-	interrupt := make(chan os.Signal, 1)
-	signal.Notify(interrupt, syscall.SIGTERM, syscall.SIGINT)
-	select {
-	case <-interrupt:
-		log.Println("closing as we got interrupt")
-		cancel()
-	case <-ctx.Done():
-	}
-
-	wg.Wait()
 }


### PR DESCRIPTION
TODO:
- [x] instantiate test boost node connected to fullnode and miner launched by the devnet
- [x] make sure TestDummydeal passes
- [x] add `go test ./...` to our CI
- [ ] get `lotus`, `lotus-seed`, `lotus-miner` in the CI PATH
- [x] fix relative/absolute path for gql
- [ ] set `HOME` to a temporary dir... or fix https://github.com/filecoin-project/boost/issues/32 - so that we avoid having to do `rm -rf ~/.lotus ~/.lotusminer`