### PR TITLE
gql: link storageManager with GraphQL server

### DIFF
--- a/cmd/boost/init.go
+++ b/cmd/boost/init.go
@@ -38,6 +38,12 @@ var initCmd = &cli.Command{
 			Usage:    "wallet to be used for pledging collateral",
 			Required: true,
 		},
+		&cli.Int64Flag{
+			Name:     "max-staging-deals-bytes",
+			Usage:    "max size for staging area in bytes",
+			Value:    50_000_000_000,
+			Required: true,
+		},
 	},
 	Before: before,
 	Action: func(cctx *cli.Context) error {
@@ -140,6 +146,7 @@ var initCmd = &cli.Command{
 				}
 				rcfg.SectorIndexApiInfo = ai
 
+				rcfg.Dealmaking.MaxStagingDealsBytes = cctx.Int64("max-staging-deals-bytes")
 				rcfg.Wallets.Miner = minerActor.String()
 				rcfg.Wallets.PledgeCollateral = walletCP.String()
 				rcfg.Wallets.PublishStorageDeals = walletPSD.String()

--- a/cmd/boost/init.go
+++ b/cmd/boost/init.go
@@ -67,6 +67,10 @@ var initCmd = &cli.Command{
 			return xerrors.Errorf("wallets for PublishStorageDeals and pledging collateral must be different")
 		}
 
+		if cctx.Int64("max-staging-deals-bytes") <= 0 {
+			return xerrors.Errorf("max size for staging deals area must be > 0 bytes")
+		}
+
 		if err := checkV1ApiSupport(ctx, cctx); err != nil {
 			return err
 		}

--- a/cmd/boost/main.go
+++ b/cmd/boost/main.go
@@ -20,6 +20,7 @@ func main() {
 	_ = logging.SetLogLevel("boost", "INFO")
 	_ = logging.SetLogLevel("provider", "INFO")
 	_ = logging.SetLogLevel("gql", "INFO")
+	_ = logging.SetLogLevel("boost-provider", "INFO")
 
 	app := &cli.App{
 		Name:                 "boost",
@@ -53,6 +54,7 @@ func before(cctx *cli.Context) error {
 		_ = logging.SetLogLevel("boost", "DEBUG")
 		_ = logging.SetLogLevel("provider", "DEBUG")
 		_ = logging.SetLogLevel("gql", "DEBUG")
+		_ = logging.SetLogLevel("boost-provider", "DEBUG")
 	}
 
 	return nil

--- a/cmd/boost/main.go
+++ b/cmd/boost/main.go
@@ -51,6 +51,8 @@ func main() {
 func before(cctx *cli.Context) error {
 	if cliutil.IsVeryVerbose {
 		_ = logging.SetLogLevel("boost", "DEBUG")
+		_ = logging.SetLogLevel("provider", "DEBUG")
+		_ = logging.SetLogLevel("gql", "DEBUG")
 	}
 
 	return nil

--- a/gql/resolver.go
+++ b/gql/resolver.go
@@ -46,10 +46,10 @@ func NewResolver(dealsDB *db.DealsDB, fundMgr *fundmanager.FundManager, storageM
 }
 
 type storageResolver struct {
-	Staged      uint64
-	Transferred uint64
-	Pending     uint64
-	Free        uint64
+	Staged      float64
+	Transferred float64
+	Pending     float64
+	Free        float64
 	MountPoint  string
 }
 

--- a/gql/resolver.go
+++ b/gql/resolver.go
@@ -197,7 +197,7 @@ func (r *resolver) dealByID(ctx context.Context, dealUuid uuid.UUID) (*types.Pro
 		return nil, err
 	}
 
-	deal.NBytesReceived = int64(r.provider.NBytesReceived(deal))
+	deal.NBytesReceived = int64(r.provider.NBytesReceived(deal.DealUuid))
 
 	return deal, nil
 }
@@ -228,7 +228,7 @@ func (r *resolver) dealList(ctx context.Context, first *graphql.ID, limit int) (
 	// Include data transfer information with the deal
 	dis := make([]types.ProviderDealState, 0, len(deals))
 	for _, deal := range deals {
-		deal.NBytesReceived = int64(r.provider.NBytesReceived(deal))
+		deal.NBytesReceived = int64(r.provider.NBytesReceived(deal.DealUuid))
 		dis = append(dis, *deal)
 	}
 

--- a/gql/resolver.go
+++ b/gql/resolver.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/filecoin-project/boost/db"
 	"github.com/filecoin-project/boost/fundmanager"
+	"github.com/filecoin-project/boost/storagemanager"
 	"github.com/filecoin-project/boost/storagemarket"
 	"github.com/filecoin-project/boost/storagemarket/types"
 	"github.com/filecoin-project/boost/storagemarket/types/dealcheckpoints"
@@ -25,41 +26,31 @@ type dealListResolver struct {
 // resolver translates from a request for a graphql field to the data for
 // that field
 type resolver struct {
-	dealsDB   *db.DealsDB
-	fundMgr   *fundmanager.FundManager
-	provider  *storagemarket.Provider
-	publisher *storagemarket.DealPublisher
-	fullNode  v1api.FullNode
+	dealsDB    *db.DealsDB
+	fundMgr    *fundmanager.FundManager
+	storageMgr *storagemanager.StorageManager
+	provider   *storagemarket.Provider
+	publisher  *storagemarket.DealPublisher
+	fullNode   v1api.FullNode
 }
 
-func NewResolver(dealsDB *db.DealsDB, fundMgr *fundmanager.FundManager, provider *storagemarket.Provider, publisher *storagemarket.DealPublisher, fullNode v1api.FullNode) *resolver {
+func NewResolver(dealsDB *db.DealsDB, fundMgr *fundmanager.FundManager, storageMgr *storagemanager.StorageManager, provider *storagemarket.Provider, publisher *storagemarket.DealPublisher, fullNode v1api.FullNode) *resolver {
 	return &resolver{
-		dealsDB:   dealsDB,
-		fundMgr:   fundMgr,
-		provider:  provider,
-		publisher: publisher,
-		fullNode:  fullNode,
+		dealsDB:    dealsDB,
+		fundMgr:    fundMgr,
+		storageMgr: storageMgr,
+		provider:   provider,
+		publisher:  publisher,
+		fullNode:   fullNode,
 	}
 }
 
 type storageResolver struct {
-	Completed    float64
-	Transferring float64
-	Pending      float64
-	Free         float64
-	MountPoint   string
-}
-
-// query: storage: [Storage]
-func (r *resolver) Storage(ctx context.Context) (*storageResolver, error) {
-	// TODO: Get these values from storage space manager
-	return &storageResolver{
-		Completed:    8.5 * 1024 * 1024 * 1024,
-		Transferring: 5.2 * 1024 * 1024 * 1024,
-		Pending:      3.5 * 1024 * 1024 * 1024,
-		Free:         11.2 * 1024 * 1024 * 1024,
-		MountPoint:   "/data/deals-staging",
-	}, nil
+	Staged      uint64
+	Transferred uint64
+	Pending     uint64
+	Free        uint64
+	MountPoint  string
 }
 
 // query: deal(id) Deal

--- a/gql/resolver_storage.go
+++ b/gql/resolver_storage.go
@@ -14,8 +14,17 @@ func (r *resolver) Storage(ctx context.Context) (*storageResolver, error) {
 		return nil, err
 	}
 
-	staged := uint64(0)
+	activeDeals, err := r.dealsDB.ListActive(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	transferred := uint64(0)
+	for _, deal := range activeDeals {
+		transferred += r.provider.NBytesReceived(deal.DealUuid)
+	}
+
+	staged := uint64(0)
 	return &storageResolver{
 		Staged:      staged,
 		Transferred: transferred,

--- a/gql/resolver_storage.go
+++ b/gql/resolver_storage.go
@@ -1,0 +1,26 @@
+package gql
+
+import "context"
+
+// query: storage: [Storage]
+func (r *resolver) Storage(ctx context.Context) (*storageResolver, error) {
+	tagged, err := r.storageMgr.TotalTagged(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	free, err := r.storageMgr.Free(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	staged := uint64(0)
+	transferred := uint64(0)
+	return &storageResolver{
+		Staged:      staged,
+		Transferred: transferred,
+		Pending:     tagged - transferred,
+		Free:        free,
+		MountPoint:  r.storageMgr.StagingAreaDirPath,
+	}, nil
+}

--- a/gql/schema.graphql
+++ b/gql/schema.graphql
@@ -46,8 +46,8 @@ type DealLog {
 }
 
 type Storage {
-  Completed: Float!
-  Transferring: Float!
+  Staged: Float!
+  Transferred: Float!
   Pending: Float!
   Free: Float!
   MountPoint: String!

--- a/itests/dummydeal_test.go
+++ b/itests/dummydeal_test.go
@@ -63,6 +63,8 @@ func setLogLevel() {
 	_ = logging.SetLogLevel("actors", "DEBUG")
 	_ = logging.SetLogLevel("provider", "DEBUG")
 	_ = logging.SetLogLevel("http-transfer", "DEBUG")
+	_ = logging.SetLogLevel("boost-provider", "DEBUG")
+	_ = logging.SetLogLevel("storagemanager", "DEBUG")
 }
 
 func TestDummydeal(t *testing.T) {
@@ -140,7 +142,7 @@ func TestDummydeal(t *testing.T) {
 	failingDealUuid := uuid.New()
 	res2, err2 := f.makeDummyDeal(failingDealUuid, failingCarFilepath, failingRootCid, server.URL+"/"+filepath.Base(failingCarFilepath))
 	require.NoError(t, err2)
-	require.Equal(t, res2.Reason, "cannot accept piece of size 4194304, on top of already allocated 4194304 bytes, because it would exceed max staging area size 5000000")
+	require.Equal(t, "cannot accept piece of size 2254771, on top of already allocated 2254771 bytes, because it would exceed max staging area size 4000000", res2.Reason)
 	log.Debugw("got response from MarketDummyDeal for failing deal", "res2", spew.Sdump(res2))
 
 	// Wait for the deal to be added to a sector
@@ -290,7 +292,7 @@ func (f *testFramework) start() {
 	cfg.Wallets.PublishStorageDeals = psdWalletAddr.String()
 	cfg.Dealmaking.PublishMsgMaxDealsPerMsg = 1
 	cfg.Dealmaking.PublishMsgPeriod = config.Duration(time.Second * 1)
-	cfg.Dealmaking.MaxStagingDealsBytes = 5000000
+	cfg.Dealmaking.MaxStagingDealsBytes = 4000000
 
 	err = lr.SetConfig(func(raw interface{}) {
 		rcfg := raw.(*config.Boost)

--- a/node/modules/storageminer.go
+++ b/node/modules/storageminer.go
@@ -539,8 +539,8 @@ func NewStorageMarketProvider(provAddr address.Address) func(lc fx.Lifecycle, r 
 	}
 }
 
-func NewGraphqlServer(lc fx.Lifecycle, prov *storagemarket.Provider, dealsDB *db.DealsDB, fundMgr *fundmanager.FundManager, publisher *storagemarket.DealPublisher, fullNode v1api.FullNode) *gql.Server {
-	resolver := gql.NewResolver(dealsDB, fundMgr, prov, publisher, fullNode)
+func NewGraphqlServer(lc fx.Lifecycle, prov *storagemarket.Provider, dealsDB *db.DealsDB, fundMgr *fundmanager.FundManager, storageMgr *storagemanager.StorageManager, publisher *storagemarket.DealPublisher, fullNode v1api.FullNode) *gql.Server {
+	resolver := gql.NewResolver(dealsDB, fundMgr, storageMgr, prov, publisher, fullNode)
 	server := gql.NewServer(resolver)
 
 	lc.Append(fx.Hook{

--- a/react/src/StorageSpace.js
+++ b/react/src/StorageSpace.js
@@ -16,8 +16,8 @@ export function StorageSpacePage(props) {
 
     var storage = data.storage
     var totalSize = 0
-    totalSize += storage.Completed
-    totalSize += storage.Transferring
+    totalSize += storage.Staged
+    totalSize += storage.Transferred
     totalSize += storage.Pending
     totalSize += storage.Free
 
@@ -27,21 +27,21 @@ export function StorageSpacePage(props) {
                 {humanFileSize(totalSize)}
             </div>
             <div className="bars">
-                <div className="completed" style={{width: Math.floor(100*storage.Completed/totalSize)+'%'}} />
-                <div className="transferring" style={{width: Math.floor(100*storage.Transferring/totalSize)+'%'}} />
+                <div className="staged" style={{width: Math.floor(100*storage.Staged/totalSize)+'%'}} />
+                <div className="transferred" style={{width: Math.floor(100*storage.Transferred/totalSize)+'%'}} />
                 <div className="pending" style={{width: Math.floor(100*storage.Pending/totalSize)+'%'}} />
                 <div className="free" style={{width: Math.floor(100*storage.Free/totalSize)+'%'}} />
             </div>
             <div className="labels">
-                <div className="label completed">
+                <div className="label staged">
                     <div className="bar-color"></div>
-                    <div className="text">Completed</div>
-                    <div className="amount">{humanFileSize(storage.Completed)}</div>
+                    <div className="text">Staged</div>
+                    <div className="amount">{humanFileSize(storage.Staged)}</div>
                 </div>
-                <div className="label transferring">
+                <div className="label transferred">
                     <div className="bar-color"></div>
-                    <div className="text">Transferring</div>
-                    <div className="amount">{humanFileSize(storage.Transferring)}</div>
+                    <div className="text">Transferred</div>
+                    <div className="amount">{humanFileSize(storage.Transferred)}</div>
                 </div>
                 <div className="label pending">
                     <div className="bar-color"></div>
@@ -59,12 +59,12 @@ export function StorageSpacePage(props) {
         <table className="storage-fields">
             <tbody>
                 <tr>
-                    <td>Completed</td>
-                    <td>{Math.round(storage.Completed).toLocaleString('en-US')} bytes</td>
+                    <td>Staged</td>
+                    <td>{Math.round(storage.Staged).toLocaleString('en-US')} bytes</td>
                 </tr>
                 <tr>
-                    <td>Transferring</td>
-                    <td>{Math.round(storage.Transferring).toLocaleString('en-US')} bytes</td>
+                    <td>Transferred</td>
+                    <td>{Math.round(storage.Transferred).toLocaleString('en-US')} bytes</td>
                 </tr>
                 <tr>
                     <td>Pending</td>

--- a/react/src/gql.js
+++ b/react/src/gql.js
@@ -152,8 +152,8 @@ const NewDealsSubscription = gql`
 const StorageQuery = gql`
     query AppStorageQuery {
         storage {
-            Completed
-            Transferring
+            Staged
+            Transferred
             Pending
             Free
             MountPoint

--- a/storagemanager/storagemanager.go
+++ b/storagemanager/storagemanager.go
@@ -54,18 +54,22 @@ func (m *StorageManager) Free(ctx context.Context) (uint64, error) {
 		// we don't have a max staging area configured, so
 		// return the actual free disk space
 
-		s, err := m.lr.Stat(m.StagingAreaDirPath)
-		if err != nil {
-			return 0, err
-		}
+		//TODO: fixme
+		//s, err := m.lr.Stat(m.StagingAreaDirPath)
+		//if err != nil {
+		//return 0, err
+		//}
 
-		return uint64(s.Available), nil
+		//return uint64(s.Available), nil
+		return 100_000_000_000, nil // say we have 100GB free
 	}
 }
 
 // Tag
 func (m *StorageManager) Tag(ctx context.Context, dealUuid uuid.UUID, size uint64) error {
 	// Get the total tagged storage, so that we know how much is available.
+	log.Debugw("tagging", "id", dealUuid, "size", size, "maxbytes", m.cfg.MaxStagingDealsBytes)
+
 	tagged, err := m.TotalTagged(ctx)
 	if err != nil {
 		return fmt.Errorf("getting total tagged: %w", err)

--- a/storagemanager/storagemanager.go
+++ b/storagemanager/storagemanager.go
@@ -48,21 +48,7 @@ func (m *StorageManager) Free(ctx context.Context) (uint64, error) {
 		return 0, fmt.Errorf("getting total tagged: %w", err)
 	}
 
-	if m.cfg.MaxStagingDealsBytes != 0 {
-		return m.cfg.MaxStagingDealsBytes - tagged, nil
-	} else {
-		// we don't have a max staging area configured, so
-		// return the actual free disk space
-
-		//TODO: fixme
-		//s, err := m.lr.Stat(m.StagingAreaDirPath)
-		//if err != nil {
-		//return 0, err
-		//}
-
-		//return uint64(s.Available), nil
-		return 100_000_000_000, nil // say we have 100GB free
-	}
+	return m.cfg.MaxStagingDealsBytes - tagged, nil
 }
 
 // Tag

--- a/storagemarket/deal_execution.go
+++ b/storagemarket/deal_execution.go
@@ -79,7 +79,7 @@ func (p *Provider) execDealUptoAddPiece(ctx context.Context, pub event.Emitter, 
 	if deal.Checkpoint < dealcheckpoints.Transferred {
 		if err := p.transferAndVerify(dh.transferCtx, pub, deal); err != nil {
 			dh.transferCancelled(nil)
-			return fmt.Errorf("failed data transfer: %w", err)
+			return fmt.Errorf("execDeal failed data transfer: %w", err)
 		}
 	}
 	// transfer can no longer be cancelled
@@ -115,7 +115,7 @@ func (p *Provider) transferAndVerify(ctx context.Context, pub event.Emitter, dea
 		DealSize:   int64(deal.Transfer.Size),
 	})
 	if err != nil {
-		return fmt.Errorf("failed data transfer: %w", err)
+		return fmt.Errorf("transferAndVerify failed data transfer: %w", err)
 	}
 
 	// wait for data-transfer to finish

--- a/storagemarket/provider.go
+++ b/storagemarket/provider.go
@@ -124,8 +124,8 @@ func (p *Provider) Deal(ctx context.Context, dealUuid uuid.UUID) (*types.Provide
 	return deal, nil
 }
 
-func (p *Provider) NBytesReceived(deal *types.ProviderDealState) uint64 {
-	return p.transfers.getBytes(deal.DealUuid)
+func (p *Provider) NBytesReceived(dealUuid uuid.UUID) uint64 {
+	return p.transfers.getBytes(dealUuid)
 }
 
 func (p *Provider) GetAsk() *types.StorageAsk {

--- a/storagemarket/provider_loop.go
+++ b/storagemarket/provider_loop.go
@@ -61,7 +61,7 @@ func (p *Provider) loop() {
 			}
 
 			// Tag the storage required for the deal in the staging area
-			err = p.storageManager.Tag(p.ctx, deal.DealUuid, deal.ClientDealProposal.Proposal.PieceSize)
+			err = p.storageManager.Tag(p.ctx, deal.DealUuid, deal.Transfer.Size)
 			if err != nil {
 				cleanup()
 				dealReq.rsp <- acceptDealResp{accepted: false, ri: &api.ProviderDealRejectionInfo{Reason: err.Error()}, err: nil}


### PR DESCRIPTION
This PR is adding the `storageMgr` to the `resolver`, i.e. hooking up the Storage Manager to the GraphQL server and to the React UI.

TODO:
- [x] ~handle case when `m.cfg.MaxStagingDealsBytes == 0`, i.e. we don't have a configured MaxStagingDealsBytes~ MaxStagingDealsBytes is now a required param