### PR TITLE
Test that fails when sending a CAR v1 file

### DIFF
--- a/storagemarket/adapter.go
+++ b/storagemarket/adapter.go
@@ -71,6 +71,7 @@ func (n *Adapter) AddPieceToSector(ctx context.Context, deal smtypes.ProviderDea
 
 	// Attempt to add the piece to a sector (repeatedly if necessary)
 	pieceSize := deal.ClientDealProposal.Proposal.PieceSize.Unpadded()
+	log.Infow("add piece to sector", "piece-size", pieceSize)
 	p, offset, err := n.secb.AddPiece(ctx, pieceSize, pieceData, sdInfo)
 	curTime := build.Clock.Now()
 	for build.Clock.Since(curTime) < addPieceRetryTimeout {
@@ -82,6 +83,7 @@ func (n *Adapter) AddPieceToSector(ctx context.Context, deal smtypes.ProviderDea
 		}
 		select {
 		case <-build.Clock.After(addPieceRetryWait):
+			log.Infow("retry add piece to sector", "piece-size", pieceSize)
 			p, offset, err = n.secb.AddPiece(ctx, pieceSize, pieceData, sdInfo)
 		case <-ctx.Done():
 			return nil, xerrors.New("context expired while waiting to retry AddPiece")

--- a/storagemarket/deal_execution.go
+++ b/storagemarket/deal_execution.go
@@ -278,6 +278,7 @@ func (p *Provider) publishDeal(ctx context.Context, pub event.Emitter, deal *typ
 
 // addPiece hands off a published deal for sealing and commitment in a sector
 func (p *Provider) addPiece(ctx context.Context, pub event.Emitter, deal *types.ProviderDealState) error {
+	log.Info("Create CARv2 reader")
 	p.addDealLog(deal.DealUuid, "Hand off deal to sealer")
 
 	// Open a reader against the CAR file with the deal data
@@ -286,6 +287,7 @@ func (p *Provider) addPiece(ctx context.Context, pub event.Emitter, deal *types.
 		return fmt.Errorf("failed to open CARv2 file: %w", err)
 	}
 
+	log.Info("pad CAR")
 	// Inflate the deal size so that it exactly fills a piece
 	proposal := deal.ClientDealProposal.Proposal
 	paddedReader, err := padreader.NewInflator(v2r.DataReader(), v2r.Header.DataSize, proposal.PieceSize.Unpadded())
@@ -293,8 +295,10 @@ func (p *Provider) addPiece(ctx context.Context, pub event.Emitter, deal *types.
 		return fmt.Errorf("failed to create inflator: %w", err)
 	}
 
+	log.Info("Add piece to sector")
 	// Add the piece to a sector
 	packingInfo, packingErr := p.adapter.AddPieceToSector(p.ctx, *deal, paddedReader)
+	log.Info("Added piece to sector")
 
 	// Close the reader as we're done reading from it.
 	if err := v2r.Close(); err != nil {

--- a/storagemarket/deal_execution.go
+++ b/storagemarket/deal_execution.go
@@ -288,9 +288,19 @@ func (p *Provider) addPiece(ctx context.Context, pub event.Emitter, deal *types.
 	}
 
 	log.Info("pad CAR")
+
+	var size uint64
+	switch v2r.Version {
+	case 2:
+		size = v2r.Header.DataSize
+	case 1:
+		stat, _ := os.Stat(deal.InboundFilePath)
+		size = uint64(stat.Size())
+	}
+
 	// Inflate the deal size so that it exactly fills a piece
 	proposal := deal.ClientDealProposal.Proposal
-	paddedReader, err := padreader.NewInflator(v2r.DataReader(), v2r.Header.DataSize, proposal.PieceSize.Unpadded())
+	paddedReader, err := padreader.NewInflator(v2r.DataReader(), size, proposal.PieceSize.Unpadded())
 	if err != nil {
 		return fmt.Errorf("failed to create inflator: %w", err)
 	}


### PR DESCRIPTION
To run locally:
```
ps -Af | grep lotus
<kill any lotus processes>
rm -rf ~/.lotusmarkets && rm -rf ~/.lotus && rm -rf ~/.lotusminer && rm -rf ~/.genesis_sectors
go test --count=1 --tags=debug -v ./itests/dummydeal_test.go
```

Output of failed test (truncated):
```
2021-12-07T15:47:38.097+0100	INFO	boosttest	itests/dummydeal_test.go:396	deal state: Accepted
2021-12-07T15:47:38.146+0100	INFO	boost-provider	storagemarket/deal_publisher.go:216	add deal with piece CID baga6ea4seaqh2sx5alndlud7l3d5rxqrvnyd4zwwpgpkmc7hv6shzjymzxqoqci to publish deals queue - 1 deals in queue (max queue size 1)
2021-12-07T15:47:38.146+0100	INFO	boost-provider	storagemarket/deal_publisher.go:222	publish deals queue has reached max size of 1, publishing deals
2021-12-07T15:47:38.150+0100	INFO	boost-provider	storagemarket/deal_publisher.go:369	validating deal	{"took": 0.003932346, "proposal": "bafy2bzacea7itgic7pbs24lpfhtai5hg7ba65l67q3lldsr23rybtdaghgybc"}
2021-12-07T15:47:38.150+0100	INFO	boost-provider	storagemarket/deal_publisher.go:380	publishing 1 deals in publish deals queue with piece CIDs: baga6ea4seaqh2sx5alndlud7l3d5rxqrvnyd4zwwpgpkmc7hv6shzjymzxqoqci
2021-12-07T15:47:39.102+0100	INFO	boosttest	itests/dummydeal_test.go:396	deal state: Published
2021-12-07T15:47:40.103+0100	INFO	boosttest	itests/dummydeal_test.go:396	deal state: Published
2021-12-07T15:47:41.109+0100	INFO	boosttest	itests/dummydeal_test.go:396	deal state: Published
2021-12-07T15:47:42.113+0100	INFO	boosttest	itests/dummydeal_test.go:396	deal state: Published
2021-12-07T15:47:43.118+0100	INFO	boosttest	itests/dummydeal_test.go:396	deal state: Published
2021-12-07T15:47:44.120+0100	INFO	boosttest	itests/dummydeal_test.go:396	deal state: Published
2021-12-07T15:47:45.126+0100	INFO	boosttest	itests/dummydeal_test.go:396	deal state: Published
2021-12-07T15:47:46.130+0100	INFO	boosttest	itests/dummydeal_test.go:396	deal state: Published
2021-12-07T15:47:47.135+0100	INFO	boosttest	itests/dummydeal_test.go:396	deal state: Published
2021-12-07T15:47:48.139+0100	INFO	boosttest	itests/dummydeal_test.go:396	deal state: Published
2021-12-07T15:47:49.140+0100	INFO	boosttest	itests/dummydeal_test.go:396	deal state: Published
2021-12-07T15:47:50.141+0100	INFO	boosttest	itests/dummydeal_test.go:396	deal state: Published
2021-12-07T15:47:51.143+0100	INFO	boosttest	itests/dummydeal_test.go:396	deal state: Published
2021-12-07T15:47:52.147+0100	INFO	boosttest	itests/dummydeal_test.go:396	deal state: Published
2021-12-07T15:47:53.148+0100	INFO	boosttest	itests/dummydeal_test.go:396	deal state: Published
2021-12-07T15:47:54.149+0100	INFO	boosttest	itests/dummydeal_test.go:396	deal state: Published
2021-12-07T15:47:55.103+0100	INFO	boost-provider	storagemarket/deal_execution.go:281	Create CARv2 reader
2021-12-07T15:47:55.104+0100	INFO	boost-provider	storagemarket/deal_execution.go:290	pad CAR
2021-12-07T15:47:55.104+0100	INFO	boost-provider	storagemarket/deal_execution.go:298	Add piece to sector
2021-12-07T15:47:55.104+0100	INFO	boost-provider	storagemarket/adapter.go:74	add piece to sector	{"piece-size": 4161536}
2021-12-07T15:47:55.150+0100	INFO	boosttest	itests/dummydeal_test.go:396	deal state: PublishConfirmed
2021-12-07T15:47:55.449+0100	ERROR	boost-provider	storagemarket/adapter.go:80	failed to addPiece for deal	{"id": "17326a87-d2c1-47ee-b5d9-dc34c5668bd5", "err": "got unexpected piece CID: expected:baga6ea4seaqh2sx5alndlud7l3d5rxqrvnyd4zwwpgpkmc7hv6shzjymzxqoqci, got:baga6ea4seaqijqccdoqgqwqbx54vui2eazh6ijf5kku5eq3xwokp6tclivuoqei"}
2021-12-07T15:47:55.449+0100	INFO	boost-provider	storagemarket/deal_execution.go:301	Added piece to sector
2021-12-07T15:47:55.540+0100	ERROR	boost-provider	storagemarket/provider_loop.go:126	deal failed	{"id": "17326a87-d2c1-47ee-b5d9-dc34c5668bd5", "err": "failed to add piece: packing piece baga6ea4seaqh2sx5alndlud7l3d5rxqrvnyd4zwwpgpkmc7hv6shzjymzxqoqci: AddPiece failed: got unexpected piece CID: expected:baga6ea4seaqh2sx5alndlud7l3d5rxqrvnyd4zwwpgpkmc7hv6shzjymzxqoqci, got:baga6ea4seaqijqccdoqgqwqbx54vui2eazh6ijf5kku5eq3xwokp6tclivuoqei"}
```