### PR TITLE
Integrate libp2p-http in Boost

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -99,6 +99,8 @@ require (
 	github.com/ipld/go-car v0.3.2-0.20211001225732-32d0d9933823
 	github.com/jbenet/go-random v0.0.0-20190219211222-123a90aedc0c
 	github.com/jpillora/backoff v1.0.0
+	github.com/libp2p/go-libp2p-gostream v0.3.0
+	github.com/libp2p/go-libp2p-http v0.2.1
 	github.com/multiformats/go-multihash v0.0.15
 	github.com/whyrusleeping/cbor-gen v0.0.0-20211110122933-f57984553008
 	go.uber.org/atomic v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -925,6 +925,7 @@ github.com/libp2p/go-libp2p v0.8.1/go.mod h1:QRNH9pwdbEBpx5DTJYg+qxcVaDMAz3Ee/qD
 github.com/libp2p/go-libp2p v0.8.3/go.mod h1:EsH1A+8yoWK+L4iKcbPYu6MPluZ+CHWI9El8cTaefiM=
 github.com/libp2p/go-libp2p v0.9.2/go.mod h1:cunHNLDVus66Ct9iXXcjKRLdmHdFdHVe1TAnbubJQqQ=
 github.com/libp2p/go-libp2p v0.10.0/go.mod h1:yBJNpb+mGJdgrwbKAKrhPU0u3ogyNFTfjJ6bdM+Q/G8=
+github.com/libp2p/go-libp2p v0.12.0/go.mod h1:FpHZrfC1q7nA8jitvdjKBDF31hguaC676g/nT9PgQM0=
 github.com/libp2p/go-libp2p v0.13.0/go.mod h1:pM0beYdACRfHO1WcJlp65WXyG2A6NqYM+t2DTVAJxMo=
 github.com/libp2p/go-libp2p v0.14.0/go.mod h1:dsQrWLAoIn+GkHPN/U+yypizkHiB9tnv79Os+kSgQ4Q=
 github.com/libp2p/go-libp2p v0.14.4/go.mod h1:EIRU0Of4J5S8rkockZM7eJp2S0UrCyi55m2kJVru3rM=
@@ -1007,8 +1008,12 @@ github.com/libp2p/go-libp2p-discovery v0.4.0/go.mod h1:bZ0aJSrFc/eX2llP0ryhb1kpg
 github.com/libp2p/go-libp2p-discovery v0.5.0/go.mod h1:+srtPIU9gDaBNu//UHvcdliKBIcr4SfDcm0/PfPJLug=
 github.com/libp2p/go-libp2p-discovery v0.5.1 h1:CJylx+h2+4+s68GvrM4pGNyfNhOYviWBPtVv5PA7sfo=
 github.com/libp2p/go-libp2p-discovery v0.5.1/go.mod h1:+srtPIU9gDaBNu//UHvcdliKBIcr4SfDcm0/PfPJLug=
+github.com/libp2p/go-libp2p-gostream v0.3.0 h1:rnas//vRdHYCr7bjraZJISPwZV8OGMjeX5k5fN5Ax44=
+github.com/libp2p/go-libp2p-gostream v0.3.0/go.mod h1:pLBQu8db7vBMNINGsAwLL/ZCE8wng5V1FThoaE5rNjc=
 github.com/libp2p/go-libp2p-host v0.0.1/go.mod h1:qWd+H1yuU0m5CwzAkvbSjqKairayEHdR5MMl7Cwa7Go=
 github.com/libp2p/go-libp2p-host v0.0.3/go.mod h1:Y/qPyA6C8j2coYyos1dfRm0I8+nvd4TGrDGt4tA7JR8=
+github.com/libp2p/go-libp2p-http v0.2.1 h1:h8kuv7ExPe0nDtWAexKQWbjnXqks1hwOdYLs84gMCpo=
+github.com/libp2p/go-libp2p-http v0.2.1/go.mod h1:9KdioZ7XqNH0eZkZG9bulZLzHv11A7/12fT97agqWhg=
 github.com/libp2p/go-libp2p-interface-connmgr v0.0.1/go.mod h1:GarlRLH0LdeWcLnYM/SaBykKFl9U5JFnbBGruAk/D5k=
 github.com/libp2p/go-libp2p-interface-connmgr v0.0.4/go.mod h1:GarlRLH0LdeWcLnYM/SaBykKFl9U5JFnbBGruAk/D5k=
 github.com/libp2p/go-libp2p-interface-connmgr v0.0.5/go.mod h1:GarlRLH0LdeWcLnYM/SaBykKFl9U5JFnbBGruAk/D5k=
@@ -1029,6 +1034,7 @@ github.com/libp2p/go-libp2p-mplex v0.2.0/go.mod h1:Ejl9IyjvXJ0T9iqUTE1jpYATQ9NM3
 github.com/libp2p/go-libp2p-mplex v0.2.1/go.mod h1:SC99Rxs8Vuzrf/6WhmH41kNn13TiYdAWNYHrwImKLnE=
 github.com/libp2p/go-libp2p-mplex v0.2.2/go.mod h1:74S9eum0tVQdAfFiKxAyKzNdSuLqw5oadDq7+L/FELo=
 github.com/libp2p/go-libp2p-mplex v0.2.3/go.mod h1:CK3p2+9qH9x+7ER/gWWDYJ3QW5ZxWDkm+dVvjfuG3ek=
+github.com/libp2p/go-libp2p-mplex v0.3.0/go.mod h1:l9QWxRbbb5/hQMECEb908GbS9Sm2UAR2KFZKUJEynEs=
 github.com/libp2p/go-libp2p-mplex v0.4.0/go.mod h1:yCyWJE2sc6TBTnFpjvLuEJgTSw/u+MamvzILKdX7asw=
 github.com/libp2p/go-libp2p-mplex v0.4.1 h1:/pyhkP1nLwjG3OM+VuaNJkQT/Pqq73WzB3aDN3Fx1sc=
 github.com/libp2p/go-libp2p-mplex v0.4.1/go.mod h1:cmy+3GfqfM1PceHTLL7zQzAAYaryDu6iPSC+CIb094g=
@@ -1100,6 +1106,7 @@ github.com/libp2p/go-libp2p-swarm v0.2.4/go.mod h1:/xIpHFPPh3wmSthtxdGbkHZ0OET1h
 github.com/libp2p/go-libp2p-swarm v0.2.7/go.mod h1:ZSJ0Q+oq/B1JgfPHJAT2HTall+xYRNYp1xs4S2FBWKA=
 github.com/libp2p/go-libp2p-swarm v0.2.8/go.mod h1:JQKMGSth4SMqonruY0a8yjlPVIkb0mdNSwckW7OYziM=
 github.com/libp2p/go-libp2p-swarm v0.3.0/go.mod h1:hdv95GWCTmzkgeJpP+GK/9D9puJegb7H57B5hWQR5Kk=
+github.com/libp2p/go-libp2p-swarm v0.3.1/go.mod h1:hdv95GWCTmzkgeJpP+GK/9D9puJegb7H57B5hWQR5Kk=
 github.com/libp2p/go-libp2p-swarm v0.4.0/go.mod h1:XVFcO52VoLoo0eitSxNQWYq4D6sydGOweTOAjJNraCw=
 github.com/libp2p/go-libp2p-swarm v0.5.0/go.mod h1:sU9i6BoHE0Ve5SKz3y9WfKrh8dUat6JknzUehFx8xW4=
 github.com/libp2p/go-libp2p-swarm v0.5.3 h1:hsYaD/y6+kZff1o1Mc56NcuwSg80lIphTS/zDk3mO4M=

--- a/node/modules/storageminer.go
+++ b/node/modules/storageminer.go
@@ -531,7 +531,7 @@ func NewDealsDB(sqldb *sql.DB) *db.DealsDB {
 
 func NewStorageMarketProvider(provAddr address.Address) func(lc fx.Lifecycle, r repo.LockedRepo, h host.Host, a v1api.FullNode, sqldb *sql.DB, dealsDB *db.DealsDB, fundMgr *fundmanager.FundManager, storageMgr *storagemanager.StorageManager, dp *storagemarket.DealPublisher, secb *sectorblocks.SectorBlocks, sps sealingpipeline.State) (*storagemarket.Provider, error) {
 	return func(lc fx.Lifecycle, r repo.LockedRepo, h host.Host, a v1api.FullNode, sqldb *sql.DB, dealsDB *db.DealsDB, fundMgr *fundmanager.FundManager, storageMgr *storagemanager.StorageManager, dp *storagemarket.DealPublisher, secb *sectorblocks.SectorBlocks, sps sealingpipeline.State) (*storagemarket.Provider, error) {
-		prov, err := storagemarket.NewProvider(r.Path(), sqldb, dealsDB, fundMgr, storageMgr, a, dp, provAddr, secb, sps)
+		prov, err := storagemarket.NewProvider(r.Path(), h, sqldb, dealsDB, fundMgr, storageMgr, a, dp, provAddr, secb, sps)
 		lp2pnet := lp2pimpl.NewDealProvider(h, prov)
 
 		if err != nil {

--- a/storagemarket/provider.go
+++ b/storagemarket/provider.go
@@ -10,6 +10,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/libp2p/go-libp2p-core/host"
+
 	"github.com/filecoin-project/boost/api"
 	"github.com/filecoin-project/boost/db"
 	"github.com/filecoin-project/boost/filestore"
@@ -78,7 +80,7 @@ type Provider struct {
 	dhs   map[uuid.UUID]*dealHandler
 }
 
-func NewProvider(repoRoot string, sqldb *sql.DB, dealsDB *db.DealsDB, fundMgr *fundmanager.FundManager, storageMgr *storagemanager.StorageManager, fullnodeApi v1api.FullNode, dealPublisher *DealPublisher, addr address.Address, secb *sectorblocks.SectorBlocks, sps sealingpipeline.State) (*Provider, error) {
+func NewProvider(repoRoot string, h host.Host, sqldb *sql.DB, dealsDB *db.DealsDB, fundMgr *fundmanager.FundManager, storageMgr *storagemanager.StorageManager, fullnodeApi v1api.FullNode, dealPublisher *DealPublisher, addr address.Address, secb *sectorblocks.SectorBlocks, sps sealingpipeline.State) (*Provider, error) {
 	fspath := path.Join(repoRoot, "incoming")
 	err := os.MkdirAll(fspath, os.ModePerm)
 	if err != nil {
@@ -107,7 +109,7 @@ func NewProvider(repoRoot string, sqldb *sql.DB, dealsDB *db.DealsDB, fundMgr *f
 		finishedDealChan:  make(chan finishedDealReq),
 		publishedDealChan: make(chan publishDealReq),
 
-		Transport:      httptransport.New(),
+		Transport:      httptransport.New(h),
 		fundManager:    fundMgr,
 		storageManager: storageMgr,
 

--- a/transport/httptransport/http_transport_test.go
+++ b/transport/httptransport/http_transport_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -14,6 +16,14 @@ import (
 	"testing"
 	"time"
 
+	p2phttp "github.com/libp2p/go-libp2p-http"
+
+	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p-core/peerstore"
+	gostream "github.com/libp2p/go-libp2p-gostream"
+	"github.com/multiformats/go-multiaddr"
+
+	"github.com/libp2p/go-libp2p-core/host"
 	"go.uber.org/atomic"
 
 	"golang.org/x/xerrors"
@@ -28,43 +38,54 @@ import (
 
 func TestSimpleTransfer(t *testing.T) {
 	ctx := context.Background()
-
-	// start server with data to send
 	size := (100 * readBufferSize) + 30
-	str := strings.Repeat("a", size)
-	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		rd := strings.NewReader(str)
-		http.ServeContent(w, r, "", time.Now(), rd)
-	}))
-	defer svr.Close()
+	str := randSeq(size)
+	svcs := serversWithRangeHandler(t, str)
 
-	of := getTempFilePath(t)
-	th := executeTransfer(t, ctx, &httpTransport{}, size, svr.URL, of)
-	require.NotNil(t, th)
+	for name, init := range svcs {
+		t.Run(name, func(t *testing.T) {
+			url, closer, h := init(t)
+			defer closer()
+			of := getTempFilePath(t)
+			th := executeTransfer(t, ctx, New(h), size, url, of)
+			require.NotNil(t, th)
 
-	evts := waitForTransferComplete(th)
-	require.NotEmpty(t, evts)
-	require.EqualValues(t, size, evts[len(evts)-1].NBytesReceived)
-
-	assertFileContents(t, of, str)
+			evts := waitForTransferComplete(th)
+			require.NotEmpty(t, evts)
+			require.EqualValues(t, size, evts[len(evts)-1].NBytesReceived)
+			assertFileContents(t, of, str)
+		})
+	}
 }
 
 func TestTransportRespectsContext(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(1 * time.Hour)
-	}))
+	closing := make(chan struct{}, 2)
 
-	of := getTempFilePath(t)
-	th := executeTransfer(t, ctx, &httpTransport{}, 100, svr.URL, of)
-	require.NotNil(t, th)
+	svcs := serversWithCustomHandler(t, func(http.ResponseWriter, *http.Request) {
+		<-closing
+		return
+	})
 
-	evts := waitForTransferComplete(th)
-	require.NotEmpty(t, evts)
-	require.Len(t, evts, 1)
-	require.Contains(t, evts[0].Error.Error(), "context")
+	for name, init := range svcs {
+		t.Run(name, func(t *testing.T) {
+			url, close, h := init(t)
+			defer close()
+
+			of := getTempFilePath(t)
+			th := executeTransfer(t, ctx, New(h), 100, url, of)
+			require.NotNil(t, th)
+
+			evts := waitForTransferComplete(th)
+			require.NotEmpty(t, evts)
+			require.Len(t, evts, 1)
+			require.Contains(t, evts[0].Error.Error(), "context")
+
+			closing <- struct{}{}
+		})
+	}
 }
 
 func TestConcurrentTransfers(t *testing.T) {
@@ -72,46 +93,48 @@ func TestConcurrentTransfers(t *testing.T) {
 
 	// start server with data to send
 	size := (100 * readBufferSize) + 30
-	str := strings.Repeat("a", size)
-	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		rd := strings.NewReader(str)
-		http.ServeContent(w, r, "", time.Now(), rd)
-	}))
-	defer svr.Close()
-	ht := &httpTransport{}
+	str := randSeq(size)
+	svcs := serversWithRangeHandler(t, str)
 
-	var errG errgroup.Group
-	for i := 0; i < 10; i++ {
-		errG.Go(func() error {
-			of := getTempFilePath(t)
-			th := executeTransfer(t, ctx, ht, size, svr.URL, of)
+	for name, s := range svcs {
+		t.Run(name, func(t *testing.T) {
+			url, closer, h := s(t)
+			defer closer()
 
-			evts := waitForTransferComplete(th)
-			if len(evts) == 0 {
-				return errors.New("events should NOT be empty")
+			var errG errgroup.Group
+			for i := 0; i < 10; i++ {
+				errG.Go(func() error {
+					of := getTempFilePath(t)
+					th := executeTransfer(t, ctx, New(h), size, url, of)
+
+					evts := waitForTransferComplete(th)
+					if len(evts) == 0 {
+						return errors.New("events should NOT be empty")
+					}
+
+					if size != int(evts[len(evts)-1].NBytesReceived) {
+						return errors.New("size mismatch")
+					}
+
+					f, err := os.Open(of)
+					if err != nil {
+						return err
+					}
+					bz, err := ioutil.ReadAll(f)
+					if err != nil {
+						return err
+					}
+
+					if str != string(bz) {
+						return errors.New("content mismatch")
+					}
+					return nil
+				})
 			}
 
-			if size != int(evts[len(evts)-1].NBytesReceived) {
-				return errors.New("size mismatch")
-			}
-
-			f, err := os.Open(of)
-			if err != nil {
-				return err
-			}
-			bz, err := ioutil.ReadAll(f)
-			if err != nil {
-				return err
-			}
-
-			if str != string(bz) {
-				return errors.New("content mismatch")
-			}
-			return nil
+			require.NoError(t, errG.Wait())
 		})
 	}
-
-	require.NoError(t, errG.Wait())
 }
 
 func TestCompletionOnMultipleAttemptsWithSameFile(t *testing.T) {
@@ -120,59 +143,92 @@ func TestCompletionOnMultipleAttemptsWithSameFile(t *testing.T) {
 
 	// start server with data to send
 	size := (100 * readBufferSize) + 30
-	str := strings.Repeat("a", size)
+	str := randSeq(size)
 
-	end := readBufferSize
-	for i := 1; ; i++ {
-		svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := func(i int) func(w http.ResponseWriter, r *http.Request) {
+		return func(w http.ResponseWriter, r *http.Request) {
 			rangeEnd := readBufferSize * i
 			if rangeEnd > size {
 				rangeEnd = size
 			}
 			http.ServeContent(w, r, "", time.Time{}, strings.NewReader(str[:rangeEnd]))
-		}))
-
-		th := executeTransfer(t, ctx, &httpTransport{}, size, svr.URL, of)
-		require.NotNil(t, th)
-
-		evts := waitForTransferComplete(th)
-
-		if len(evts) == 1 {
-			require.EqualValues(t, size, evts[0].NBytesReceived)
-			break
-		}
-		require.Contains(t, evts[len(evts)-1].Error.Error(), "mismatch")
-
-		assertFileContents(t, of, str[:end])
-		svr.Close()
-		end = end + readBufferSize
-		if end > size {
-			end = size
 		}
 	}
 
-	// ensure file contents are correct in the end
-	assertFileContents(t, of, str)
+	svcs := map[string]struct {
+		init func(t *testing.T, i int) (url string, close func(), h host.Host)
+	}{
+		"http": {
+			init: func(t *testing.T, i int) (string, func(), host.Host) {
+				svr := httptest.NewServer(http.HandlerFunc(handler((i))))
+				return svr.URL, svr.Close, nil
+			},
+		},
+		"libp2p-http": {
+			init: func(t *testing.T, i int) (string, func(), host.Host) {
+				svr := newLibp2pHttpServer(t, handler(i))
+				return svr.URL, svr.Close, svr.clientHost
+			},
+		},
+	}
+
+	for name, s := range svcs {
+		t.Run(name, func(t *testing.T) {
+			end := readBufferSize
+			for i := 1; ; i++ {
+				url, closer, h := s.init(t, i)
+
+				th := executeTransfer(t, ctx, New(h), size, url, of)
+				require.NotNil(t, th)
+
+				evts := waitForTransferComplete(th)
+
+				if len(evts) == 1 {
+					require.EqualValues(t, size, evts[0].NBytesReceived)
+					break
+				}
+				require.Contains(t, evts[len(evts)-1].Error.Error(), "mismatch")
+
+				assertFileContents(t, of, str[:end])
+				closer()
+				end = end + readBufferSize
+				if end > size {
+					end = size
+				}
+			}
+
+			// ensure file contents are correct in the end
+			assertFileContents(t, of, str)
+		})
+	}
 }
 
 func TestTransferCancellation(t *testing.T) {
-
 	// start server with data to send
 	size := (100 * readBufferSize) + 30
-	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(100 * time.Second)
-	}))
-	defer svr.Close()
 
-	of := getTempFilePath(t)
-	th := executeTransfer(t, context.Background(), &httpTransport{}, size, svr.URL, of)
-	require.NotNil(t, th)
-	// close the transfer so context is cancelled
-	th.Close()
+	closing := make(chan struct{}, 2)
+	svcs := serversWithCustomHandler(t, func(http.ResponseWriter, *http.Request) {
+		fmt.Println("Hello")
+		<-closing
+	})
 
-	evts := waitForTransferComplete(th)
-	require.Len(t, evts, 1)
-	require.True(t, xerrors.Is(evts[0].Error, context.Canceled))
+	for name, s := range svcs {
+		t.Run(name, func(t *testing.T) {
+			url, closer, h := s(t)
+			defer closer()
+			of := getTempFilePath(t)
+			th := executeTransfer(t, context.Background(), New(h), size, url, of)
+			require.NotNil(t, th)
+			// close the transfer so context is cancelled
+			th.Close()
+
+			evts := waitForTransferComplete(th)
+			require.Len(t, evts, 1)
+			require.True(t, xerrors.Is(evts[0].Error, context.Canceled))
+			closing <- struct{}{}
+		})
+	}
 }
 
 type contextKey struct {
@@ -215,10 +271,52 @@ func TestTransferResumption(t *testing.T) {
 	}))
 	svr.Config.ConnContext = SaveConnInContext
 	svr.Start()
+	defer svr.Close()
+
+	ht := New(nil, BackOffRetryOpt(50*time.Millisecond, 100*time.Millisecond, 2, 1000))
+	of := getTempFilePath(t)
+	th := executeTransfer(t, context.Background(), ht, size, svr.URL, of)
+	require.NotNil(t, th)
+
+	evts := waitForTransferComplete(th)
+	require.NotEmpty(t, evts)
+	require.EqualValues(t, size, evts[len(evts)-1].NBytesReceived)
+
+	assertFileContents(t, of, str)
+
+	// assert we had to make multiple connections to the server
+	require.True(t, nAttempts.Load() > 10)
+}
+
+func TestLibp2pTransferResumption(t *testing.T) {
+	// start server with data to send
+	size := (100 * readBufferSize) + 30
+	str := strings.Repeat("a", size)
+
+	var nAttempts atomic.Int32
+
+	// start http server that always sends 500Kb and disconnects (total file size is greater than 100 Mb)
+	svr := newLibp2pHttpServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nAttempts.Inc()
+		offset := r.Header.Get("Range")
+		finalOffset := strings.TrimSuffix(strings.TrimPrefix(offset, "bytes="), "-")
+		start, _ := strconv.ParseInt(finalOffset, 10, 64)
+
+		end := int(start + (readBufferSize + 70))
+		if end > size {
+			end = size
+		}
+
+		w.WriteHeader(200)
+		w.Write([]byte(str[start:end])) //nolint:errcheck
+		// close the connection so user sees an error while reading the response
+		c := GetConn(r)
+		c.Close() //nolint:errcheck
+	}))
 
 	defer svr.Close()
 
