### PR TITLE
initial storage manager ; local filter for mpool ; various fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,7 +129,7 @@ jobs:
       - install-deps
       - prepare
       - run:
-          command: make build
+          command: make debug
           no_output_timeout: 30m
       - lotus-artefacts
       - run:
@@ -184,7 +184,7 @@ jobs:
           key: v3-go-deps-{{ arch }}-{{ checksum "~/go/src/github.com/filecoin-project/boost/go.sum" }}
       - install-deps
       - run:
-          command: make build
+          command: make debug
           no_output_timeout: 30m
       - run:
           name: check tag and version output match
@@ -237,7 +237,7 @@ jobs:
       - install-deps
       - prepare
       - run:
-          command: make deps
+          command: make debug deps
           no_output_timeout: 30m
       - go/install-golangci-lint:
           gobin: $HOME/.local/bin

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,6 @@ ifneq ($(strip $(LDFLAGS)),)
 endif
 
 GOFLAGS+=-ldflags="$(ldflags)"
-GOFLAGS+=--tags=debug
 
 
 ## FFI
@@ -61,6 +60,8 @@ build/.update-modules:
 ## MAIN BINARIES
 
 CLEAN+=build/.update-modules
+
+debug: GOFLAGS+=-tags=debug
 
 deps: $(BUILD_DEPS)
 .PHONY: deps

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ build/.update-modules:
 CLEAN+=build/.update-modules
 
 debug: GOFLAGS+=-tags=debug
+debug: build
 
 deps: $(BUILD_DEPS)
 .PHONY: deps

--- a/cmd/boost/dummydeal.go
+++ b/cmd/boost/dummydeal.go
@@ -273,7 +273,7 @@ func dealProposal(ctx context.Context, fullNode v0api.FullNode, rootCid cid.Cid,
 		StartEpoch:           startEpoch,
 		EndEpoch:             endEpoch,
 		StoragePricePerEpoch: abi.NewTokenAmount(1),
-		ProviderCollateral:   abi.NewTokenAmount(0),
+		ProviderCollateral:   abi.NewTokenAmount(152546066071935), // TODO: where is this minimum value coming from?
 		ClientCollateral:     abi.NewTokenAmount(0),
 	}
 

--- a/cmd/boost/dummydeal.go
+++ b/cmd/boost/dummydeal.go
@@ -273,7 +273,7 @@ func dealProposal(ctx context.Context, fullNode v0api.FullNode, rootCid cid.Cid,
 		StartEpoch:           startEpoch,
 		EndEpoch:             endEpoch,
 		StoragePricePerEpoch: abi.NewTokenAmount(1),
-		ProviderCollateral:   abi.NewTokenAmount(152546066071935), // TODO: where is this minimum value coming from?
+		ProviderCollateral:   abi.NewTokenAmount(162546066071935), // TODO: where is this minimum value coming from?
 		ClientCollateral:     abi.NewTokenAmount(0),
 	}
 

