### PR TITLE
refactor: rename pieceSize to transferSize

### DIFF
--- a/db/create.sql
+++ b/db/create.sql
@@ -53,12 +53,12 @@ CREATE TABLE IF NOT EXISTS FundsTagged (
 CREATE TABLE IF NOT EXISTS StorageLogs (
     DealUUID TEXT,
     CreatedAt DateTime,
-    PieceSize TEXT,
+    TransferSize TEXT,
     LogText TEXT
 );
 
 CREATE TABLE IF NOT EXISTS StorageTagged (
     DealUUID TEXT,
     CreatedAt DateTime,
-    PieceSize TEXT
+    TransferSize TEXT
 );

--- a/db/storage_test.go
+++ b/db/storage_test.go
@@ -43,7 +43,7 @@ func TestStorageDB(t *testing.T) {
 
 	fl := &StorageLog{
 		DealUUID:  dealUUID,
-		PieceSize: uint64(1234),
+		TransferSize: uint64(1234),
 		Text:      "Hello",
 	}
 	err = db.InsertLog(ctx, fl)
@@ -53,6 +53,6 @@ func TestStorageDB(t *testing.T) {
 	req.NoError(err)
 	req.Len(logs, 1)
 	req.Equal(fl.DealUUID, logs[0].DealUUID)
-	req.Equal(fl.PieceSize, logs[0].PieceSize)
+	req.Equal(fl.TransferSize, logs[0].TransferSize)
 	req.Equal(fl.Text, logs[0].Text)
 }

--- a/storagemanager/storagemanager.go
+++ b/storagemanager/storagemanager.go
@@ -77,22 +77,22 @@ func (m *StorageManager) Tag(ctx context.Context, dealUuid uuid.UUID, size uint6
 
 // Untag
 func (m *StorageManager) Untag(ctx context.Context, dealUuid uuid.UUID) error {
-	pieceSize, err := m.db.Untag(ctx, dealUuid)
+	size, err := m.db.Untag(ctx, dealUuid)
 	if err != nil {
 		return fmt.Errorf("persisting untag storage for deal to DB: %w", err)
 	}
 
 	storageLog := &db.StorageLog{
-		DealUUID:  dealUuid,
-		Text:      "Untag staging storage for deal",
-		PieceSize: pieceSize,
+		DealUUID:     dealUuid,
+		Text:         "Untag staging storage for deal",
+		TransferSize: size,
 	}
 	err = m.db.InsertLog(ctx, storageLog)
 	if err != nil {
 		return fmt.Errorf("persisting untag storage log to DB: %w", err)
 	}
 
-	log.Infow("untag storage", "id", dealUuid, "pieceSize", pieceSize)
+	log.Infow("untag storage", "id", dealUuid, "size", size)
 	return nil
 }
 
@@ -111,9 +111,9 @@ func (m *StorageManager) persistTagged(ctx context.Context, dealUuid uuid.UUID, 
 	}
 
 	storageLog := &db.StorageLog{
-		DealUUID:  dealUuid,
-		PieceSize: pieceSize,
-		Text:      "Tag staging storage",
+		DealUUID:     dealUuid,
+		TransferSize: pieceSize,
+		Text:         "Tag staging storage",
 	}
 	err = m.db.InsertLog(ctx, storageLog)
 	if err != nil {


### PR DESCRIPTION
We are transferring and storing transfers, and not pieces on Boost side, so reflecting this in the model as well.