### PR TITLE
storage resolver: fix pending underflow

### DIFF
--- a/cmd/boost/main.go
+++ b/cmd/boost/main.go
@@ -21,6 +21,7 @@ func main() {
 	_ = logging.SetLogLevel("provider", "INFO")
 	_ = logging.SetLogLevel("gql", "INFO")
 	_ = logging.SetLogLevel("boost-provider", "INFO")
+	_ = logging.SetLogLevel("storagemanager", "INFO")
 
 	app := &cli.App{
 		Name:                 "boost",
@@ -55,6 +56,7 @@ func before(cctx *cli.Context) error {
 		_ = logging.SetLogLevel("provider", "DEBUG")
 		_ = logging.SetLogLevel("gql", "DEBUG")
 		_ = logging.SetLogLevel("boost-provider", "DEBUG")
+		_ = logging.SetLogLevel("storagemanager", "DEBUG")
 	}
 
 	return nil

--- a/storagemanager/storagemanager.go
+++ b/storagemanager/storagemanager.go
@@ -104,15 +104,15 @@ func (m *StorageManager) TotalTagged(ctx context.Context) (uint64, error) {
 	return total, nil
 }
 
-func (m *StorageManager) persistTagged(ctx context.Context, dealUuid uuid.UUID, pieceSize uint64) error {
-	err := m.db.Tag(ctx, dealUuid, pieceSize)
+func (m *StorageManager) persistTagged(ctx context.Context, dealUuid uuid.UUID, size uint64) error {
+	err := m.db.Tag(ctx, dealUuid, size)
 	if err != nil {
 		return fmt.Errorf("persisting tagged storage for deal to DB: %w", err)
 	}
 
 	storageLog := &db.StorageLog{
 		DealUUID:     dealUuid,
-		TransferSize: pieceSize,
+		TransferSize: size,
 		Text:         "Tag staging storage",
 	}
 	err = m.db.InsertLog(ctx, storageLog)
@@ -120,6 +120,6 @@ func (m *StorageManager) persistTagged(ctx context.Context, dealUuid uuid.UUID, 
 		return fmt.Errorf("persisting tag storage log to DB: %w", err)
 	}
 
-	log.Infow("tag storage", "id", dealUuid, "pieceSize", pieceSize)
+	log.Infow("tag storage", "id", dealUuid, "size", size)
 	return nil
 }


### PR DESCRIPTION
Fixes: https://github.com/filecoin-project/boost/issues/159

---

<img width="1261" alt="Screenshot 2021-12-12 at 20 47 14" src="https://user-images.githubusercontent.com/50459/145725419-fe7afa0b-b14e-4f24-b486-81c9ea51f72d.png">

<img width="1248" alt="Screenshot 2021-12-12 at 20 46 59" src="https://user-images.githubusercontent.com/50459/145725423-ccdec1b0-4b62-474e-9184-ea64daf6fb41.png">

---

This PR is fixing the `pending` overflow, and introduces the following semantics in `boost` with respect to deals storage and boost staging area:

1. `Staging` - when a deal data is successfully transferred, but still stored on `boost` side, it is marked as `Staging`.
2. `Transferred` - bytes transferred for deals that are not yet fully transferred from client to boost
3. `Pending` - bytes to be transferred to `boost`.
4. `Sealing` (not visible in UI yet) - deals that are passed from `boost` to a `sealer` node.

We have to decide how/if we want to visualise storage for deals that are already passed to a sealer node for inclusion in sectors - probably yes, but this is certainly not part of the `markets/boost staging area` storage.