--- a/cmd/boost/dummydeal.go
+++ b/cmd/boost/dummydeal.go
@@ -89,11 +89,11 @@ var dummydealCmd = &cli.Command{
 		url := cctx.String("url")
 		if url == "" {
 			// Create a CAR file
-			randomFilepath, err := testutil.CreateRandomFile(rand.Int(), 2000000)
+			randomFilepath, err := testutil.CreateRandomFile(os.TempDir(), rand.Int(), 2000000)
 			if err != nil {
 				return fmt.Errorf("creating random file: %w", err)
 			}
-			payloadCid, carFilepath, err := testutil.CreateDenseCARv2(randomFilepath)
+			payloadCid, carFilepath, err := testutil.CreateDenseCARv2(os.TempDir(), randomFilepath)
 			if err != nil {
 				return fmt.Errorf("creating CAR: %w", err)
 			}

--- a/db/create.sql
+++ b/db/create.sql
@@ -49,3 +49,16 @@ CREATE TABLE IF NOT EXISTS FundsTagged (
     Collateral TEXT,
     PubMsg TEXT
 );
+
+CREATE TABLE IF NOT EXISTS StorageLogs (
+    DealUUID TEXT,
+    CreatedAt DateTime,
+    PieceSize TEXT,
+    LogText TEXT
+);
+
+CREATE TABLE IF NOT EXISTS StorageTagged (
+    DealUUID TEXT,
+    CreatedAt DateTime,
+    PieceSize TEXT
+);

--- a/db/fixtures.go
+++ b/db/fixtures.go
@@ -101,7 +101,7 @@ func GenerateDeals() ([]types.ProviderDealState, error) {
 			SectorID:    abi.SectorNumber(rand.Intn(10000)),
 			Offset:      abi.PaddedPieceSize(rand.Intn(1000000)),
 			Length:      abi.PaddedPieceSize(rand.Intn(1000000)),
-			Checkpoint:  dealcheckpoints.New,
+			Checkpoint:  dealcheckpoints.Accepted,
 		}
 
 		deals = append(deals, deal)

--- a/db/storage.go
+++ b/db/storage.go
@@ -27,11 +27,9 @@ func NewStorageDB(db *sql.DB) *StorageDB {
 }
 
 func (s *StorageDB) Tag(ctx context.Context, dealUuid uuid.UUID, pieceSize abi.PaddedPieceSize) error {
-	ps := big.NewIntUnsigned(uint64(pieceSize))
-
 	qry := "INSERT INTO StorageTagged (DealUUID, CreatedAt, PieceSize) "
 	qry += "VALUES (?, ?, ?)"
-	values := []interface{}{dealUuid, time.Now(), ps.String()}
+	values := []interface{}{dealUuid, time.Now(), fmt.Sprintf("%d", pieceSize)}
 	_, err := s.db.ExecContext(ctx, qry, values...)
 	return err
 }
@@ -64,11 +62,9 @@ func (s *StorageDB) InsertLog(ctx context.Context, logs ...*StorageLog) error {
 			l.CreatedAt = now
 		}
 
-		ps := big.NewIntUnsigned(uint64(l.PieceSize))
-
 		qry := "INSERT INTO StorageLogs (DealUUID, CreatedAt, PieceSize, LogText) "
 		qry += "VALUES (?, ?, ?, ?)"
-		values := []interface{}{l.DealUUID, l.CreatedAt, ps.String(), l.Text}
+		values := []interface{}{l.DealUUID, l.CreatedAt, fmt.Sprintf("%d", l.PieceSize), l.Text}
 		_, err := s.db.ExecContext(ctx, qry, values...)
 		if err != nil {
 			return fmt.Errorf("inserting storage log: %w", err)

--- a/db/storage.go
+++ b/db/storage.go
@@ -1,0 +1,148 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
+	"github.com/google/uuid"
+)
+
+type StorageLog struct {
+	DealUUID  uuid.UUID
+	CreatedAt time.Time
+	PieceSize abi.PaddedPieceSize
+	Text      string
+}
+
+type StorageDB struct {
+	db *sql.DB
+}
+
+func NewStorageDB(db *sql.DB) *StorageDB {
+	return &StorageDB{db: db}
+}
+
+func (s *StorageDB) Tag(ctx context.Context, dealUuid uuid.UUID, pieceSize abi.PaddedPieceSize) error {
+	ps := big.NewIntUnsigned(uint64(pieceSize))
+
+	qry := "INSERT INTO StorageTagged (DealUUID, CreatedAt, PieceSize) "
+	qry += "VALUES (?, ?, ?)"
+	values := []interface{}{dealUuid, time.Now(), ps.String()}
+	_, err := s.db.ExecContext(ctx, qry, values...)
+	return err
+}
+
+func (s *StorageDB) Untag(ctx context.Context, dealUuid uuid.UUID) (abi.PaddedPieceSize, error) {
+	qry := "SELECT PieceSize FROM StorageTagged WHERE DealUUID = ?"
+	row := s.db.QueryRowContext(ctx, qry, dealUuid)
+
+	ps := &bigIntFieldDef{f: new(big.Int)}
+	err := row.Scan(&ps.marshalled)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return abi.PaddedPieceSize(0), nil
+		}
+		return abi.PaddedPieceSize(0), fmt.Errorf("getting untagged amount: %w", err)
+	}
+	err = ps.unmarshall()
+	if err != nil {
+		return abi.PaddedPieceSize(0), fmt.Errorf("unmarshalling untagged PieceSize")
+	}
+
+	_, err = s.db.ExecContext(ctx, "DELETE FROM StorageTagged WHERE DealUUID = ?", dealUuid)
+	return abi.PaddedPieceSize((*ps.f).Uint64()), err
+}
+
+func (s *StorageDB) InsertLog(ctx context.Context, logs ...*StorageLog) error {
+	now := time.Now()
+	for _, l := range logs {
+		if l.CreatedAt.IsZero() {
+			l.CreatedAt = now
+		}
+
+		ps := big.NewIntUnsigned(uint64(l.PieceSize))
+
+		qry := "INSERT INTO StorageLogs (DealUUID, CreatedAt, PieceSize, LogText) "
+		qry += "VALUES (?, ?, ?, ?)"
+		values := []interface{}{l.DealUUID, l.CreatedAt, ps.String(), l.Text}
+		_, err := s.db.ExecContext(ctx, qry, values...)
+		if err != nil {
+			return fmt.Errorf("inserting storage log: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (s *StorageDB) Logs(ctx context.Context) ([]StorageLog, error) {
+	qry := "SELECT DealUUID, CreatedAt, PieceSize, LogText FROM StorageLogs"
+	rows, err := s.db.QueryContext(ctx, qry)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	storageLogs := make([]StorageLog, 0, 16)
+	for rows.Next() {
+		ps := &bigIntFieldDef{f: new(big.Int)}
+
+		var storageLog StorageLog
+		err := rows.Scan(
+			&storageLog.DealUUID,
+			&storageLog.CreatedAt,
+			&ps.marshalled,
+			&storageLog.Text)
+
+		if err != nil {
+			return nil, err
+		}
+
+		err = ps.unmarshall()
+		if err != nil {
+			return nil, fmt.Errorf("unmarshalling PieceSize: %w", err)
+		}
+
+		storageLog.PieceSize = abi.PaddedPieceSize((*ps.f).Uint64())
+		storageLogs = append(storageLogs, storageLog)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return storageLogs, nil
+}
+
+func (s *StorageDB) TotalTagged(ctx context.Context) (abi.PaddedPieceSize, error) {
+	rows, err := s.db.QueryContext(ctx, "SELECT PieceSize FROM StorageTagged")
+	if err != nil {
+		return 0, fmt.Errorf("getting total tagged: %w", err)
+	}
+	defer rows.Close()
+
+	total := big.NewIntUnsigned(0)
+
+	for rows.Next() {
+		val := &bigIntFieldDef{f: new(big.Int)}
+		err := rows.Scan(&val.marshalled)
+		if err != nil {
+			return 0, fmt.Errorf("getting piece size: %w", err)
+		}
+
+		err = val.unmarshall()
+		if err != nil {
+			return 0, fmt.Errorf("unmarshalling untagged PieceSize: %w", err)
+		}
+		if val.f.Int != nil {
+			total = big.Add(total, *val.f)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return 0, fmt.Errorf("getting total tagged: %w", err)
+	}
+
+	return abi.PaddedPieceSize(total.Uint64()), nil
+}

--- a/db/storage_test.go
+++ b/db/storage_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/google/uuid"
 
 	"github.com/stretchr/testify/require"
@@ -22,27 +21,27 @@ func TestStorageDB(t *testing.T) {
 
 	tt, err := db.TotalTagged(ctx)
 	req.NoError(err)
-	req.Equal(abi.PaddedPieceSize(0), tt)
+	req.Equal(uint64(0), tt)
 
 	dealUUID := uuid.New()
 	amt, err := db.Untag(ctx, dealUUID)
 	req.NoError(err)
-	req.Equal(abi.PaddedPieceSize(0), amt)
+	req.Equal(uint64(0), amt)
 
-	err = db.Tag(ctx, dealUUID, abi.PaddedPieceSize(1111))
+	err = db.Tag(ctx, dealUUID, 1111)
 	req.NoError(err)
 
 	total, err := db.TotalTagged(ctx)
 	req.NoError(err)
-	req.Equal(abi.PaddedPieceSize(1111), total)
+	req.Equal(uint64(1111), total)
 
 	amt, err = db.Untag(ctx, dealUUID)
 	req.NoError(err)
-	req.Equal(abi.PaddedPieceSize(1111), amt)
+	req.Equal(uint64(1111), amt)
 
 	fl := &StorageLog{
 		DealUUID:  dealUUID,
-		PieceSize: abi.PaddedPieceSize(1234),
+		PieceSize: uint64(1234),
 		Text:      "Hello",
 	}
 	err = db.InsertLog(ctx, fl)

--- a/db/storage_test.go
+++ b/db/storage_test.go
@@ -1,0 +1,57 @@
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/google/uuid"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStorageDB(t *testing.T) {
+	req := require.New(t)
+	ctx := context.Background()
+
+	sqldb, err := CreateTmpDB(ctx)
+	req.NoError(err)
+
+	db := NewStorageDB(sqldb)
+	req.NoError(err)
+
+	tt, err := db.TotalTagged(ctx)
+	req.NoError(err)
+	req.Equal(abi.PaddedPieceSize(0), tt)
+
+	dealUUID := uuid.New()
+	amt, err := db.Untag(ctx, dealUUID)
+	req.NoError(err)
+	req.Equal(abi.PaddedPieceSize(0), amt)
+
+	err = db.Tag(ctx, dealUUID, abi.PaddedPieceSize(1111))
+	req.NoError(err)
+
+	total, err := db.TotalTagged(ctx)
+	req.NoError(err)
+	req.Equal(abi.PaddedPieceSize(1111), total)
+
+	amt, err = db.Untag(ctx, dealUUID)
+	req.NoError(err)
+	req.Equal(abi.PaddedPieceSize(1111), amt)
+
+	fl := &StorageLog{
+		DealUUID:  dealUUID,
+		PieceSize: abi.PaddedPieceSize(1234),
+		Text:      "Hello",
+	}
+	err = db.InsertLog(ctx, fl)
+	req.NoError(err)
+
+	logs, err := db.Logs(ctx)
+	req.NoError(err)
+	req.Len(logs, 1)
+	req.Equal(fl.DealUUID, logs[0].DealUUID)
+	req.Equal(fl.PieceSize, logs[0].PieceSize)
+	req.Equal(fl.Text, logs[0].Text)
+}

--- a/gql/dummy.go
+++ b/gql/dummy.go
@@ -1,15 +1,11 @@
 package gql
 
 import (
-	"errors"
 	"fmt"
-	"io/fs"
 	"net/http"
 	"os"
-	"path"
-	"path/filepath"
-	"strings"
-	"time"
+
+	"github.com/filecoin-project/boost/testutil"
 )
 
 const DummyDealsDir = "/tmp/dummy"
@@ -18,68 +14,11 @@ const DummyDealsPrefix = "dummy"
 var DummyDealsBase = fmt.Sprintf("http://localhost:%d/"+DummyDealsPrefix, httpPort)
 
 func serveDummyDeals() error {
-	// Serve dummy-deals
 	dpath := "/" + DummyDealsPrefix + "/"
 	if err := os.MkdirAll(DummyDealsDir, 0755); err != nil {
 		return fmt.Errorf("failed to mk directory %s for dummy deals: %w", DummyDealsDir, err)
 	}
-	fileSystem := &slowFileOpener{dir: DummyDealsDir}
+	fileSystem := &testutil.SlowFileOpener{Dir: DummyDealsDir}
 	http.Handle(dpath, http.StripPrefix(dpath, http.FileServer(fileSystem)))
 	return nil
-}
-
-const slowChunkSize = 256
-const slowChunkDelay = time.Millisecond
-
-type slowReader struct {
-	*os.File
-}
-
-func (r *slowReader) Read(p []byte) (int, error) {
-	bz := make([]byte, slowChunkSize)
-	time.Sleep(slowChunkDelay)
-	n, err := r.File.Read(bz)
-	copy(p, bz)
-	return n, err
-}
-
-type slowFileOpener struct {
-	dir string
-}
-
-func (s *slowFileOpener) Open(name string) (http.File, error) {
-	if filepath.Separator != '/' && strings.ContainsRune(name, filepath.Separator) {
-		return nil, errors.New("http: invalid character in file path")
-	}
-	dir := s.dir
-	if dir == "" {
-		dir = "."
-	}
-	fullName := filepath.Join(dir, filepath.FromSlash(path.Clean("/"+name)))
-	f, err := os.Open(fullName)
-	if err != nil {
-		return nil, mapDirOpenError(err, fullName)
-	}
-	return &slowReader{File: f}, nil
-}
-
-func mapDirOpenError(originalErr error, name string) error {
-	if os.IsNotExist(originalErr) || os.IsPermission(originalErr) {
-		return originalErr
-	}
-
-	parts := strings.Split(name, string(filepath.Separator))
-	for i := range parts {
-		if parts[i] == "" {
-			continue
-		}
-		fi, err := os.Stat(strings.Join(parts[:i+1], string(filepath.Separator)))
-		if err != nil {
-			return originalErr
-		}
-		if !fi.IsDir() {
-			return fs.ErrNotExist
-		}
-	}
-	return originalErr
 }

--- a/gql/resolver.go
+++ b/gql/resolver.go
@@ -296,7 +296,7 @@ func (dr *dealResolver) PieceCid() string {
 
 func (dr *dealResolver) Message() string {
 	switch dr.Checkpoint {
-	case dealcheckpoints.New:
+	case dealcheckpoints.Accepted:
 		switch dr.transferred {
 		case 0:
 			return "Transfer queued"

--- a/gql/schema.graphql
+++ b/gql/schema.graphql
@@ -109,7 +109,7 @@ type RootQuery {
   transfers: [TransferPoint]!
 
   """Get local messages in the mpool"""
-  mpool: [MpoolMessage]!
+  mpool(local: Boolean!): [MpoolMessage]!
 }
 
 type RootMutation {

--- a/itests/dummydeal_test.go
+++ b/itests/dummydeal_test.go
@@ -121,12 +121,6 @@ func TestDummydeal(t *testing.T) {
 
 	failingRootCid, failingCarFilepath, err := testutil.CreateDenseCARv2(tempdir, failingFilepath)
 	require.NoError(t, err)
-	t.Cleanup(func() {
-		os.Remove(randomFilepath)
-		os.Remove(carFilepath)
-		os.Remove(failingFilepath)
-		os.Remove(failingCarFilepath)
-	})
 
 	// Start a web server to serve the car files
 	server, err := runWebServer(tempdir)

--- a/itests/dummydeal_test.go
+++ b/itests/dummydeal_test.go
@@ -140,7 +140,7 @@ func TestDummydeal(t *testing.T) {
 	failingDealUuid := uuid.New()
 	res2, err2 := f.makeDummyDeal(failingDealUuid, failingCarFilepath, failingRootCid, server.URL+"/"+filepath.Base(failingCarFilepath))
 	require.NoError(t, err2)
-	require.Equal(t, res2.Reason, "miner overloaded, staging area is full")
+	require.Equal(t, res2.Reason, "cannot accept piece of size 4194304, on top of already allocated 4194304 bytes, because it would exceed max staging area size 5000000")
 	log.Debugw("got response from MarketDummyDeal for failing deal", "res2", spew.Sdump(res2))
 
 	// Wait for the deal to be added to a sector

--- a/itests/dummydeal_test.go
+++ b/itests/dummydeal_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/filecoin-project/boost/build"
 	"math/rand"
 	"net/http"
 	"net/http/httptest"
@@ -13,6 +12,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/filecoin-project/boost/build"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/filecoin-project/boost/api"
@@ -165,7 +166,7 @@ func (f *testFramework) start() {
 
 	apiinfo := cliutil.ParseApiInfo(fullnodeApiString)
 
-	fullnodeApi, closer, err := client.NewFullNodeRPCV1(f.ctx, addr, apiinfo.AuthHeader())
+	fullnodeApi, closerFullnode, err := client.NewFullNodeRPCV1(f.ctx, addr, apiinfo.AuthHeader())
 	require.NoError(f.t, err)
 
 	f.fullNode = fullnodeApi
@@ -227,7 +228,7 @@ func (f *testFramework) start() {
 
 	minerApiInfo := cliutil.ParseApiInfo(minerEndpoint)
 	minerConnAddr := "ws://127.0.0.1:2345/rpc/v0"
-	minerApi, closer, err := client.NewStorageMinerRPCV0(f.ctx, minerConnAddr, minerApiInfo.AuthHeader())
+	minerApi, closerMiner, err := client.NewStorageMinerRPCV0(f.ctx, minerConnAddr, minerApiInfo.AuthHeader())
 	require.NoError(f.t, err)
 
 	log.Debugw("minerApiInfo.Address", "addr", minerApiInfo.Addr)
@@ -320,7 +321,8 @@ func (f *testFramework) start() {
 		shutdownChan <- struct{}{}
 		_ = stop(f.ctx)
 		<-finishCh
-		closer()
+		closerFullnode()
+		closerMiner()
 	}
 }
 

--- a/itests/dummydeal_test.go
+++ b/itests/dummydeal_test.go
@@ -143,9 +143,9 @@ func TestDummydeal(t *testing.T) {
 	failingDealUuid := uuid.New()
 	res2, err2 := f.makeDummyDeal(failingDealUuid, failingCarFilepath, failingRootCid, server.URL+"/"+filepath.Base(failingCarFilepath))
 	require.NoError(t, err2)
-	require.Equal(res2.Reason, "miner overloaded, staging area is full")
+	require.Equal(t, res2.Reason, "miner overloaded, staging area is full")
 
-	log.Debugw("got response from MarketDummyDeal", "res", spew.Sdump(res2))
+	log.Debugw("got response from MarketDummyDeal for failing deal", "res2", spew.Sdump(res2))
 
 	// Wait for the deal to be added to a sector
 	err = f.waitForDealAddedToSector(dealUuid)
@@ -284,7 +284,7 @@ func (f *testFramework) start() {
 	cfg.Wallets.PublishStorageDeals = psdWalletAddr.String()
 	cfg.Dealmaking.PublishMsgMaxDealsPerMsg = 1
 	cfg.Dealmaking.PublishMsgPeriod = config.Duration(time.Second * 1)
-	cfg.Dealmaking.MaxStagingDealsBytes = 3000000
+	cfg.Dealmaking.MaxStagingDealsBytes = 5000000
 
 	err = lr.SetConfig(func(raw interface{}) {
 		rcfg := raw.(*config.Boost)

--- a/node/builder.go
+++ b/node/builder.go
@@ -397,7 +397,7 @@ func ConfigBoost(c interface{}) Option {
 		})),
 
 		Override(new(*storagemanager.StorageManager), storagemanager.New(storagemanager.Config{
-			MaxStagingDealsBytes: 8192, // TODO: add to node config
+			MaxStagingDealsBytes: 0, // TODO: add to node config
 		})),
 
 		// Sector API

--- a/node/builder.go
+++ b/node/builder.go
@@ -397,7 +397,7 @@ func ConfigBoost(c interface{}) Option {
 		})),
 
 		Override(new(*storagemanager.StorageManager), storagemanager.New(storagemanager.Config{
-			MaxStagingDealsBytes: 0, // TODO: add to node config
+			MaxStagingDealsBytes: uint64(cfg.Dealmaking.MaxStagingDealsBytes),
 		})),
 
 		// Sector API

--- a/node/builder.go
+++ b/node/builder.go
@@ -24,6 +24,7 @@ import (
 	"github.com/filecoin-project/boost/node/modules/lp2p"
 	"github.com/filecoin-project/boost/node/repo"
 	"github.com/filecoin-project/boost/storage/sectorblocks"
+	"github.com/filecoin-project/boost/storagemanager"
 	"github.com/filecoin-project/boost/storagemarket"
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
@@ -393,6 +394,10 @@ func ConfigBoost(c interface{}) Option {
 			CollatWallet: walletPledgeCollat,
 			PubMsgWallet: walletPSD,
 			PubMsgBalMin: abi.NewTokenAmount(1000), // TODO: add to node config
+		})),
+
+		Override(new(*storagemanager.StorageManager), storagemanager.New(storagemanager.Config{
+			MaxStagingDealsBytes: 8192, // TODO: add to node config
 		})),
 
 		// Sector API

--- a/node/modules/storageminer.go
+++ b/node/modules/storageminer.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/filecoin-project/boost/fundmanager"
+	"github.com/filecoin-project/boost/storagemanager"
 
 	"go.uber.org/fx"
 	"go.uber.org/multierr"
@@ -524,9 +525,9 @@ func NewDealsDB(sqldb *sql.DB) *db.DealsDB {
 	return db.NewDealsDB(sqldb)
 }
 
-func NewStorageMarketProvider(provAddr address.Address) func(lc fx.Lifecycle, r repo.LockedRepo, a v1api.FullNode, sqldb *sql.DB, dealsDB *db.DealsDB, fundMgr *fundmanager.FundManager, dp *storagemarket.DealPublisher, secb *sectorblocks.SectorBlocks) (*storagemarket.Provider, error) {
-	return func(lc fx.Lifecycle, r repo.LockedRepo, a v1api.FullNode, sqldb *sql.DB, dealsDB *db.DealsDB, fundMgr *fundmanager.FundManager, dp *storagemarket.DealPublisher, secb *sectorblocks.SectorBlocks) (*storagemarket.Provider, error) {
-		prov, err := storagemarket.NewProvider(r.Path(), sqldb, dealsDB, fundMgr, a, dp, provAddr, secb)
+func NewStorageMarketProvider(provAddr address.Address) func(lc fx.Lifecycle, r repo.LockedRepo, a v1api.FullNode, sqldb *sql.DB, dealsDB *db.DealsDB, fundMgr *fundmanager.FundManager, storageMgr *storagemanager.StorageManager, dp *storagemarket.DealPublisher, secb *sectorblocks.SectorBlocks) (*storagemarket.Provider, error) {
+	return func(lc fx.Lifecycle, r repo.LockedRepo, a v1api.FullNode, sqldb *sql.DB, dealsDB *db.DealsDB, fundMgr *fundmanager.FundManager, storageMgr *storagemanager.StorageManager, dp *storagemarket.DealPublisher, secb *sectorblocks.SectorBlocks) (*storagemarket.Provider, error) {
+		prov, err := storagemarket.NewProvider(r.Path(), sqldb, dealsDB, fundMgr, storageMgr, a, dp, provAddr, secb)
 
 		if err != nil {
 			return nil, err

--- a/react/package-lock.json
+++ b/react/package-lock.json
@@ -2310,6 +2310,7 @@
         "jest-resolve": "^26.6.2",
         "jest-util": "^26.6.2",
         "jest-worker": "^26.6.2",
+        "node-notifier": "^8.0.0",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
@@ -5695,6 +5696,7 @@
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
+        "fsevents": "~2.3.2",
         "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -7599,7 +7601,8 @@
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1"
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -11487,6 +11490,7 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
+        "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^26.0.0",
         "jest-serializer": "^26.6.2",
@@ -12497,6 +12501,7 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dependencies": {
+        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {
@@ -16047,6 +16052,7 @@
         "eslint-webpack-plugin": "^2.5.2",
         "file-loader": "6.1.1",
         "fs-extra": "^9.0.1",
+        "fsevents": "^2.1.3",
         "html-webpack-plugin": "4.5.0",
         "identity-obj-proxy": "3.0.0",
         "jest": "26.6.0",
@@ -19627,8 +19633,10 @@
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.5.tgz",
       "integrity": "sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==",
       "dependencies": {
+        "chokidar": "^3.4.1",
         "graceful-fs": "^4.1.2",
-        "neo-async": "^2.5.0"
+        "neo-async": "^2.5.0",
+        "watchpack-chokidar2": "^2.0.1"
       },
       "optionalDependencies": {
         "chokidar": "^3.4.1",
@@ -19718,6 +19726,7 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
+        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -20141,6 +20150,7 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
+        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -20668,6 +20678,9 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dependencies": {
+        "graceful-fs": "^4.1.6"
+      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -21148,6 +21161,9 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dependencies": {
+        "graceful-fs": "^4.1.6"
+      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }

--- a/react/src/Mpool.css
+++ b/react/src/Mpool.css
@@ -1,3 +1,8 @@
+.mpool .button {
+    display: inline-block;
+    margin-left: 2em;
+}
+
 .mpool td, .mpool th {
     padding: 0.5em 1em;
     font-weight: normal;

--- a/react/src/Mpool.js
+++ b/react/src/Mpool.js
@@ -1,11 +1,12 @@
 import {useQuery} from "./hooks";
-import {MpoolQuery} from "./gql";
-import React from "react";
+import {DealsListQuery, gqlQuery, MpoolQuery} from "./gql";
+import {React, useState} from "react";
 import {humanFIL} from "./util";
 import './Mpool.css'
 
 export function MpoolPage(props) {
-    const {loading, error, data} = useQuery(MpoolQuery)
+    const [local, setLocal] = useState(true)
+    const {loading, error, data} = useQuery(MpoolQuery, { variables: { local } })
 
     if (loading) {
         return <div>Loading...</div>
@@ -17,6 +18,13 @@ export function MpoolPage(props) {
     const msgs = data.mpool
 
     return <div className="mpool">
+        <p>
+            Showing {msgs.length} messages in {local ? 'local' : ''} message pool.
+            <div className="button" onClick={() => setLocal(!local)}>
+                Show {local ? 'All' : 'Local'} messages
+            </div>
+        </p>
+
         <table>
             <tbody>
                 {msgs.map((msg, i) => <MpoolMessage msg={msg} key={i} />)}

--- a/react/src/gql.js
+++ b/react/src/gql.js
@@ -163,8 +163,8 @@ const FundsMoveToEscrow = gql`
 `;
 
 const MpoolQuery = gql`
-    query AppMpoolQuery {
-        mpool {
+    query AppMpoolQuery($local: Boolean!) {
+        mpool(local: $local) {
             From
             To
             Nonce

--- a/storagemanager/storagemanager.go
+++ b/storagemanager/storagemanager.go
@@ -1,0 +1,66 @@
+package storagemanager
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sync"
+
+	"github.com/filecoin-project/boost/db"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/google/uuid"
+	logging "github.com/ipfs/go-log/v2"
+)
+
+var log = logging.Logger("storagemanager")
+
+type Config struct {
+}
+
+type StorageManager struct {
+	db *db.StorageDB
+
+	lk sync.RWMutex
+}
+
+func New(cfg Config) func(sqldb *sql.DB) *StorageManager {
+	return func(sqldb *sql.DB) *StorageManager {
+		return &StorageManager{
+			db: db.NewStorageDB(sqldb),
+			//cfg: cfg,
+		}
+	}
+}
+
+// Tag
+func (m *StorageManager) Tag(ctx context.Context, dealUuid uuid.UUID, pieceSize abi.PaddedPieceSize) error {
+	m.lk.Lock()
+	defer m.lk.Unlock()
+
+	err := m.persistTagged(ctx, dealUuid, pieceSize)
+	if err != nil {
+		return fmt.Errorf("saving total tagged storage: %w", err)
+	}
+
+	return nil
+}
+
+func (m *StorageManager) persistTagged(ctx context.Context, dealUuid uuid.UUID, pieceSize abi.PaddedPieceSize) error {
+	err := m.db.Tag(ctx, dealUuid, pieceSize)
+	if err != nil {
+		return fmt.Errorf("persisting tagged storage for deal to DB: %w", err)
+	}
+
+	storageLog := &db.StorageLog{
+		DealUUID:  dealUuid,
+		PieceSize: pieceSize,
+		Text:      "Tag staging storage",
+	}
+	err = m.db.InsertLog(ctx, storageLog)
+	if err != nil {
+		return fmt.Errorf("persisting tag storage log to DB: %w", err)
+	}
+
+	log.Infow("tag", "id", dealUuid, "piecesize", pieceSize)
+	return nil
+}

--- a/storagemanager/storagemanager.go
+++ b/storagemanager/storagemanager.go
@@ -46,12 +46,12 @@ func (m *StorageManager) Tag(ctx context.Context, dealUuid uuid.UUID, pieceSize 
 	}
 
 	if m.cfg.MaxStagingDealsBytes != 0 {
-		if uint64(tagged)+uint64(pieceSize) >= m.cfg.MaxStagingDealsBytes {
+		if tagged+uint64(pieceSize) >= m.cfg.MaxStagingDealsBytes {
 			return fmt.Errorf("cannot accept piece of size %d, on top of already allocated %d bytes, because it would exceed max staging area size %d", uint64(pieceSize), uint64(tagged), m.cfg.MaxStagingDealsBytes)
 		}
 	}
 
-	err = m.persistTagged(ctx, dealUuid, pieceSize)
+	err = m.persistTagged(ctx, dealUuid, uint64(pieceSize))
 	if err != nil {
 		return fmt.Errorf("saving total tagged storage: %w", err)
 	}
@@ -84,7 +84,7 @@ func (m *StorageManager) Untag(ctx context.Context, dealUuid uuid.UUID) error {
 }
 
 // unlocked
-func (m *StorageManager) totalTagged(ctx context.Context) (abi.PaddedPieceSize, error) {
+func (m *StorageManager) totalTagged(ctx context.Context) (uint64, error) {
 	total, err := m.db.TotalTagged(ctx)
 	if err != nil {
 		return 0, fmt.Errorf("getting total tagged from DB: %w", err)
@@ -92,7 +92,7 @@ func (m *StorageManager) totalTagged(ctx context.Context) (abi.PaddedPieceSize, 
 	return total, nil
 }
 
-func (m *StorageManager) persistTagged(ctx context.Context, dealUuid uuid.UUID, pieceSize abi.PaddedPieceSize) error {
+func (m *StorageManager) persistTagged(ctx context.Context, dealUuid uuid.UUID, pieceSize uint64) error {
 	err := m.db.Tag(ctx, dealUuid, pieceSize)
 	if err != nil {
 		return fmt.Errorf("persisting tagged storage for deal to DB: %w", err)

--- a/storagemanager/storagemanager.go
+++ b/storagemanager/storagemanager.go
@@ -46,8 +46,10 @@ func (m *StorageManager) Tag(ctx context.Context, dealUuid uuid.UUID, pieceSize 
 		return fmt.Errorf("getting total tagged: %w", err)
 	}
 
-	if uint64(tagged)+uint64(pieceSize) >= m.cfg.MaxStagingDealsBytes {
-		return fmt.Errorf("miner overloaded, staging area is full")
+	if m.cfg.MaxStagingDealsBytes != 0 {
+		if uint64(tagged)+uint64(pieceSize) >= m.cfg.MaxStagingDealsBytes {
+			return fmt.Errorf("miner overloaded, staging area is full")
+		}
 	}
 
 	err = m.persistTagged(ctx, dealUuid, pieceSize)

--- a/storagemanager/storagemanager.go
+++ b/storagemanager/storagemanager.go
@@ -39,8 +39,7 @@ func (m *StorageManager) Tag(ctx context.Context, dealUuid uuid.UUID, pieceSize 
 	m.lk.Lock()
 	defer m.lk.Unlock()
 
-	// Check that the provider has enough funds in escrow to cover the
-	// collateral requirement for the deal
+	// Get the total tagged storage, so that we know how much is available.
 	tagged, err := m.totalTagged(ctx)
 	if err != nil {
 		return fmt.Errorf("getting total tagged: %w", err)

--- a/storagemanager/storagemanager.go
+++ b/storagemanager/storagemanager.go
@@ -47,7 +47,7 @@ func (m *StorageManager) Tag(ctx context.Context, dealUuid uuid.UUID, pieceSize 
 
 	if m.cfg.MaxStagingDealsBytes != 0 {
 		if uint64(tagged)+uint64(pieceSize) >= m.cfg.MaxStagingDealsBytes {
-			return fmt.Errorf("miner overloaded, staging area is full")
+			return fmt.Errorf("cannot accept piece of size %d, on top of already allocated %d bytes, because it would exceed max staging area size %d", uint64(pieceSize), uint64(tagged), m.cfg.MaxStagingDealsBytes)
 		}
 	}
 

--- a/storagemarket/deal_execution.go
+++ b/storagemarket/deal_execution.go
@@ -319,6 +319,15 @@ func (p *Provider) addPiece(ctx context.Context, pub event.Emitter, deal *types.
 
 	p.addDealLog(deal.DealUuid, "Deal handed off to sealer successfully")
 
+	// Now that the deal has been published, we no longer need to have funds
+	// tagged as being for this deal (the publish message moves collateral
+	// from the storage market actor escrow balance to the locked balance)
+	err = p.storageManager.Untag(ctx, deal.DealUuid)
+	if err != nil {
+		log.Errorw("untagging storage", "uuid", deal.DealUuid, "err", err)
+		return err
+	}
+
 	return p.updateCheckpoint(ctx, pub, deal, dealcheckpoints.AddedPiece)
 }
 

--- a/storagemarket/deal_execution.go
+++ b/storagemarket/deal_execution.go
@@ -319,9 +319,7 @@ func (p *Provider) addPiece(ctx context.Context, pub event.Emitter, deal *types.
 
 	p.addDealLog(deal.DealUuid, "Deal handed off to sealer successfully")
 
-	// Now that the deal has been published, we no longer need to have funds
-	// tagged as being for this deal (the publish message moves collateral
-	// from the storage market actor escrow balance to the locked balance)
+	// Now that the deal has been handed off to sealer, we should untag storage from the staging area.
 	err = p.storageManager.Untag(ctx, deal.DealUuid)
 	if err != nil {
 		log.Errorw("untagging storage", "uuid", deal.DealUuid, "err", err)

--- a/storagemarket/deal_execution.go
+++ b/storagemarket/deal_execution.go
@@ -361,11 +361,17 @@ func (p *Provider) failDeal(pub event.Emitter, deal *types.ProviderDealState, er
 
 func (p *Provider) cleanupDeal(ctx context.Context, deal *types.ProviderDealState) {
 	_ = os.Remove(deal.InboundFilePath)
-	// ...
-	//cleanup resources here
+
+	// clean up tagged funds
 	err := p.fundManager.UntagFunds(ctx, deal.DealUuid)
 	if err != nil {
-		log.Errorw("untagging funds", "id", deal.DealUuid, "err", err)
+		log.Errorw("untagging funds", "uuid", deal.DealUuid, "err", err)
+	}
+
+	// clean up storage tag
+	err = p.storageManager.Untag(ctx, deal.DealUuid)
+	if err != nil {
+		log.Errorw("untagging storage", "uuid", deal.DealUuid, "err", err)
 	}
 
 	p.dealHandlers.del(deal.DealUuid)

--- a/storagemarket/deal_execution.go
+++ b/storagemarket/deal_execution.go
@@ -363,13 +363,13 @@ func (p *Provider) cleanupDeal(ctx context.Context, deal *types.ProviderDealStat
 	// clean up tagged funds
 	err := p.fundManager.UntagFunds(ctx, deal.DealUuid)
 	if err != nil {
-		log.Errorw("untagging funds", "uuid", deal.DealUuid, "err", err)
+		log.Errorw("untagging funds", "id", deal.DealUuid, "err", err)
 	}
 
 	// clean up storage tag
 	err = p.storageManager.Untag(ctx, deal.DealUuid)
 	if err != nil {
-		log.Errorw("untagging storage", "uuid", deal.DealUuid, "err", err)
+		log.Errorw("untagging storage", "id", deal.DealUuid, "err", err)
 	}
 
 	p.dealHandlers.del(deal.DealUuid)

--- a/storagemarket/provider.go
+++ b/storagemarket/provider.go
@@ -14,6 +14,7 @@ import (
 	"github.com/filecoin-project/boost/filestore"
 	"github.com/filecoin-project/boost/fundmanager"
 	"github.com/filecoin-project/boost/storage/sectorblocks"
+	"github.com/filecoin-project/boost/storagemanager"
 	"github.com/filecoin-project/boost/storagemarket/types"
 	"github.com/filecoin-project/boost/transport"
 	"github.com/filecoin-project/boost/transport/httptransport"
@@ -58,16 +59,17 @@ type Provider struct {
 	db      *sql.DB
 	dealsDB *db.DealsDB
 
-	Transport     transport.Transport
-	fundManager   *fundmanager.FundManager
-	dealPublisher *DealPublisher
-	adapter       *Adapter
-	transfers     *dealTransfers
+	Transport      transport.Transport
+	fundManager    *fundmanager.FundManager
+	storageManager *storagemanager.StorageManager
+	dealPublisher  *DealPublisher
+	adapter        *Adapter
+	transfers      *dealTransfers
 
 	dealHandlers *dealHandlers
 }
 
-func NewProvider(repoRoot string, sqldb *sql.DB, dealsDB *db.DealsDB, fundMgr *fundmanager.FundManager, fullnodeApi v1api.FullNode, dealPublisher *DealPublisher, addr address.Address, secb *sectorblocks.SectorBlocks) (*Provider, error) {
+func NewProvider(repoRoot string, sqldb *sql.DB, dealsDB *db.DealsDB, fundMgr *fundmanager.FundManager, storageMgr *storagemanager.StorageManager, fullnodeApi v1api.FullNode, dealPublisher *DealPublisher, addr address.Address, secb *sectorblocks.SectorBlocks) (*Provider, error) {
 	fspath := path.Join(repoRoot, "incoming")
 	err := os.MkdirAll(fspath, os.ModePerm)
 	if err != nil {
@@ -95,8 +97,9 @@ func NewProvider(repoRoot string, sqldb *sql.DB, dealsDB *db.DealsDB, fundMgr *f
 		failedDealsChan:  make(chan failedDealReq),
 		restartDealsChan: make(chan restartReq),
 
-		Transport:   httptransport.New(),
-		fundManager: fundMgr,
+		Transport:      httptransport.New(),
+		fundManager:    fundMgr,
+		storageManager: storageMgr,
 
 		dealPublisher: dealPublisher,
 		adapter: &Adapter{

--- a/storagemarket/provider.go
+++ b/storagemarket/provider.go
@@ -86,7 +86,7 @@ func NewProvider(repoRoot string, sqldb *sql.DB, dealsDB *db.DealsDB, fundMgr *f
 	}
 
 	return &Provider{
-		config:    Config{MaxTransferDuration: 30 * time.Second},
+		config:    Config{MaxTransferDuration: 24 * 3600 * time.Second},
 		Address:   addr,
 		newDealPS: newDealPS,
 		fs:        fs,

--- a/storagemarket/provider.go
+++ b/storagemarket/provider.go
@@ -103,8 +103,9 @@ func NewProvider(repoRoot string, sqldb *sql.DB, dealsDB *db.DealsDB, fundMgr *f
 
 		dealPublisher: dealPublisher,
 		adapter: &Adapter{
-			FullNode: fullnodeApi,
-			secb:     secb,
+			FullNode:                    fullnodeApi,
+			secb:                        secb,
+			maxDealCollateralMultiplier: 2,
 		},
 		transfers: newDealTransfers(),
 

--- a/storagemarket/provider_loop.go
+++ b/storagemarket/provider_loop.go
@@ -87,7 +87,7 @@ func (p *Provider) loop() {
 			log.Infow("inserting deal into DB", "id", deal.DealUuid)
 
 			deal.CreatedAt = time.Now()
-			deal.Checkpoint = dealcheckpoints.New
+			deal.Checkpoint = dealcheckpoints.Accepted
 
 			err = p.dealsDB.Insert(p.ctx, deal)
 			if err != nil {

--- a/storagemarket/provider_loop.go
+++ b/storagemarket/provider_loop.go
@@ -72,6 +72,17 @@ func (p *Provider) loop() {
 				continue
 			}
 
+			// Tag the storage required for the deal in the staging area
+			err = p.storageManager.Tag(p.ctx, deal.DealUuid, deal.ClientDealProposal.Proposal.PieceSize)
+			if err != nil {
+				go writeDealResp(false, &api.ProviderDealRejectionInfo{
+					// TODO: provide a custom reason message (instead of sending provider
+					// error messages back to client) eg "Not enough staging storage for deal"
+					Reason: err.Error(),
+				}, nil)
+				continue
+			}
+
 			// write deal state to the database
 			log.Infow("inserting deal into DB", "id", deal.DealUuid)
 

--- a/storagemarket/types/dealcheckpoints/checkpoints.go
+++ b/storagemarket/types/dealcheckpoints/checkpoints.go
@@ -5,7 +5,7 @@ import "golang.org/x/xerrors"
 type Checkpoint int
 
 const (
-	New Checkpoint = iota
+	Accepted Checkpoint = iota
 	Transferred
 	Published
 	PublishConfirmed
@@ -14,7 +14,7 @@ const (
 )
 
 var names = map[Checkpoint]string{
-	New:              "New",
+	Accepted:         "Accepted",
 	Transferred:      "Transferred",
 	Published:        "Published",
 	PublishConfirmed: "PublishConfirmed",
@@ -38,7 +38,7 @@ func (c Checkpoint) String() string {
 func FromString(str string) (Checkpoint, error) {
 	cp, ok := strToCP[str]
 	if !ok {
-		return New, xerrors.Errorf("unrecognized checkpoint %s", str)
+		return Accepted, xerrors.Errorf("unrecognized checkpoint %s", str)
 	}
 	return cp, nil
 }

--- a/testutil/car.go
+++ b/testutil/car.go
@@ -39,10 +39,10 @@ type CarRes struct {
 }
 
 // CreateRandomFile
-func CreateRandomFile(rseed, size int) (string, error) {
+func CreateRandomFile(dir string, rseed, size int) (string, error) {
 	source := io.LimitReader(rand.New(rand.NewSource(int64(rseed))), int64(size))
 
-	file, err := os.CreateTemp("", "sourcefile.dat")
+	file, err := os.CreateTemp(dir, "sourcefile.dat")
 	if err != nil {
 		return "", err
 	}
@@ -63,7 +63,7 @@ func CreateRandomFile(rseed, size int) (string, error) {
 
 // CreateDenseCARv2 generates a "dense" UnixFS CARv2 from the supplied ordinary file.
 // A dense UnixFS CARv2 is one storing leaf data. Contrast to CreateRefCARv2.
-func CreateDenseCARv2(src string) (cid.Cid, string, error) {
+func CreateDenseCARv2(dir, src string) (cid.Cid, string, error) {
 	bs := bstore.NewBlockstore(dssync.MutexWrap(ds.NewMapDatastore()))
 	dagSvc := merkledag.NewDAGService(blockservice.New(bs, offline.Exchange(bs)))
 
@@ -74,7 +74,7 @@ func CreateDenseCARv2(src string) (cid.Cid, string, error) {
 
 	// Create a UnixFS DAG again AND generate a CARv2 file using a CARv2
 	// read-write blockstore now that we have the root.
-	out, err := os.CreateTemp("", "rand")
+	out, err := os.CreateTemp(dir, "rand")
 	if err != nil {
 		return cid.Undef, "", err
 	}

--- a/testutil/slowreader.go
+++ b/testutil/slowreader.go
@@ -1,0 +1,68 @@
+package testutil
+
+import (
+	"errors"
+	"io/fs"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const slowChunkSize = 256
+const slowChunkDelay = 1 * time.Millisecond
+
+type SlowReader struct {
+	*os.File
+}
+
+func (r *SlowReader) Read(p []byte) (int, error) {
+	bz := make([]byte, slowChunkSize)
+	time.Sleep(slowChunkDelay)
+	n, err := r.File.Read(bz)
+	copy(p, bz)
+	return n, err
+}
+
+type SlowFileOpener struct {
+	Dir string
+}
+
+func (s *SlowFileOpener) Open(name string) (http.File, error) {
+	if filepath.Separator != '/' && strings.ContainsRune(name, filepath.Separator) {
+		return nil, errors.New("http: invalid character in file path")
+	}
+	dir := s.Dir
+	if dir == "" {
+		dir = "."
+	}
+	fullName := filepath.Join(dir, filepath.FromSlash(path.Clean("/"+name)))
+	f, err := os.Open(fullName)
+	if err != nil {
+		return nil, mapDirOpenError(err, fullName)
+	}
+	return &SlowReader{File: f}, nil
+}
+
+func mapDirOpenError(originalErr error, name string) error {
+	if os.IsNotExist(originalErr) || os.IsPermission(originalErr) {
+		return originalErr
+	}
+
+	parts := strings.Split(name, string(filepath.Separator))
+	for i := range parts {
+		if parts[i] == "" {
+			continue
+		}
+		fi, err := os.Stat(strings.Join(parts[:i+1], string(filepath.Separator)))
+		if err != nil {
+			return originalErr
+		}
+		if !fi.IsDir() {
+			return fs.ErrNotExist
+		}
+	}
+	return originalErr
+}


### PR DESCRIPTION
This PR includes:
- initial Storage Manager implementation
- local filter for mpool
- updated Makefile with builds for both production and debug (2KiB/8MiB sectors)
- fixed dummydeal cmdline tool with correct `StartEpoch` and `EndEpoch`
- `maxDealCollateralMultiplier` hardcoded to 2, instead of 0, which is certainly not correct
- renamed `New` state to `Accepted` 

TODO:

- [x] add tests for MaxStagingDealsBytes != 0 and make sure we reject deals if we hit the limit
- [x] make sure we untag Staging storage, once a deal is passed to the sealer