### PR TITLE
ux - publish now

### DIFF
--- a/gql/resolver_dealpublish.go
+++ b/gql/resolver_dealpublish.go
@@ -55,3 +55,9 @@ func (r *dealPublishResolver) Deals(ctx context.Context) ([]*dealResolver, error
 
 	return deals, nil
 }
+
+// mutation: dealPublishNow(): bool
+func (r *resolver) DealPublishNow(ctx context.Context) (bool, error) {
+	r.publisher.ForcePublishPendingDeals()
+	return true, nil
+}

--- a/gql/schema.graphql
+++ b/gql/schema.graphql
@@ -89,6 +89,9 @@ type RootQuery {
 type RootMutation {
   """Cancel a Deal"""
   dealCancel(id: ID!): ID!
+
+  """Publish all pending deals now"""
+  dealPublishNow: Boolean!
 }
 
 type RootSubscription {

--- a/react/src/DealDetail.js
+++ b/react/src/DealDetail.js
@@ -42,7 +42,7 @@ export function DealDetail(props) {
     return <div className="deal-detail modal" id={deal.ID}>
         <div className="content">
             <div className="close" onClick={props.onCloseClick}>
-                <div className="button">X</div>
+                <div>X</div>
             </div>
             <div className="title">Deal {deal.ID}</div>
             <table className="deal-fields">

--- a/react/src/DealPublish.js
+++ b/react/src/DealPublish.js
@@ -1,10 +1,13 @@
-import {useQuery} from "./hooks";
-import {DealPublishQuery} from "./gql";
+import {useMutation, useQuery} from "./hooks";
+import {DealPublishNowMutation, DealPublishQuery} from "./gql";
 import React from "react";
 import moment from "moment";
 
 export function DealPublishPage(props) {
     const {loading, error, data} = useQuery(DealPublishQuery)
+    const [publishNow] = useMutation(DealPublishNowMutation, {
+        refetchQueries: [{ query: DealPublishQuery }]
+    })
 
     if (loading) {
         return <div>Loading...</div>
@@ -18,10 +21,18 @@ export function DealPublishPage(props) {
 
     var deals = data.dealPublish.Deals
     return <div>
-        <p>
-            {deals.length} deal{deals.length === 1 ? '' : 's'} will be published
-            at {publishTime.format('HH:mm:ss')} (in {publishTime.toNow()})
-        </p>
+        {deals.length ? (
+            <>
+            <div className="buttons">
+                <div className="button cancel" onClick={publishNow}>Publish Now</div>
+            </div>
+
+            <p>
+                {deals.length} deal{deals.length === 1 ? '' : 's'} will be published
+                at {publishTime.format('HH:mm:ss')} (in {publishTime.toNow()})
+            </p>
+            </>
+        ) : null}
 
         <table className="deal-publish">
             <tbody>
@@ -36,7 +47,9 @@ export function DealPublishPage(props) {
             </tbody>
         </table>
 
-        { deals.length && <DealsTable deals={deals} /> }
+        { deals.length ? <DealsTable deals={deals} /> : (
+            <p>There are no deals in the batch publish queue</p>
+        ) }
     </div>
 }
 

--- a/react/src/gql.js
+++ b/react/src/gql.js
@@ -139,6 +139,12 @@ const DealPublishQuery = gql`
     }
 `;
 
+const DealPublishNowMutation = gql`
+    mutation AppDealPublishNowMutation {
+        dealPublishNow
+    }
+`;
+
 export {
     gqlClient,
     gqlQuery,
@@ -151,4 +157,5 @@ export {
     FundsQuery,
     FundsLogsQuery,
     DealPublishQuery,
+    DealPublishNowMutation,
 }

--- a/react/src/index.css
+++ b/react/src/index.css
@@ -135,7 +135,7 @@ body.modal-open {
   float: right;
 }
 
-#deal-detail .buttons .button {
+.button {
   color: #fff;
   background-color: #3399ff;
   border-radius: 0.5em;
@@ -204,6 +204,16 @@ body.modal-open {
 
 #deal-publish p {
   padding-left: 1em
+}
+
+#deal-publish .buttons {
+  position: relative;
+}
+
+#deal-publish .buttons .button {
+  position: absolute;
+  right: -7em;
+  top: -1em;
 }
 
 .deal-publish td {


### PR DESCRIPTION
Add a "Publish Now" button to the batch publish deals page.
When the button is clicked calls a graphql mutation that tells the batch deal publisher to publish all pending deals.
This is equivalent to `lotus-miner storage-deals pending-publish --publish-now`