### PR TITLE
Use correct payload size for a CARv1 file

### DIFF
--- a/storagemarket/deal_execution.go
+++ b/storagemarket/deal_execution.go
@@ -183,16 +183,26 @@ func GenerateCommP(filepath string) (cidAndSize *writer.DataCIDSize, finalErr er
 
 	// dump the CARv1 payload of the CARv2 file to the Commp Writer and get back the CommP.
 	w := &writer.Writer{}
-	//written, err := io.Copy(w, rd.DataReader())
-	_, err = io.Copy(w, rd.DataReader())
+	written, err := io.Copy(w, rd.DataReader())
 	if err != nil {
 		return nil, fmt.Errorf("failed to write to CommP writer: %w", err)
 	}
 
-	// TODO: figure out why the CARv1 payload size is always 0
-	//if written != int64(rd.Header.DataSize) {
-	//	return cid.Undef, fmt.Errorf("number of bytes written to CommP writer %d not equal to the CARv1 payload size %d", written, rd.Header.DataSize)
-	//}
+	var size int64
+	switch rd.Version {
+	case 2:
+		size = int64(rd.Header.DataSize)
+	case 1:
+		st, err := os.Stat(filepath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to stat CARv1 file: %w", err)
+		}
+		size = st.Size()
+	}
+
+	if written != size {
+		return nil, fmt.Errorf("number of bytes written to CommP writer %d not equal to the CARv1 payload size %d", written, rd.Header.DataSize)
+	}
 
 	cidAndSize = &writer.DataCIDSize{}
 	*cidAndSize, err = w.Sum()


### PR DESCRIPTION
For a CARv1 file, using the CARv2 reader over it returns an empty header. We shouldn't use this header to determine the payload size of a CARv1 file and should instead check the size of the file.