-	ht := New(BackOffRetryOpt(50*time.Millisecond, 100*time.Millisecond, 2, 1000))
+	ht := New(svr.clientHost, BackOffRetryOpt(50*time.Millisecond, 100*time.Millisecond, 2, 1000))
 	of := getTempFilePath(t)
 	th := executeTransfer(t, context.Background(), ht, size, svr.URL, of)
 	require.NotNil(t, th)
@@ -251,9 +349,7 @@ func executeTransfer(t *testing.T, ctx context.Context, ht *httpTransport, size 
 }
 
 func assertFileContents(t *testing.T, file string, expected string) {
-	f, err := os.Open(file)
-	require.NoError(t, err)
-	bz, err := ioutil.ReadAll(f)
+	bz, err := ioutil.ReadFile(file)
 	require.NoError(t, err)
 	require.EqualValues(t, expected, string(bz))
 }
@@ -274,4 +370,91 @@ func waitForTransferComplete(th transport.Handler) []types.TransportEvent {
 	}
 
 	return evts
+}
+
+func serversWithRangeHandler(t *testing.T, str string) map[string]func(t *testing.T) (url string, close func(), h host.Host) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		offset := r.Header.Get("Range")
+		finalOffset := strings.TrimSuffix(strings.TrimPrefix(offset, "bytes="), "-")
+		start, _ := strconv.ParseInt(finalOffset, 10, 64)
+		w.WriteHeader(200)
+		w.Write([]byte(str[start:]))
+	}
+
+	return serversWithCustomHandler(t, handler)
+}
+
+func serversWithCustomHandler(t *testing.T, handler http.HandlerFunc) map[string]func(t *testing.T) (url string, close func(), h host.Host) {
+	svcs := map[string]func(t *testing.T) (url string, close func(), h host.Host){
+		"http": func(t *testing.T) (string, func(), host.Host) {
+			svr := httptest.NewServer(handler)
+			return svr.URL, svr.Close, nil
+		},
+		"libp2p-http": func(t *testing.T) (string, func(), host.Host) {
+			svr := newLibp2pHttpServer(t, handler)
+			return svr.URL, svr.Close, svr.clientHost
+		},
+	}
+
+	return svcs
+}
+
+type lip2pHttpServer struct {
+	srvHost    host.Host
+	clientHost host.Host
+	listener   net.Listener
+	URL        string
+}
+
+func (l *lip2pHttpServer) Close() {
+	l.srvHost.Close()
+	l.clientHost.Close()
+	l.listener.Close()
+}
+
+func newLibp2pHttpServer(t *testing.T, handler func(http.ResponseWriter, *http.Request)) *lip2pHttpServer {
+	l := &lip2pHttpServer{}
+
+	m1, _ := multiaddr.NewMultiaddr("/ip4/127.0.0.1/tcp/0")
+	m2, _ := multiaddr.NewMultiaddr("/ip4/127.0.0.1/tcp/0")
+	l.srvHost = newHost(t, m1)
+	l.clientHost = newHost(t, m2)
+
+	l.srvHost.Peerstore().AddAddrs(l.clientHost.ID(), l.clientHost.Addrs(), peerstore.PermanentAddrTTL)
+	l.clientHost.Peerstore().AddAddrs(l.srvHost.ID(), l.srvHost.Addrs(), peerstore.PermanentAddrTTL)
+
+	listener, err := gostream.Listen(l.srvHost, p2phttp.DefaultP2PProtocol)
+	require.NoError(t, err)
+	l.listener = listener
+
+	patt := randSeq(10)
+
+	go func() {
+		http.HandleFunc("/"+patt, handler)
+		server := &http.Server{}
+		server.ConnContext = SaveConnInContext
+		server.Serve(listener)
+	}()
+
+	l.URL = fmt.Sprintf("libp2p://%s/%s", l.srvHost.ID().Pretty(), patt)
+	return l
+}
+
+func newHost(t *testing.T, listen multiaddr.Multiaddr) host.Host {
+	h, err := libp2p.New(
+		context.Background(),
+		libp2p.ListenAddrs(listen),
+	)
+	require.NoError(t, err)
+	return h
+}
+
+var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+func randSeq(n int) string {
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(b)
 }


### PR DESCRIPTION
Reuses the http transport we have so we get resumption, notifications etc out of the box.
Augments all tests that we already have for the http transport to use the libp2p-http transport as well.