### PR TITLE
Bench libp2p svr

### DIFF
--- a/car/block_info_cache.go
+++ b/car/block_info_cache.go
@@ -1,0 +1,168 @@
+package car
+
+import (
+	"sync"
+	"time"
+
+	"github.com/ipfs/go-cid"
+	format "github.com/ipfs/go-ipld-format"
+)
+
+// BlockInfoCacheManager gets a BlockInfoCache for a given payload cid.
+// Implementations may wish to share the same cache between multiple
+// requests for the same payload.
+type BlockInfoCacheManager interface {
+	// Get the BlockInfoCache by payload cid
+	Get(payloadCid cid.Cid) *BlockInfoCache
+	// Unref is called when a request no longer needs the cache
+	Unref(payloadCid cid.Cid)
+}
+
+type cacheRefs struct {
+	refs  int
+	cache *BlockInfoCache
+}
+
+// RefCountBICM keeps track of references to a BlockInfoCache by payload cid,
+// and deletes the cache once references reach zero.
+type RefCountBICM struct {
+	lk    sync.Mutex
+	cache map[cid.Cid]*cacheRefs
+}
+
+var _ BlockInfoCacheManager = (*RefCountBICM)(nil)
+
+func NewRefCountBICM() *RefCountBICM {
+	return &RefCountBICM{cache: make(map[cid.Cid]*cacheRefs)}
+}
+
+func (bm *RefCountBICM) Get(payloadCid cid.Cid) *BlockInfoCache {
+	bm.lk.Lock()
+	defer bm.lk.Unlock()
+
+	bic, ok := bm.cache[payloadCid]
+	if ok {
+		bic.refs++
+	} else {
+		bic = &cacheRefs{cache: NewBlockInfoCache()}
+		bm.cache[payloadCid] = bic
+	}
+	return bic.cache
+}
+
+func (bm *RefCountBICM) Unref(payloadCid cid.Cid) {
+	bm.lk.Lock()
+	defer bm.lk.Unlock()
+
+	bic, ok := bm.cache[payloadCid]
+	if !ok {
+		return
+	}
+
+	bic.refs--
+	if bic.refs == 0 {
+		delete(bm.cache, payloadCid)
+	}
+}
+
+// DelayedUnrefBICM is like RefCountBCIM but when the last reference is
+// unrefed, the cache is not removed for some delay. This is useful for the
+// case where a connection goes down momentarily and then a new request
+// is made (and we want to keep the cache for the new request).
+type DelayedUnrefBICM struct {
+	*RefCountBICM
+	unrefDelay time.Duration
+	timers     map[cid.Cid]*time.Timer
+}
+
+var _ BlockInfoCacheManager = (*DelayedUnrefBICM)(nil)
+
+func NewDelayedUnrefBICM(unrefDelay time.Duration) *DelayedUnrefBICM {
+	return &DelayedUnrefBICM{
+		RefCountBICM: NewRefCountBICM(),
+		unrefDelay:   unrefDelay,
+		timers:       make(map[cid.Cid]*time.Timer),
+	}
+}
+
+func (d *DelayedUnrefBICM) Unref(payloadCid cid.Cid) {
+	d.unref(payloadCid, true)
+}
+
+func (d *DelayedUnrefBICM) unref(payloadCid cid.Cid, withDelay bool) {
+	d.lk.Lock()
+	defer d.lk.Unlock()
+
+	bic, ok := d.cache[payloadCid]
+	if !ok {
+		return
+	}
+
+	bic.refs--
+
+	// If there are no more references to the cache for this payload cid
+	if bic.refs == 0 {
+		if withDelay {
+			// If there's already a timer running, stop it
+			timer, ok := d.timers[payloadCid]
+			if ok {
+				timer.Stop()
+			}
+
+			// Start a new timer
+			timer = time.AfterFunc(d.unrefDelay, func() {
+				// When the timer expires, remove the cache for this payload cid
+				d.unref(payloadCid, false)
+			})
+			d.timers[payloadCid] = timer
+		} else {
+			// Delete the timer for this payload cid
+			delete(d.timers, payloadCid)
+		}
+
+		// Delete the cache for this payload cid
+		delete(d.cache, payloadCid)
+	}
+}
+
+func (d *DelayedUnrefBICM) Close() {
+	// Stop any running timers
+	for _, timer := range d.timers {
+		timer.Stop()
+	}
+}
+
+// BlockInfo keeps track of blocks in a CAR file
+type BlockInfo struct {
+	// The offset into the CAR file
+	offset uint64
+	// Note: size is the size of the block and metadata in the CAR file
+	size uint64
+	// Links to child nodes in the DAG
+	links []*format.Link
+}
+
+// BlockInfoCache keeps block info by cid
+type BlockInfoCache struct {
+	lk    sync.RWMutex
+	cache map[cid.Cid]*BlockInfo
+}
+
+func NewBlockInfoCache() *BlockInfoCache {
+	return &BlockInfoCache{cache: make(map[cid.Cid]*BlockInfo)}
+}
+
+func (bic *BlockInfoCache) Get(c cid.Cid) (*BlockInfo, bool) {
+	bic.lk.RLock()
+	defer bic.lk.RUnlock()
+
+	bi, ok := bic.cache[c]
+	return bi, ok
+}
+
+func (bic *BlockInfoCache) Put(c cid.Cid, bi *BlockInfo) {
+	bic.lk.Lock()
+	defer bic.lk.Unlock()
+
+	bic.cache[c] = bi
+}

--- a/car/block_info_cache_test.go
+++ b/car/block_info_cache_test.go
@@ -1,0 +1,132 @@
+package car
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/ipfs/go-cid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRefCountBICM(t *testing.T) {
+	bicm := NewRefCountBICM()
+	testRefCountBICM(t, bicm, bicm.cache)
+}
+
+func testRefCountBICM(t *testing.T, bicm BlockInfoCacheManager, internalCache map[cid.Cid]*cacheRefs) {
+	payloadCid, err := cid.Parse("bafkqaaa")
+	require.NoError(t, err)
+
+	bic := bicm.Get(payloadCid)
+	bic2 := bicm.Get(payloadCid)
+	require.True(t, bic == bic2)
+	require.Len(t, internalCache, 1)
+
+	// Unref the cache once, should still be a copy in memory
+	bicm.Unref(payloadCid, nil)
+	require.Len(t, internalCache, 1)
+
+	// Unref the cache a second time, there should now be no copies in memory
+	bicm.Unref(payloadCid, nil)
+	require.Len(t, internalCache, 0)
+}
+
+func TestDelayedUnrefBICM(t *testing.T) {
+	t.Run("test ref counting: unref with nil error", func(t *testing.T) {
+		bicm := NewDelayedUnrefBICM(100 * time.Millisecond)
+		testRefCountBICM(t, bicm, bicm.cache)
+	})
+
+	t.Run("test ref counting: each unref with an error", func(t *testing.T) {
+		duration := 100 * time.Millisecond
+		bicm := NewDelayedUnrefBICM(duration)
+		internalCache := bicm.cache
+
+		payloadCid, err := cid.Parse("bafkqaaa")
+		require.NoError(t, err)
+
+		bic := bicm.Get(payloadCid)
+		bic2 := bicm.Get(payloadCid)
+		require.True(t, bic == bic2)
+		require.Len(t, internalCache, 1)
+
+		// Unref the cache twice, with an error each time.
+		// Expect the cache not to be cleared until the timer has expired on
+		// the last unreference.
+		bicm.Unref(payloadCid, errors.New("err"))
+		time.Sleep(duration / 2)
+		bicm.Unref(payloadCid, errors.New("err"))
+
+		// total sleep:
+		// first ref - 0.5 timer duration
+		// second ref - 0 timer duration
+		require.Len(t, internalCache, 1)
+
+		time.Sleep(duration/2 + duration/4)
+		// total sleep:
+		// first ref - 1.25 timer duration
+		// second ref - 0.75 timer duration
+		require.Len(t, internalCache, 1)
+
+		time.Sleep(duration)
+		// total sleep:
+		// first ref - 2.25 timer duration
+		// second ref - 1.75 timer duration
+		require.Len(t, internalCache, 0)
+	})
+
+	t.Run("test ref counting: unref with error, then unref with no error", func(t *testing.T) {
+		duration := 100 * time.Millisecond
+		bicm := NewDelayedUnrefBICM(duration)
+		internalCache := bicm.cache
+
+		payloadCid, err := cid.Parse("bafkqaaa")
+		require.NoError(t, err)
+
+		bic := bicm.Get(payloadCid)
+		bic2 := bicm.Get(payloadCid)
+		require.True(t, bic == bic2)
+		require.Len(t, internalCache, 1)
+
+		// Unref the cache twice, the first with an error, the second without
+		// an error
+		bicm.Unref(payloadCid, errors.New("err"))
+		bicm.Unref(payloadCid, nil)
+
+		// Expect the cache not to be cleared until the timer has expired on the
+		// unref with an error
+		require.Len(t, internalCache, 1)
+		time.Sleep(duration / 2)
+		require.Len(t, internalCache, 1)
+		time.Sleep(duration)
+		require.Len(t, internalCache, 0)
+	})
+
+	t.Run("test ref counting: unref with no error, then unref with error", func(t *testing.T) {
+		duration := 100 * time.Millisecond
+		bicm := NewDelayedUnrefBICM(duration)
+		internalCache := bicm.cache
+
+		payloadCid, err := cid.Parse("bafkqaaa")
+		require.NoError(t, err)
+
+		bic := bicm.Get(payloadCid)
+		bic2 := bicm.Get(payloadCid)
+		require.True(t, bic == bic2)
+		require.Len(t, internalCache, 1)
+
+		// Unref the cache twice, the first with no error, the second with
+		// an error
+		bicm.Unref(payloadCid, nil)
+		bicm.Unref(payloadCid, errors.New("err"))
+
+		// Expect the cache not to be cleared until the timer has expired on the
+		// unref with an error
+		require.Len(t, internalCache, 1)
+		time.Sleep(duration / 2)
+		require.Len(t, internalCache, 1)
+		time.Sleep(duration)
+		require.Len(t, internalCache, 0)
+	})
+}

--- a/car/car_offset_writer.go
+++ b/car/car_offset_writer.go
@@ -1,0 +1,161 @@
+package car
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/ipfs/go-blockservice"
+	"github.com/ipfs/go-cid"
+	blockstore "github.com/ipfs/go-ipfs-blockstore"
+	offline "github.com/ipfs/go-ipfs-exchange-offline"
+	format "github.com/ipfs/go-ipld-format"
+	"github.com/ipfs/go-merkledag"
+	"github.com/ipld/go-car"
+	"github.com/ipld/go-car/util"
+)
+
+// CarOffsetWriter turns a blockstore and a root CID into a CAR file stream,
+// starting from an offset
+type CarOffsetWriter struct {
+	payloadCid cid.Cid
+	nodeGetter format.NodeGetter
+	blockInfos *BlockInfoCache
+	header     car.CarHeader
+}
+
+func NewCarOffsetWriter(payloadCid cid.Cid, bstore blockstore.Blockstore, blockInfos *BlockInfoCache) *CarOffsetWriter {
+	ng := merkledag.NewDAGService(blockservice.New(bstore, offline.Exchange(bstore)))
+	return &CarOffsetWriter{
+		payloadCid: payloadCid,
+		nodeGetter: ng,
+		blockInfos: blockInfos,
+		header:     carHeader(payloadCid),
+	}
+}
+
+func carHeader(payloadCid cid.Cid) car.CarHeader {
+	return car.CarHeader{
+		Roots:   []cid.Cid{payloadCid},
+		Version: 1,
+	}
+}
+
+func (s *CarOffsetWriter) Write(ctx context.Context, w io.Writer, offset uint64) error {
+	headerSize, err := s.writeHeader(w, offset)
+	if err != nil {
+		return err
+	}
+
+	return s.writeBlocks(ctx, w, headerSize, offset)
+}
+
+func (s *CarOffsetWriter) writeHeader(w io.Writer, offset uint64) (uint64, error) {
+	headerSize, err := car.HeaderSize(&s.header)
+	if err != nil {
+		return 0, fmt.Errorf("failed to size car header: %w", err)
+	}
+
+	// Check if the offset from which to start writing is after the header
+	if offset >= headerSize {
+		return headerSize, nil
+	}
+
+	// Write out the header, starting at the offset
+	_, err = skipWrite(w, offset, func(sw io.Writer) (int, error) {
+		return 0, car.WriteHeader(&s.header, sw)
+	})
+	if err != nil {
+		return 0, fmt.Errorf("failed to write car header: %w", err)
+	}
+
+	return headerSize, nil
+}
+
+func (s *CarOffsetWriter) writeBlocks(ctx context.Context, w io.Writer, headerSize uint64, writeOffset uint64) error {
+	// The first block's offset is the size of the header
+	offset := headerSize
+
+	// This function gets called for each CID during the merkle DAG walk
+	nextCid := func(ctx context.Context, c cid.Cid) ([]*format.Link, error) {
+		// There will be an item in the cache if writeBlocks has already been
+		// called before, and the DAG traversal reached this CID
+		cached, ok := s.blockInfos.Get(c)
+		if ok {
+			// Check if the offset from which to start writing is after this
+			// block
+			nextBlockOffset := cached.offset + cached.size
+			if writeOffset >= nextBlockOffset {
+				// The offset from which to start writing is after this block
+				// so don't write anything, just skip over this block
+				offset = nextBlockOffset
+				return cached.links, nil
+			}
+		}
+
+		// Get the block from the blockstore
+		nd, err := s.nodeGetter.Get(ctx, c)
+		if err != nil {
+			return nil, fmt.Errorf("getting block %s: %w", c, err)
+		}
+
+		// Get the size of the block and metadata
+		ldsize := util.LdSize(nd.Cid().Bytes(), nd.RawData())
+
+		// Check if the offset from which to start writing is in or before this
+		// block
+		nextBlockOffset := offset + ldsize
+		if writeOffset < nextBlockOffset {
+			// Check if the offset from which to start writing is in this block
+			var blockWriteOffset uint64
+			if writeOffset >= offset {
+				blockWriteOffset = writeOffset - offset
+			}
+
+			// Write the block data to the writer, starting at the block offset
+			_, err = skipWrite(w, blockWriteOffset, func(sw io.Writer) (int, error) {
+				return 0, util.LdWrite(sw, nd.Cid().Bytes(), nd.RawData())
+			})
+			if err != nil {
+				return nil, fmt.Errorf("writing CAR block %s: %w", c, err)
+			}
+		}
+
+		// Add the block to the cache
+		s.blockInfos.Put(nd.Cid(), &BlockInfo{
+			offset: offset,
+			size:   ldsize,
+			links:  nd.Links(),
+		})
+
+		offset = nextBlockOffset
+
+		// Return any links from this block to other DAG blocks
+		return nd.Links(), nil
+	}
+
+	seen := cid.NewSet()
+	return merkledag.Walk(ctx, nextCid, s.payloadCid, seen.Visit)
+}
+
+// Write data to the writer, skipping the first skip bytes
+func skipWrite(w io.Writer, skip uint64, write func(sw io.Writer) (int, error)) (int, error) {
+	// If there's nothing to skip, just do a normal write
+	if skip == 0 {
+		return write(w)
+	}
+
+	// Write to a buffer
+	var buff bytes.Buffer
+	if count, err := write(&buff); err != nil {
+		return count, err
+	}
+
+	// Write the buffer to the writer, skipping the first skip bytes
+	bz := buff.Bytes()
+	if skip >= uint64(len(bz)) {
+		return 0, nil
+	}
+	return w.Write(bz[skip:])
+}

--- a/car/car_offset_writer_test.go
+++ b/car/car_offset_writer_test.go
@@ -37,7 +37,7 @@ func TestCarOffsetWriter(t *testing.T) {
 	// Write the CAR to a buffer from offset 0 so the buffer can be used for
 	// comparison
 	payloadCid := nd.Cid()
-	fullCarCow := NewCarOffsetWriter(payloadCid, bs)
+	fullCarCow := NewCarOffsetWriter(payloadCid, bs, NewBlockInfoCache())
 	var fullBuff bytes.Buffer
 	err = fullCarCow.Write(context.Background(), &fullBuff, 0)
 	require.NoError(t, err)
@@ -81,13 +81,13 @@ func TestCarOffsetWriter(t *testing.T) {
 
 	// Run tests with a new CarOffsetWriter
 	runTestCases("new car offset writer", func() *CarOffsetWriter {
-		return NewCarOffsetWriter(payloadCid, bs)
+		return NewCarOffsetWriter(payloadCid, bs, NewBlockInfoCache())
 	})
 
 	// Run tests with a CarOffsetWriter that has already been used to write
 	// a CAR starting at offset 0
 	runTestCases("fully written car offset writer", func() *CarOffsetWriter {
-		fullCarCow := NewCarOffsetWriter(payloadCid, bs)
+		fullCarCow := NewCarOffsetWriter(payloadCid, bs, NewBlockInfoCache())
 		var buff bytes.Buffer
 		err = fullCarCow.Write(context.Background(), &buff, 0)
 		require.NoError(t, err)
@@ -97,7 +97,7 @@ func TestCarOffsetWriter(t *testing.T) {
 	// Run tests with a CarOffsetWriter that has already been used to write
 	// a CAR starting at offset 1
 	runTestCases("car offset writer written from offset 1", func() *CarOffsetWriter {
-		fullCarCow := NewCarOffsetWriter(payloadCid, bs)
+		fullCarCow := NewCarOffsetWriter(payloadCid, bs, NewBlockInfoCache())
 		var buff bytes.Buffer
 		err = fullCarCow.Write(context.Background(), &buff, 1)
 		require.NoError(t, err)
@@ -107,7 +107,7 @@ func TestCarOffsetWriter(t *testing.T) {
 	// Run tests with a CarOffsetWriter that has already been used to write
 	// a CAR starting part way through the second block
 	runTestCases("car offset writer written from offset 1.5 blocks", func() *CarOffsetWriter {
-		fullCarCow := NewCarOffsetWriter(payloadCid, bs)
+		fullCarCow := NewCarOffsetWriter(payloadCid, bs, NewBlockInfoCache())
 		var buff bytes.Buffer
 		err = fullCarCow.Write(context.Background(), &buff, 1024*1024+512*1024)
 		require.NoError(t, err)
@@ -117,15 +117,13 @@ func TestCarOffsetWriter(t *testing.T) {
 	// Run tests with a CarOffsetWriter that has already been used to write
 	// a CAR repeatedly
 	runTestCases("car offset writer written from offset repeatedly", func() *CarOffsetWriter {
-		fullCarCow := NewCarOffsetWriter(payloadCid, bs)
+		fullCarCow := NewCarOffsetWriter(payloadCid, bs, NewBlockInfoCache())
 		var buff bytes.Buffer
 		err = fullCarCow.Write(context.Background(), &buff, 1024)
 		require.NoError(t, err)
-		fullCarCow = NewCarOffsetWriter(payloadCid, bs)
 		var buff2 bytes.Buffer
 		err = fullCarCow.Write(context.Background(), &buff2, 10)
 		require.NoError(t, err)
-		fullCarCow = NewCarOffsetWriter(payloadCid, bs)
 		var buff3 bytes.Buffer
 		err = fullCarCow.Write(context.Background(), &buff3, 1024*1024+512*1024)
 		require.NoError(t, err)

--- a/car/car_offset_writer_test.go
+++ b/car/car_offset_writer_test.go
@@ -1,0 +1,207 @@
+package car
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"math/rand"
+	"testing"
+
+	"github.com/ipfs/go-blockservice"
+	"github.com/ipfs/go-cidutil"
+	"github.com/ipfs/go-datastore"
+	dss "github.com/ipfs/go-datastore/sync"
+	bstore "github.com/ipfs/go-ipfs-blockstore"
+	chunk "github.com/ipfs/go-ipfs-chunker"
+	format "github.com/ipfs/go-ipld-format"
+	"github.com/ipfs/go-merkledag"
+	"github.com/ipfs/go-unixfs/importer/balanced"
+	"github.com/ipfs/go-unixfs/importer/helpers"
+	"github.com/ipld/go-car"
+	mh "github.com/multiformats/go-multihash"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCarOffsetWriter(t *testing.T) {
+	ds := dss.MutexWrap(datastore.NewMapDatastore())
+	bs := bstore.NewBlockstore(ds)
+	bserv := blockservice.New(bs, nil)
+	dserv := merkledag.NewDAGService(bserv)
+
+	rseed := 5
+	size := 2 * 1024 * 1024
+	source := io.LimitReader(rand.New(rand.NewSource(int64(rseed))), int64(size))
+	nd, err := DAGImport(dserv, source)
+	require.NoError(t, err)
+
+	// Write the CAR to a buffer from offset 0 so the buffer can be used for
+	// comparison
+	payloadCid := nd.Cid()
+	fullCarCow := NewCarOffsetWriter(payloadCid, bs)
+	var fullBuff bytes.Buffer
+	err = fullCarCow.Write(context.Background(), &fullBuff, 0)
+	require.NoError(t, err)
+
+	fullCar := fullBuff.Bytes()
+	header := carHeader(nd.Cid())
+	headerSize, err := car.HeaderSize(&header)
+
+	testCases := []struct {
+		name   string
+		offset uint64
+	}{{
+		name:   "1 byte offset",
+		offset: 1,
+	}, {
+		name:   "offset < header size",
+		offset: headerSize - 1,
+	}, {
+		name:   "offset == header size",
+		offset: headerSize,
+	}, {
+		name:   "offset > header size",
+		offset: headerSize + 1,
+	}, {
+		name:   "offset > header + one block size",
+		offset: headerSize + 1024*1024 + 512*1024,
+	}}
+
+	runTestCases := func(name string, runTCWithCow func() *CarOffsetWriter) {
+		for _, tc := range testCases {
+			t.Run(name+" - "+tc.name, func(t *testing.T) {
+				cow := runTCWithCow()
+				var buff bytes.Buffer
+				err = cow.Write(context.Background(), &buff, tc.offset)
+				require.NoError(t, err)
+				require.Equal(t, len(fullCar)-int(tc.offset), len(buff.Bytes()))
+				require.Equal(t, fullCar[tc.offset:], buff.Bytes())
+			})
+		}
+	}
+
+	// Run tests with a new CarOffsetWriter
+	runTestCases("new car offset writer", func() *CarOffsetWriter {
+		return NewCarOffsetWriter(payloadCid, bs)
+	})
+
+	// Run tests with a CarOffsetWriter that has already been used to write
+	// a CAR starting at offset 0
+	runTestCases("fully written car offset writer", func() *CarOffsetWriter {
+		fullCarCow := NewCarOffsetWriter(payloadCid, bs)
+		var buff bytes.Buffer
+		err = fullCarCow.Write(context.Background(), &buff, 0)
+		require.NoError(t, err)
+		return fullCarCow
+	})
+
+	// Run tests with a CarOffsetWriter that has already been used to write
+	// a CAR starting at offset 1
+	runTestCases("car offset writer written from offset 1", func() *CarOffsetWriter {
+		fullCarCow := NewCarOffsetWriter(payloadCid, bs)
+		var buff bytes.Buffer
+		err = fullCarCow.Write(context.Background(), &buff, 1)
+		require.NoError(t, err)
+		return fullCarCow
+	})
+
+	// Run tests with a CarOffsetWriter that has already been used to write
+	// a CAR starting part way through the second block
+	runTestCases("car offset writer written from offset 1.5 blocks", func() *CarOffsetWriter {
+		fullCarCow := NewCarOffsetWriter(payloadCid, bs)
+		var buff bytes.Buffer
+		err = fullCarCow.Write(context.Background(), &buff, 1024*1024+512*1024)
+		require.NoError(t, err)
+		return fullCarCow
+	})
+
+	// Run tests with a CarOffsetWriter that has already been used to write
+	// a CAR repeatedly
+	runTestCases("car offset writer written from offset repeatedly", func() *CarOffsetWriter {
+		fullCarCow := NewCarOffsetWriter(payloadCid, bs)
+		var buff bytes.Buffer
+		err = fullCarCow.Write(context.Background(), &buff, 1024)
+		require.NoError(t, err)
+		fullCarCow = NewCarOffsetWriter(payloadCid, bs)
+		var buff2 bytes.Buffer
+		err = fullCarCow.Write(context.Background(), &buff2, 10)
+		require.NoError(t, err)
+		fullCarCow = NewCarOffsetWriter(payloadCid, bs)
+		var buff3 bytes.Buffer
+		err = fullCarCow.Write(context.Background(), &buff3, 1024*1024+512*1024)
+		require.NoError(t, err)
+		return fullCarCow
+	})
+}
+
+func TestSkipWriter(t *testing.T) {
+	testCases := []struct {
+		name     string
+		size     int
+		skip     int
+		expected int
+	}{{
+		name:     "no skip",
+		size:     1024,
+		skip:     0,
+		expected: 1024,
+	}, {
+		name:     "skip 1",
+		size:     1024,
+		skip:     1,
+		expected: 1023,
+	}, {
+		name:     "skip all",
+		size:     1024,
+		skip:     1024,
+		expected: 0,
+	}, {
+		name:     "skip overflow",
+		size:     1024,
+		skip:     1025,
+		expected: 0,
+	}}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buff bytes.Buffer
+			write := func(sw io.Writer) (int, error) {
+				bz := make([]byte, tc.size)
+				return sw.Write(bz)
+			}
+			count, err := skipWrite(&buff, uint64(tc.skip), write)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, count)
+			require.Equal(t, tc.expected, len(buff.Bytes()))
+		})
+	}
+}
+
+var DefaultHashFunction = uint64(mh.SHA2_256)
+
+func DAGImport(dserv format.DAGService, fi io.Reader) (format.Node, error) {
+	prefix, err := merkledag.PrefixForCidVersion(1)
+	if err != nil {
+		return nil, err
+	}
+	prefix.MhType = DefaultHashFunction
+
+	spl := chunk.NewSizeSplitter(fi, 1024*1024)
+	dbp := helpers.DagBuilderParams{
+		Maxlinks:  1024,
+		RawLeaves: true,
+
+		CidBuilder: cidutil.InlineBuilder{
+			Builder: prefix,
+			Limit:   32,
+		},
+
+		Dagserv: dserv,
+	}
+
+	db, err := dbp.New(spl)
+	if err != nil {
+		return nil, err
+	}
+
+	return balanced.Layout(db)
+}

--- a/car/car_reader_seeker.go
+++ b/car/car_reader_seeker.go
@@ -1,0 +1,128 @@
+package car
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sync"
+
+	"golang.org/x/xerrors"
+)
+
+// CarReaderSeeker wraps CarOffsetWriter with a ReadSeeker implementation.
+type CarReaderSeeker struct {
+	parentCtx context.Context
+	size      uint64
+	offset    int64
+	cow       *CarOffsetWriter // 🐮
+
+	lk            sync.Mutex
+	reader        *io.PipeReader
+	writer        *io.PipeWriter
+	writeCancel   context.CancelFunc
+	writeComplete chan struct{}
+}
+
+var _ io.ReadSeekCloser = (*CarReaderSeeker)(nil)
+
+func NewCarReaderSeeker(ctx context.Context, cow *CarOffsetWriter, size uint64) *CarReaderSeeker {
+	return &CarReaderSeeker{
+		parentCtx:     ctx,
+		size:          size,
+		cow:           cow,
+		writeComplete: make(chan struct{}, 1),
+	}
+}
+
+func (c *CarReaderSeeker) Read(p []byte) (n int, err error) {
+	c.lk.Lock()
+	defer c.lk.Unlock()
+
+	if uint64(c.offset) >= c.size {
+		return 0, fmt.Errorf("cannot read from offset %d >= file size %d", c.offset, c.size)
+	}
+
+	// Check if there's already a write in progress
+	if c.reader == nil {
+		// No write in progress, start a new write from the current offset
+		// in a go routine
+		writeCtx, writeCancel := context.WithCancel(c.parentCtx)
+		c.writeCancel = writeCancel
+		pr, pw := io.Pipe()
+		c.reader = pr
+		c.writer = pw
+
+		go func() {
+			err := c.cow.Write(writeCtx, pw, uint64(c.offset))
+			if err != nil && !xerrors.Is(err, context.Canceled) {
+				pw.CloseWithError(err)
+			} else {
+				pw.Close()
+			}
+			c.writeComplete <- struct{}{}
+		}()
+	}
+
+	return c.reader.Read(p)
+}
+
+func (c *CarReaderSeeker) Seek(offset int64, whence int) (int64, error) {
+	c.lk.Lock()
+	defer c.lk.Unlock()
+
+	// Update the offset
+	switch whence {
+	case io.SeekStart:
+		if offset < 0 {
+			return 0, fmt.Errorf("invalid offset %d from start: must be positive", offset)
+		}
+		c.offset = offset
+	case io.SeekCurrent:
+		if c.offset+offset < 0 {
+			return 0, fmt.Errorf("invalid offset %d from current %d: resulting offset is negative", offset, c.offset)
+		}
+		c.offset += offset
+	case io.SeekEnd:
+		if int64(c.size)+offset < 0 {
+			return 0, fmt.Errorf("invalid offset %d from end: larger than total size %d", offset, c.size)
+		}
+		c.offset = int64(c.size) + offset
+	}
+
+	// Cancel any ongoing write and wait for it to complete
+	if c.reader != nil {
+		c.writeCancel()
+
+		c.reader.Close()
+
+		select {
+		case <-c.parentCtx.Done():
+			return 0, c.parentCtx.Err()
+		case <-c.writeComplete:
+		}
+
+		c.reader = nil
+	}
+
+	return c.offset, nil
+}
+
+func (c *CarReaderSeeker) Close() error {
+	c.lk.Lock()
+	defer c.lk.Unlock()
+
+	if c.writer != nil {
+		return c.writer.Close()
+	}
+	return nil
+}
+
+func (c *CarReaderSeeker) CloseWithError(err error) error {
+	c.lk.Lock()
+	defer c.lk.Unlock()
+
+	if c.writer != nil {
+		return c.writer.CloseWithError(err)
+	}
+	return nil
+}

--- a/car/car_reader_seeker.go
+++ b/car/car_reader_seeker.go
@@ -55,7 +55,7 @@ func (c *CarReaderSeeker) Read(p []byte) (n int, err error) {
 		go func() {
 			err := c.cow.Write(writeCtx, pw, uint64(c.offset))
 			if err != nil && !xerrors.Is(err, context.Canceled) {
-				pw.CloseWithError(err)
+				pw.CloseWithError(err) //nolint:errcheck
 			} else {
 				pw.Close()
 			}

--- a/car/car_reader_seeker.go
+++ b/car/car_reader_seeker.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"io"
 	"sync"
-
-	"golang.org/x/xerrors"
 )
 
 // CarReaderSeeker wraps CarOffsetWriter with a ReadSeeker implementation.
@@ -54,10 +52,10 @@ func (c *CarReaderSeeker) Read(p []byte) (n int, err error) {
 
 		go func() {
 			err := c.cow.Write(writeCtx, pw, uint64(c.offset))
-			if err != nil && !xerrors.Is(err, context.Canceled) {
+			if err != nil {
 				pw.CloseWithError(err) //nolint:errcheck
 			} else {
-				pw.Close()
+				pw.Close() //nolint:errcheck
 			}
 			c.writeComplete <- struct{}{}
 		}()
@@ -93,7 +91,7 @@ func (c *CarReaderSeeker) Seek(offset int64, whence int) (int64, error) {
 	if c.reader != nil {
 		c.writeCancel()
 
-		c.reader.Close()
+		c.reader.Close() //nolint:errcheck
 
 		select {
 		case <-c.parentCtx.Done():

--- a/car/car_reader_seeker_test.go
+++ b/car/car_reader_seeker_test.go
@@ -1,0 +1,177 @@
+package car
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"math/rand"
+	"testing"
+
+	"github.com/ipfs/go-blockservice"
+	"github.com/ipfs/go-datastore"
+	dss "github.com/ipfs/go-datastore/sync"
+	bstore "github.com/ipfs/go-ipfs-blockstore"
+	"github.com/ipfs/go-merkledag"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCarReaderSeeker(t *testing.T) {
+	ctx := context.Background()
+
+	ds := dss.MutexWrap(datastore.NewMapDatastore())
+	bs := bstore.NewBlockstore(ds)
+	bserv := blockservice.New(bs, nil)
+	dserv := merkledag.NewDAGService(bserv)
+
+	rseed := 5
+	size := 2 * 1024 * 1024
+	source := io.LimitReader(rand.New(rand.NewSource(int64(rseed))), int64(size))
+	nd, err := DAGImport(dserv, source)
+	require.NoError(t, err)
+
+	// Write the CAR to a buffer so it can be used for comparisons
+	fullCarCow := NewCarOffsetWriter(nd.Cid(), bs)
+	var fullBuff bytes.Buffer
+	err = fullCarCow.Write(context.Background(), &fullBuff, 0)
+	require.NoError(t, err)
+	carSize := fullBuff.Len()
+
+	readTestCases := []struct {
+		name   string
+		offset int64
+	}{{
+		name:   "read all from start",
+		offset: 0,
+	}, {
+		name:   "read all from byte 1",
+		offset: 1,
+	}, {
+		name:   "read all from middle",
+		offset: int64(carSize / 2),
+	}, {
+		name:   "read all from end - 1",
+		offset: int64(carSize - 1),
+	}}
+
+	for _, tc := range readTestCases {
+		t.Run(tc.name, func(t *testing.T) {
+			crs := NewCarReaderSeeker(ctx, nd.Cid(), bs, uint64(carSize))
+			if tc.offset > 0 {
+				_, err := crs.Seek(tc.offset, io.SeekStart)
+				require.NoError(t, err)
+			}
+			buff, err := io.ReadAll(crs)
+			require.NoError(t, err)
+			require.Equal(t, carSize-int(tc.offset), len(buff))
+			require.Equal(t, fullBuff.Bytes()[tc.offset:], buff)
+		})
+	}
+
+	seekTestCases := []struct {
+		name          string
+		whence        int
+		offset        int64
+		expectSeekErr bool
+		expectReadErr bool
+		expectOffset  int64
+	}{{
+		name:         "start +0",
+		whence:       io.SeekStart,
+		offset:       0,
+		expectOffset: 0,
+	}, {
+		name:          "start -1",
+		whence:        io.SeekStart,
+		offset:        -1,
+		expectSeekErr: true,
+	}, {
+		name:          "start +full size",
+		whence:        io.SeekStart,
+		offset:        int64(carSize),
+		expectOffset:  int64(carSize),
+		expectReadErr: true,
+	}, {
+		name:         "current +0",
+		whence:       io.SeekCurrent,
+		offset:       0,
+		expectOffset: 0,
+	}, {
+		name:         "current +10",
+		whence:       io.SeekCurrent,
+		offset:       10,
+		expectOffset: 10,
+	}, {
+		name:          "current -1",
+		whence:        io.SeekCurrent,
+		offset:        -1,
+		expectSeekErr: true,
+	}, {
+		name:          "current +full size",
+		whence:        io.SeekCurrent,
+		offset:        int64(carSize),
+		expectOffset:  int64(carSize),
+		expectReadErr: true,
+	}, {
+		name:          "end +0",
+		whence:        io.SeekEnd,
+		offset:        0,
+		expectOffset:  int64(carSize),
+		expectReadErr: true,
+	}, {
+		name:         "end -10",
+		whence:       io.SeekEnd,
+		offset:       -10,
+		expectOffset: int64(carSize) - 10,
+	}, {
+		name:          "end +1",
+		whence:        io.SeekEnd,
+		offset:        1,
+		expectOffset:  int64(carSize) + 1,
+		expectReadErr: true,
+	}, {
+		name:          "end -(full size+1)",
+		whence:        io.SeekEnd,
+		offset:        int64(-(carSize + 1)),
+		expectSeekErr: true,
+	}}
+
+	for _, tc := range seekTestCases {
+		t.Run(tc.name, func(t *testing.T) {
+			crs := NewCarReaderSeeker(ctx, nd.Cid(), bs, uint64(carSize))
+			newOffset, err := crs.Seek(tc.offset, tc.whence)
+			if tc.expectSeekErr {
+				require.Error(t, err)
+				return
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tc.expectOffset, newOffset)
+
+			buff, err := io.ReadAll(crs)
+			if tc.expectReadErr {
+				require.Error(t, err)
+				return
+			} else {
+				require.NoError(t, err)
+			}
+
+			require.Equal(t, carSize-int(tc.expectOffset), len(buff))
+			require.Equal(t, fullBuff.Bytes()[tc.expectOffset:], buff)
+		})
+	}
+
+	t.Run("double seek", func(t *testing.T) {
+		crs := NewCarReaderSeeker(ctx, nd.Cid(), bs, uint64(carSize))
+		_, err := crs.Seek(10, io.SeekStart)
+		require.NoError(t, err)
+		newOffset, err := crs.Seek(-5, io.SeekCurrent)
+		require.NoError(t, err)
+		require.EqualValues(t, 5, newOffset)
+
+		buff, err := io.ReadAll(crs)
+		require.NoError(t, err)
+
+		require.Equal(t, carSize-5, len(buff))
+		require.Equal(t, fullBuff.Bytes()[5:], buff)
+	})
+}

--- a/car/car_reader_seeker_test.go
+++ b/car/car_reader_seeker_test.go
@@ -30,7 +30,7 @@ func TestCarReaderSeeker(t *testing.T) {
 	require.NoError(t, err)
 
 	// Write the CAR to a buffer so it can be used for comparisons
-	fullCarCow := NewCarOffsetWriter(nd.Cid(), bs)
+	fullCarCow := NewCarOffsetWriter(nd.Cid(), bs, NewBlockInfoCache())
 	var fullBuff bytes.Buffer
 	err = fullCarCow.Write(context.Background(), &fullBuff, 0)
 	require.NoError(t, err)
@@ -55,7 +55,8 @@ func TestCarReaderSeeker(t *testing.T) {
 
 	for _, tc := range readTestCases {
 		t.Run(tc.name, func(t *testing.T) {
-			crs := NewCarReaderSeeker(ctx, nd.Cid(), bs, uint64(carSize))
+			cow := NewCarOffsetWriter(nd.Cid(), bs, NewBlockInfoCache())
+			crs := NewCarReaderSeeker(ctx, cow, uint64(carSize))
 			if tc.offset > 0 {
 				_, err := crs.Seek(tc.offset, io.SeekStart)
 				require.NoError(t, err)
@@ -137,7 +138,8 @@ func TestCarReaderSeeker(t *testing.T) {
 
 	for _, tc := range seekTestCases {
 		t.Run(tc.name, func(t *testing.T) {
-			crs := NewCarReaderSeeker(ctx, nd.Cid(), bs, uint64(carSize))
+			cow := NewCarOffsetWriter(nd.Cid(), bs, NewBlockInfoCache())
+			crs := NewCarReaderSeeker(ctx, cow, uint64(carSize))
 			newOffset, err := crs.Seek(tc.offset, tc.whence)
 			if tc.expectSeekErr {
 				require.Error(t, err)
@@ -161,7 +163,8 @@ func TestCarReaderSeeker(t *testing.T) {
 	}
 
 	t.Run("double seek", func(t *testing.T) {
-		crs := NewCarReaderSeeker(ctx, nd.Cid(), bs, uint64(carSize))
+		cow := NewCarOffsetWriter(nd.Cid(), bs, NewBlockInfoCache())
+		crs := NewCarReaderSeeker(ctx, cow, uint64(carSize))
 		_, err := crs.Seek(10, io.SeekStart)
 		require.NoError(t, err)
 		newOffset, err := crs.Seek(-5, io.SeekCurrent)

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/ipfs/go-ipfs-routing v0.2.1
 	github.com/ipfs/go-log/v2 v2.4.0
 	github.com/ipfs/go-metrics-interface v0.0.1
-	github.com/ipld/go-car/v2 v2.1.1
+	github.com/ipld/go-car/v2 v2.1.2-0.20220124154420-9c7956a6eb9d
 	github.com/ipld/go-ipld-selector-text-lite v0.0.1
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/libp2p/go-eventbus v0.2.1
@@ -96,11 +96,13 @@ require (
 	github.com/ipfs/go-ipfs-files v0.0.9
 	github.com/ipfs/go-ipld-format v0.2.0
 	github.com/ipfs/go-merkledag v0.5.1
-	github.com/ipfs/go-unixfs v0.2.6
+	github.com/ipfs/go-unixfs v0.3.1
+	github.com/ipld/go-car v0.3.4-0.20220124154420-9c7956a6eb9d
 	github.com/jbenet/go-random v0.0.0-20190219211222-123a90aedc0c
 	github.com/jpillora/backoff v1.0.0
-	github.com/libp2p/go-libp2p-gostream v0.3.0
+	github.com/libp2p/go-libp2p-gostream v0.3.1
 	github.com/libp2p/go-libp2p-http v0.2.1
+	github.com/multiformats/go-multiaddr-fmt v0.1.0
 	github.com/multiformats/go-multihash v0.1.0
 	github.com/whyrusleeping/cbor-gen v0.0.0-20211110122933-f57984553008
 	go.uber.org/atomic v1.9.0

--- a/go.mod
+++ b/go.mod
@@ -102,7 +102,6 @@ require (
 	github.com/jpillora/backoff v1.0.0
 	github.com/libp2p/go-libp2p-gostream v0.3.1
 	github.com/libp2p/go-libp2p-http v0.2.1
-	github.com/multiformats/go-multiaddr-fmt v0.1.0
 	github.com/multiformats/go-multihash v0.1.0
 	github.com/whyrusleeping/cbor-gen v0.0.0-20211110122933-f57984553008
 	go.uber.org/atomic v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -75,7 +75,6 @@ github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWX
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/StackExchange/wmi v1.2.1 h1:VIkavFPXSjcnS+O8yTq7NI32k0R5Aj+v39y29VYDOSA=
 github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
-github.com/Stebalien/go-bitfield v0.0.1 h1:X3kbSSPUaJK60wV2hjOPZwmpljr6VGCqdq4cBLhbQBo=
 github.com/Stebalien/go-bitfield v0.0.1/go.mod h1:GNjFpasyUVkHMsfEOk8EFLJ9syQ6SI+XWrX9Wf2XH0s=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=
@@ -91,6 +90,8 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
+github.com/alecthomas/units v0.0.0-20210927113745-59d0afb8317a h1:E/8AP5dFtMhl5KPJz66Kt9G0n+7Sn41Fy1wv9/jHOrc=
+github.com/alecthomas/units v0.0.0-20210927113745-59d0afb8317a/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
@@ -642,6 +643,8 @@ github.com/influxdata/influxdb1-client v0.0.0-20200827194710-b269163b24ab/go.mod
 github.com/ipfs/bbloom v0.0.1/go.mod h1:oqo8CVWsJFMOZqTglBG4wydCE4IQA/G2/SEofB0rjUI=
 github.com/ipfs/bbloom v0.0.4 h1:Gi+8EGJ2y5qiD5FbsbpX/TMNcJw8gSqr7eyjHa4Fhvs=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
+github.com/ipfs/go-bitfield v1.0.0 h1:y/XHm2GEmD9wKngheWNNCNL0pzrWXZwCdQGv1ikXknQ=
+github.com/ipfs/go-bitfield v1.0.0/go.mod h1:N/UiujQy+K+ceU1EF5EkVd1TNqevLrCQMIcAEPrdtus=
 github.com/ipfs/go-bitswap v0.0.9/go.mod h1:kAPf5qgn2W2DrgAcscZ3HrM9qh4pH+X8Fkk3UPrwvis=
 github.com/ipfs/go-bitswap v0.1.0/go.mod h1:FFJEf18E9izuCqUtHxbWEvq+reg7o4CW5wSAE1wsxj0=
 github.com/ipfs/go-bitswap v0.1.2/go.mod h1:qxSWS4NXGs7jQ6zQvoPY3+NmOfHHG47mhkiLzBpJQIs=
@@ -809,8 +812,9 @@ github.com/ipfs/go-peertaskqueue v0.7.0/go.mod h1:M/akTIE/z1jGNXMU7kFB4TeSEFvj68
 github.com/ipfs/go-todocounter v0.0.1/go.mod h1:l5aErvQc8qKE2r7NDMjmq5UNAvuZy0rC8BHOplkWvZ4=
 github.com/ipfs/go-unixfs v0.2.2-0.20190827150610-868af2e9e5cb/go.mod h1:IwAAgul1UQIcNZzKPYZWOCijryFBeCV79cNubPzol+k=
 github.com/ipfs/go-unixfs v0.2.4/go.mod h1:SUdisfUjNoSDzzhGVxvCL9QO/nKdwXdr+gbMUdqcbYw=
-github.com/ipfs/go-unixfs v0.2.6 h1:gq3U3T2vh8x6tXhfo3uSO3n+2z4yW0tYtNgVP/3sIyA=
 github.com/ipfs/go-unixfs v0.2.6/go.mod h1:GTTzQvaZsTZARdNkkdjDKFFnBhmO3e5mIM1PkH/x4p0=
+github.com/ipfs/go-unixfs v0.3.1 h1:LrfED0OGfG98ZEegO4/xiprx2O+yS+krCMQSp7zLVv8=
+github.com/ipfs/go-unixfs v0.3.1/go.mod h1:h4qfQYzghiIc8ZNFKiLMFWOTzrWIAtzYQ59W/pCFf1o=
 github.com/ipfs/go-verifcid v0.0.1 h1:m2HI7zIuR5TFyQ1b79Da5N9dnnCP1vcu2QqawmWlK2E=
 github.com/ipfs/go-verifcid v0.0.1/go.mod h1:5Hrva5KBeIog4A+UpqlaIU+DEstipcJYQQZc0g37pY0=
 github.com/ipfs/interface-go-ipfs-core v0.4.0 h1:+mUiamyHIwedqP8ZgbCIwpy40oX7QcXUbo4CZOeJVJg=
@@ -821,11 +825,13 @@ github.com/ipfs/iptb-plugins v0.3.0 h1:C1rpq1o5lUZtaAOkLIox5akh6ba4uk/3RwWc6ttVx
 github.com/ipfs/iptb-plugins v0.3.0/go.mod h1:5QtOvckeIw4bY86gSH4fgh3p3gCSMn3FmIKr4gaBncA=
 github.com/ipld/go-car v0.1.0/go.mod h1:RCWzaUh2i4mOEkB3W45Vc+9jnS/M6Qay5ooytiBHl3g=
 github.com/ipld/go-car v0.3.3-0.20211210032800-e6f244225a16/go.mod h1:/wkKF4908ULT4dFIFIUZYcfjAnj+KFnJvlh8Hsz1FbQ=
-github.com/ipld/go-car v0.3.3 h1:D6y+jvg9h2ZSv7GLUMWUwg5VTLy1E7Ak+uQw5orOg3I=
 github.com/ipld/go-car v0.3.3/go.mod h1:/wkKF4908ULT4dFIFIUZYcfjAnj+KFnJvlh8Hsz1FbQ=
+github.com/ipld/go-car v0.3.4-0.20220124154420-9c7956a6eb9d h1:IeWTbMLUHcmPnaXbuUtpE07WXmodz2oYZ+IM+jE1eN8=
+github.com/ipld/go-car v0.3.4-0.20220124154420-9c7956a6eb9d/go.mod h1:/wkKF4908ULT4dFIFIUZYcfjAnj+KFnJvlh8Hsz1FbQ=
 github.com/ipld/go-car/v2 v2.1.1-0.20211211000942-be2525f6bf2d/go.mod h1:+2Yvf0Z3wzkv7NeI69i8tuZ+ft7jyjPYIWZzeVNeFcI=
-github.com/ipld/go-car/v2 v2.1.1 h1:saaKz4nC0AdfCGHLYKeXLGn8ivoPC54fyS55uyOLKwA=
 github.com/ipld/go-car/v2 v2.1.1/go.mod h1:+2Yvf0Z3wzkv7NeI69i8tuZ+ft7jyjPYIWZzeVNeFcI=
+github.com/ipld/go-car/v2 v2.1.2-0.20220124154420-9c7956a6eb9d h1:ZS+tQRulViCXtszhLwNZv44569uCjGiYlmR8Ks/tRBA=
+github.com/ipld/go-car/v2 v2.1.2-0.20220124154420-9c7956a6eb9d/go.mod h1:5GmkU4R/nVUC/V/i2Ucl5iqa9373jZ3lqmvAKZnz4Vo=
 github.com/ipld/go-codec-dagpb v1.2.0/go.mod h1:6nBN7X7h8EOsEejZGqC7tej5drsdBAXbMHyBT+Fne5s=
 github.com/ipld/go-codec-dagpb v1.3.0 h1:czTcaoAuNNyIYWs6Qe01DJ+sEX7B+1Z0LcXjSatMGe8=
 github.com/ipld/go-codec-dagpb v1.3.0/go.mod h1:ga4JTU3abYApDC3pZ00BC2RSvC3qfBb9MSJkMLSwnhA=
@@ -1054,8 +1060,9 @@ github.com/libp2p/go-libp2p-discovery v0.3.0/go.mod h1:o03drFnz9BVAZdzC/QUQ+NeQO
 github.com/libp2p/go-libp2p-discovery v0.5.0/go.mod h1:+srtPIU9gDaBNu//UHvcdliKBIcr4SfDcm0/PfPJLug=
 github.com/libp2p/go-libp2p-discovery v0.6.0 h1:1XdPmhMJr8Tmj/yUfkJMIi8mgwWrLUsCB3bMxdT+DSo=
 github.com/libp2p/go-libp2p-discovery v0.6.0/go.mod h1:/u1voHt0tKIe5oIA1RHBKQLVCWPna2dXmPNHc2zR9S8=
-github.com/libp2p/go-libp2p-gostream v0.3.0 h1:rnas//vRdHYCr7bjraZJISPwZV8OGMjeX5k5fN5Ax44=
 github.com/libp2p/go-libp2p-gostream v0.3.0/go.mod h1:pLBQu8db7vBMNINGsAwLL/ZCE8wng5V1FThoaE5rNjc=
+github.com/libp2p/go-libp2p-gostream v0.3.1 h1:XlwohsPn6uopGluEWs1Csv1QCEjrTXf2ZQagzZ5paAg=
+github.com/libp2p/go-libp2p-gostream v0.3.1/go.mod h1:1V3b+u4Zhaq407UUY9JLCpboaeufAeVQbnvAt12LRsI=
 github.com/libp2p/go-libp2p-host v0.0.1/go.mod h1:qWd+H1yuU0m5CwzAkvbSjqKairayEHdR5MMl7Cwa7Go=
 github.com/libp2p/go-libp2p-host v0.0.3/go.mod h1:Y/qPyA6C8j2coYyos1dfRm0I8+nvd4TGrDGt4tA7JR8=
 github.com/libp2p/go-libp2p-http v0.2.1 h1:h8kuv7ExPe0nDtWAexKQWbjnXqks1hwOdYLs84gMCpo=

--- a/transport/httptransport/auth.go
+++ b/transport/httptransport/auth.go
@@ -1,0 +1,21 @@
+package httptransport
+
+import "encoding/base64"
+
+func BasicAuthHeader(username, password string) string {
+	return "Basic " + BasicAuth(username, password)
+}
+
+//
+// Copied from
+// https://github.com/golang/go/blob/16d6a5233a183be7264295c66167d35c689f9372/src/net/http/client.go#L413-L421
+//
+// See 2 (end of page 4) https://www.ietf.org/rfc/rfc2617.txt
+// "To receive authorization, the client sends the userid and password,
+// separated by a single colon (":") character, within a base64
+// encoded string in the credentials."
+// It is not meant to be urlencoded.
+func BasicAuth(username, password string) string {
+	auth := username + ":" + password
+	return base64.StdEncoding.EncodeToString([]byte(auth))
+}

--- a/transport/httptransport/auth_token_db.go
+++ b/transport/httptransport/auth_token_db.go
@@ -1,0 +1,62 @@
+package httptransport
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/ipfs/go-datastore"
+	"github.com/ipfs/go-datastore/namespace"
+	"golang.org/x/xerrors"
+)
+
+// ErrTokenNotFound is returned when an auth token is not found in the database
+var ErrTokenNotFound = fmt.Errorf("auth token not found")
+
+// AuthTokenDB keeps a database of auth tokens with associated data
+type AuthTokenDB struct {
+	ds datastore.Batching
+}
+
+func NewAuthTokenDB(ds datastore.Batching) *AuthTokenDB {
+	return &AuthTokenDB{
+		ds: namespace.Wrap(ds, datastore.NewKey("/auth-token")),
+	}
+}
+
+// Put adds some data to the DB and returns an auth token
+func (db *AuthTokenDB) Put(ctx context.Context, data []byte) (authtok string, e error) {
+	// Create a new auth token and add it to the datastore
+	authTokenBuff := make([]byte, 1024)
+	if _, err := rand.Read(authTokenBuff); err != nil {
+		return "", fmt.Errorf("generating auth token: %w", err)
+	}
+	authToken := hex.EncodeToString(authTokenBuff)
+
+	authTokenKey := datastore.NewKey(authToken)
+	err := db.ds.Put(ctx, authTokenKey, data)
+	if err != nil {
+		return "", fmt.Errorf("adding auth token to datastore: %w", err)
+	}
+
+	return authToken, nil
+}
+
+// Get data by auth token
+func (db *AuthTokenDB) Get(ctx context.Context, authToken string) ([]byte, error) {
+	data, err := db.ds.Get(ctx, datastore.NewKey(authToken))
+	if err != nil {
+		if xerrors.Is(err, datastore.ErrNotFound) {
+			return nil, ErrTokenNotFound
+		}
+		return nil, err
+	}
+
+	return data, err
+}
+
+// Delete data by auth token
+func (db *AuthTokenDB) Delete(ctx context.Context, authToken string) error {
+	return db.ds.Delete(ctx, datastore.NewKey(authToken))
+}

--- a/transport/httptransport/auth_token_db_test.go
+++ b/transport/httptransport/auth_token_db_test.go
@@ -1,0 +1,43 @@
+package httptransport
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ipfs/go-datastore"
+	dssync "github.com/ipfs/go-datastore/sync"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewAuthTokenDB(t *testing.T) {
+	ctx := context.Background()
+	rqr := require.New(t)
+
+	// Create auth DB
+	ds := dssync.MutexWrap(datastore.NewMapDatastore())
+	db := NewAuthTokenDB(ds)
+
+	// Expect ErrTokenNotFound when getting a non-existent token
+	_, err := db.Get(ctx, "doesnt-exist")
+	rqr.Error(err)
+	rqr.ErrorIs(err, ErrTokenNotFound)
+
+	// Put some data into the DB
+	data := []byte("data")
+	authToken, err := db.Put(ctx, data)
+	rqr.NoError(err)
+
+	// Get the data back
+	got, err := db.Get(ctx, authToken)
+	rqr.NoError(err)
+	rqr.Equal(data, got)
+
+	// Delete the data by auth token
+	err = db.Delete(ctx, authToken)
+	rqr.NoError(err)
+
+	// Get by auth token should now return ErrTokenNotFound
+	_, err = db.Get(ctx, authToken)
+	rqr.Error(err)
+	rqr.ErrorIs(err, ErrTokenNotFound)
+}

--- a/transport/httptransport/bench_test.go
+++ b/transport/httptransport/bench_test.go
@@ -1,0 +1,198 @@
+package httptransport
+
+import (
+	"context"
+	"io"
+	"io/ioutil"
+	"math/rand"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/filecoin-project/boost/transport/types"
+	"github.com/ipfs/go-blockservice"
+	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-datastore"
+	dssync "github.com/ipfs/go-datastore/sync"
+	bstore "github.com/ipfs/go-ipfs-blockstore"
+	"github.com/ipfs/go-merkledag"
+	"github.com/ipld/go-car"
+	"github.com/libp2p/go-libp2p-core/host"
+	"github.com/stretchr/testify/require"
+)
+
+type testServer interface {
+	Request(authToken string) types.HttpRequest
+	Client() *httpTransport
+	Server() *Libp2pCarServer
+	Stop() error
+}
+
+func TestBenchTransport(t *testing.T) {
+	ctx := context.Background()
+
+	rawSize := 1024 * 1024 * 1024
+	//rawSize := 2 * 1024 * 1024
+	t.Logf("Benchmark file of size %d (%.2f MB)", rawSize, float64(rawSize)/(1024*1024))
+
+	rseed := 5
+	source := io.LimitReader(rand.New(rand.NewSource(int64(rseed))), int64(rawSize))
+	ds := dssync.MutexWrap(datastore.NewMapDatastore())
+	bs := bstore.NewBlockstore(ds)
+	bserv := blockservice.New(bs, nil)
+	dserv := merkledag.NewDAGService(bserv)
+
+	t.Log("starting import")
+	importStart := time.Now()
+	nd, err := dagImport(dserv, source)
+	require.NoError(t, err)
+	t.Logf("import took %s", time.Since(importStart))
+
+	// Get the size of the CAR file
+	t.Log("getting car file size")
+	carSizeStart := time.Now()
+	cw := &countWriter{}
+	err = car.WriteCar(context.Background(), dserv, []cid.Cid{nd.Cid()}, cw)
+	require.NoError(t, err)
+	t.Logf("car size: %d bytes (%.2f MB) - took %s", cw.total, float64(cw.total)/(1024*1024), time.Since(carSizeStart))
+
+	performTransfer := func(t *testing.T, ts testServer) {
+		srv := ts.Server()
+		defer ts.Stop() //nolint:errcheck
+
+		// Create an auth token
+		carSize := cw.total
+		proposalCid, err := cid.Parse("bafkqaaa")
+		require.NoError(t, err)
+		dbid := uint(1)
+		xfer, err := srv.PrepareForDataRequest(context.Background(), dbid, proposalCid, nd.Cid(), uint64(carSize))
+		require.NoError(t, err)
+
+		// Perform retrieval with the auth token
+		req := ts.Request(xfer.AuthToken)
+		of := getTempFilePath(t)
+
+		xferStart := time.Now()
+		th := executeTransfer(t, ctx, ts.Client(), carSize, req, of)
+		require.NotNil(t, th)
+
+		// Wait for the transfer to complete
+		clientEvts := waitForTransferComplete(th)
+		end := time.Now()
+
+		require.NotEmpty(t, clientEvts)
+		lastClientEvt := clientEvts[len(clientEvts)-1]
+		require.EqualValues(t, carSize, lastClientEvt.NBytesReceived)
+
+		xferTime := end.Sub(xferStart)
+		mbPerS := (float64(cw.total) / (1024 * 1024)) / (float64(xferTime) / float64(time.Second))
+		t.Logf("transfer of %.2f MB took %s: %.2f MB / s", float64(cw.total)/(1024*1024), xferTime, mbPerS)
+	}
+
+	t.Run("http over libp2p", func(t *testing.T) {
+		clientHost, srvHost := setupLibp2pHosts(t)
+		defer srvHost.Close()
+		defer clientHost.Close()
+
+		authDB := NewAuthTokenDB(ds)
+		srv := NewLibp2pCarServer(srvHost, authDB, bs, ServerConfig{
+			AnnounceAddr: srvHost.Addrs()[0],
+		})
+		err = srv.Start()
+		require.NoError(t, err)
+
+		bsrv := &benchLibp2pHttpServer{
+			srvHost:    srvHost,
+			clientHost: clientHost,
+			srv:        srv,
+		}
+
+		performTransfer(t, bsrv)
+	})
+
+	t.Run("raw http", func(t *testing.T) {
+		clientHost, srvHost := setupLibp2pHosts(t)
+		defer srvHost.Close()
+		defer clientHost.Close()
+
+		authDB := NewAuthTokenDB(ds)
+		srv := NewLibp2pCarServer(srvHost, authDB, bs, ServerConfig{
+			AnnounceAddr: srvHost.Addrs()[0],
+		})
+
+		http.HandleFunc("/", srv.handler)
+		listenAddr := "127.0.0.1:8080"
+		go func() {
+			_ = http.ListenAndServe(listenAddr, nil)
+		}()
+
+		bsrv := &benchRawHttpServer{
+			srvHost:    srvHost,
+			clientHost: clientHost,
+			srv:        srv,
+			listenAddr: listenAddr,
+		}
+
+		performTransfer(t, bsrv)
+	})
+}
+
+type countWriter struct {
+	total int
+}
+
+func (cw *countWriter) Write(p []byte) (int, error) {
+	n, err := ioutil.Discard.Write(p)
+	cw.total += n
+	return n, err
+}
+
+type benchRawHttpServer struct {
+	srvHost    host.Host
+	clientHost host.Host
+	srv        *Libp2pCarServer
+	listenAddr string
+}
+
+func (s *benchRawHttpServer) Request(authToken string) types.HttpRequest {
+	return types.HttpRequest{
+		URL: "http://" + s.listenAddr,
+		Headers: map[string]string{
+			"Authorization": BasicAuthHeader("", authToken),
+		},
+	}
+}
+
+func (s *benchRawHttpServer) Client() *httpTransport {
+	return New(nil)
+}
+
+func (s *benchRawHttpServer) Server() *Libp2pCarServer {
+	return s.srv
+}
+
+func (s *benchRawHttpServer) Stop() error {
+	return nil
+}
+
+type benchLibp2pHttpServer struct {
+	srvHost    host.Host
+	clientHost host.Host
+	srv        *Libp2pCarServer
+}
+
+func (s *benchLibp2pHttpServer) Request(authToken string) types.HttpRequest {
+	return newLibp2pHttpRequest(s.srvHost, authToken)
+}
+
+func (s *benchLibp2pHttpServer) Client() *httpTransport {
+	return New(s.clientHost)
+}
+
+func (s *benchLibp2pHttpServer) Server() *Libp2pCarServer {
+	return s.srv
+}
+
+func (s *benchLibp2pHttpServer) Stop() error {
+	return s.srv.Stop()
+}

--- a/transport/httptransport/http_transport.go
+++ b/transport/httptransport/http_transport.go
@@ -130,7 +130,11 @@ func (h *httpTransport) Execute(ctx context.Context, transportInfo []byte, dealI
 		// Use the libp2p client
 		t.client = h.libp2pClient
 		// Add the peer's address to the peerstore so we can dial it
-		h.libp2pHost.Peerstore().AddAddr(u.peerID, u.multiaddr, time.Hour)
+		addrTtl := time.Hour
+		if deadline, ok := ctx.Deadline(); ok {
+			addrTtl = deadline.Sub(time.Now())
+		}
+		h.libp2pHost.Peerstore().AddAddr(u.peerID, u.multiaddr, addrTtl)
 	} else {
 		t.client = http.DefaultClient
 	}

--- a/transport/httptransport/http_transport.go
+++ b/transport/httptransport/http_transport.go
@@ -132,7 +132,7 @@ func (h *httpTransport) Execute(ctx context.Context, transportInfo []byte, dealI
 		// Add the peer's address to the peerstore so we can dial it
 		addrTtl := time.Hour
 		if deadline, ok := ctx.Deadline(); ok {
-			addrTtl = deadline.Sub(time.Now())
+			addrTtl = time.Until(deadline)
 		}
 		h.libp2pHost.Peerstore().AddAddr(u.peerID, u.multiaddr, addrTtl)
 	} else {

--- a/transport/httptransport/http_transport.go
+++ b/transport/httptransport/http_transport.go
@@ -94,7 +94,7 @@ func (h *httpTransport) Execute(ctx context.Context, transportInfo []byte, dealI
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse request url: %w", err)
 	}
-	tInfo.URL = u.URL
+	tInfo.URL = u.url
 
 	// check that the outputFile exists
 	fi, err := os.Stat(dealInfo.OutputFile)
@@ -126,11 +126,11 @@ func (h *httpTransport) Execute(ctx context.Context, transportInfo []byte, dealI
 	}
 
 	// If this is a libp2p URL
-	if u.Scheme == libp2pScheme {
+	if u.scheme == libp2pScheme {
 		// Use the libp2p client
 		t.client = h.libp2pClient
 		// Add the peer's address to the peerstore so we can dial it
-		h.libp2pHost.Peerstore().AddAddr(u.PeerID, u.Multiaddr, time.Hour)
+		h.libp2pHost.Peerstore().AddAddr(u.peerID, u.multiaddr, time.Hour)
 	} else {
 		t.client = http.DefaultClient
 	}

--- a/transport/httptransport/http_transport_test.go
+++ b/transport/httptransport/http_transport_test.go
@@ -443,9 +443,9 @@ func serversWithCustomHandler(handler http.HandlerFunc) map[string]func(t *testi
 
 func newLibp2pHttpServer(st *serverTest) (types.HttpRequest, func(), host.Host) {
 	clientHost, srvHost := setupLibp2pHosts(st.t)
-	srv := NewLibp2pCarServer(srvHost, st.ds, st.bs, ServerConfig{
+	authDB := NewAuthTokenDB(st.ds)
+	srv := NewLibp2pCarServer(srvHost, authDB, st.bs, ServerConfig{
 		AnnounceAddr: srvHost.Addrs()[0],
-		RetryTimeout: time.Minute,
 	})
 	err := srv.Start()
 	require.NoError(st.t, err)

--- a/transport/httptransport/libp2p_server.go
+++ b/transport/httptransport/libp2p_server.go
@@ -202,6 +202,7 @@ func (s *Libp2pCarServer) sendCar(r *http.Request, w http.ResponseWriter, val au
 		// every time (and so that multiple concurrent requests for the same
 		// data can share a cache)
 		// TODO: make the underlying cache threadsafe
+		// TODO: cancel existing ReadSeeker
 		content = xfer.content
 
 		// Seek back to the start of the reader
@@ -422,6 +423,8 @@ func (t *Libp2pTransfer) Cancel(err error) {
 	t.lk.Lock()
 	defer t.lk.Unlock()
 
+	// TODO: Add CloseWithError to CarReaderSeeker
+	//t.content.CloseWithError(err)
 	t.cancelled = true
 	t.err = err
 	t.status = types.TransferStatusFailed

--- a/transport/httptransport/libp2p_server.go
+++ b/transport/httptransport/libp2p_server.go
@@ -1,0 +1,372 @@
+package httptransport
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/filecoin-project/boost/transport/types"
+	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-datastore"
+	"github.com/ipfs/go-datastore/namespace"
+	blockstore "github.com/ipfs/go-ipfs-blockstore"
+	"github.com/ipld/go-car/v2"
+	"github.com/libp2p/go-libp2p-core/host"
+	gostream "github.com/libp2p/go-libp2p-gostream"
+	"github.com/multiformats/go-multiaddr"
+	"golang.org/x/xerrors"
+)
+
+// Libp2pCarServer serves deal data by matching an auth token to the root CID
+// of a DAG in a blockstore, and serving the data as a CAR
+type Libp2pCarServer struct {
+	h      host.Host
+	authds datastore.Batching
+	bstore blockstore.Blockstore
+	cfg    ServerConfig
+
+	ctx         context.Context
+	cancel      context.CancelFunc
+	server      *http.Server
+	netListener net.Listener
+
+	eventListenersLk sync.Mutex
+	eventListeners   map[*EventListenerFn]struct{}
+
+	transfersLk sync.Mutex
+	transfers   map[cid.Cid]*transferTimer
+}
+
+type ServerConfig struct {
+	AnnounceAddr multiaddr.Multiaddr
+	// If there is an error transferring data, wait for the data receiver to
+	// retry the transfer for up to RetryTimeout before giving up
+	RetryTimeout time.Duration
+}
+
+func NewLibp2pCarServer(h host.Host, ds datastore.Batching, bstore blockstore.Blockstore, cfg ServerConfig) *Libp2pCarServer {
+	authds := namespace.Wrap(ds, datastore.NewKey("/libp2p-car-server-auth"))
+	return &Libp2pCarServer{
+		h:              h,
+		authds:         authds,
+		bstore:         bstore,
+		cfg:            cfg,
+		eventListeners: make(map[*EventListenerFn]struct{}),
+		transfers:      make(map[cid.Cid]*transferTimer),
+	}
+}
+
+func (s *Libp2pCarServer) Start() error {
+	s.ctx, s.cancel = context.WithCancel(context.Background())
+
+	// Listen on HTTP over libp2p
+	listener, err := gostream.Listen(s.h, types.DataTransferProtocol)
+	if err != nil {
+		return fmt.Errorf("starting gostream listener: %w", err)
+	}
+
+	s.netListener = listener
+
+	handler := http.NewServeMux()
+	handler.HandleFunc("/", s.handler)
+	s.server = &http.Server{Handler: handler}
+	go s.server.Serve(listener) //nolint:errcheck
+
+	return nil
+}
+
+func (s *Libp2pCarServer) Stop() error {
+	s.cancel()
+	lerr := s.netListener.Close()
+	serr := s.server.Close()
+
+	if lerr != nil {
+		return lerr
+	}
+	return serr
+}
+
+// PrepareForDataRequest creates an auth token and saves some parameters
+// in the datastore, in preparation for a request with that auth token.
+func (s *Libp2pCarServer) PrepareForDataRequest(ctx context.Context, dbID uint, proposalCid cid.Cid, payloadCid cid.Cid, size uint64) (*DealTransfer, error) {
+	// Create a new auth token and add it to the datastore
+	authTokenBuff := make([]byte, 1024)
+	if _, err := rand.Read(authTokenBuff); err != nil {
+		return nil, fmt.Errorf("generating auth token: %w", err)
+	}
+	authToken := hex.EncodeToString(authTokenBuff)
+
+	authValueJson, err := json.Marshal(&authValue{
+		CreatedAt:   time.Now(),
+		ProposalCid: proposalCid,
+		PayloadCid:  payloadCid,
+		Size:        size,
+		DBID:        dbID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshaling auth value JSON: %w", err)
+	}
+
+	authTokenKey := datastore.NewKey(authToken)
+	err = s.authds.Put(ctx, authTokenKey, authValueJson)
+	if err != nil {
+		return nil, fmt.Errorf("adding auth token to datastore: %w", err)
+	}
+
+	dt := &DealTransfer{
+		MultiAddress: s.cfg.AnnounceAddr,
+		AuthToken:    authToken,
+	}
+	return dt, nil
+}
+
+// Cleanup removes an auth token from the datastore
+func (s *Libp2pCarServer) Cleanup(authToken string) error {
+	return s.authds.Delete(s.ctx, datastore.NewKey(authToken))
+}
+
+func (s *Libp2pCarServer) handler(w http.ResponseWriter, r *http.Request) {
+	err := s.handleNewReq(w, r)
+	if err != nil {
+		log.Infof(err.Error())
+		w.WriteHeader(err.code)
+	}
+}
+
+func (s *Libp2pCarServer) handleNewReq(w http.ResponseWriter, r *http.Request) *httpError {
+	// Get auth token from Authorization header
+	_, authToken, ok := r.BasicAuth()
+	if !ok {
+		return &httpError{
+			error: fmt.Errorf("rejected request with no Authorization header"),
+			code:  401,
+		}
+	}
+
+	// Get proposal CID from auth datastore
+	authValueJson, err := s.authds.Get(s.ctx, datastore.NewKey(authToken))
+	if xerrors.Is(err, datastore.ErrNotFound) {
+		return &httpError{
+			error: fmt.Errorf("rejected unrecognized auth token"),
+			code:  401,
+		}
+	} else if err != nil {
+		return &httpError{
+			error: fmt.Errorf("getting key from datastore: %w", err),
+			code:  500,
+		}
+	}
+
+	var val authValue
+	err = json.Unmarshal(authValueJson, &val)
+	if err != nil {
+		return &httpError{
+			error: fmt.Errorf("unmarshaling json from datastore: %w", err),
+			code:  500,
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/car")
+	content := car.NewCarReaderSeeker(s.ctx, val.PayloadCid, s.bstore, val.Size)
+	if r.Method == "HEAD" {
+		http.ServeContent(w, r, "", time.Time{}, content)
+		return nil
+	}
+
+	s.sendCar(r, w, authToken, val, content)
+	return nil
+}
+
+func (s *Libp2pCarServer) sendCar(r *http.Request, w http.ResponseWriter, authToken string, val authValue, content *car.CarReaderSeeker) {
+	var transferred uint64
+	local := s.h.ID().String()
+	remote := r.RemoteAddr // TODO: Check that RemoteAddr is the remote Peer ID
+	fireEvent := func(transferred uint64, status types.TransferStatus, msg string) {
+		evt := transferEvent(local, remote, transferred, status, msg)
+		s.eventListenersLk.Lock()
+		for l := range s.eventListeners {
+			(*l)(val.DBID, evt)
+		}
+		s.eventListenersLk.Unlock()
+	}
+
+	s.transfersLk.Lock()
+	existing, ok := s.transfers[val.ProposalCid]
+	if ok {
+		log.Infow("restarting transfer", "proposalCID", val.ProposalCid, "payloadCID", val.PayloadCid)
+		existing.cancelTimeout()
+	} else {
+		log.Infof("starting transfer", "proposalCID", val.ProposalCid, "payloadCID", val.PayloadCid)
+	}
+	xfer := &transferTimer{
+		authValue:    &val,
+		retryTimeout: s.cfg.RetryTimeout,
+		onTimeout: func(orig error) {
+			s.transfersLk.Lock()
+			delete(s.transfers, val.ProposalCid)
+			s.transfersLk.Unlock()
+
+			log.Infof("failed transfer after timeout", "proposalCID", val.ProposalCid, "payloadCID", val.PayloadCid,
+				"error", orig, "timeout", s.cfg.RetryTimeout)
+			_ = s.Cleanup(authToken)
+
+			msg := fmt.Sprintf("timed out waiting %s for data receiver to restart transfer ", s.cfg.RetryTimeout)
+			msg += "after error " + orig.Error()
+			msg += "\nfor proposal CID " + val.ProposalCid.String() + ", payloadCID " + val.PayloadCid.String()
+			fireEvent(transferred, types.TransferStatusFailed, msg)
+		},
+	}
+	s.transfers[val.ProposalCid] = xfer
+	s.transfersLk.Unlock()
+
+	// Fire event before starting transfer
+	fireEvent(0, types.TransferStatusStarted, "")
+
+	// Fire progress events during transfer.
+	// We fire a progress event each time bytes are read from the CAR.
+	// Note that we can't fire events when bytes are written to the HTTP stream
+	// because there may be some transformation first (eg adding headers etc).
+	readEmitter := &readEmitter{ReadSeeker: content, emit: func(count int, err error) {
+		if err != nil {
+			xfer.startRetryTimer(err)
+			return
+		}
+		transferred += uint64(count)
+		fireEvent(transferred, types.TransferStatusOngoing, "")
+	}}
+
+	// http.ServeContent ignores errors when writing to the stream, so we
+	// replace the writer with a class that watches for errors
+	writeErrWatcher := &writeErrorWatcher{ResponseWriter: w, onError: xfer.startRetryTimer}
+
+	http.ServeContent(writeErrWatcher, r, "", time.Time{}, readEmitter)
+
+	// Check if there was an error during the transfer
+	if xfer.errored() {
+		// There was an error, just wait for the data receiver to retry
+		return
+	}
+
+	s.transfersLk.Lock()
+	delete(s.transfers, val.ProposalCid)
+	s.transfersLk.Unlock()
+
+	// Fire event at the end of the transfer
+	fireEvent(transferred, types.TransferStatusCompleted, "")
+
+	log.Infow("completed serving request", "proposalCID", val.ProposalCid, "payloadCID", val.PayloadCid)
+}
+
+type EventListenerFn func(dbid uint, st types.TransferState)
+type UnsubFn func()
+
+func (s *Libp2pCarServer) Subscribe(cb EventListenerFn) UnsubFn {
+	s.eventListenersLk.Lock()
+	s.eventListeners[&cb] = struct{}{}
+	s.eventListenersLk.Unlock()
+
+	return func() {
+		s.eventListenersLk.Lock()
+		delete(s.eventListeners, &cb)
+		s.eventListenersLk.Unlock()
+	}
+}
+
+type transferTimer struct {
+	*authValue
+	retryTimeout time.Duration
+	onTimeout    func(orig error)
+	retryTimer   *time.Timer
+	lk           sync.Mutex
+	err          error
+}
+
+func (t *transferTimer) startRetryTimer(err error) {
+	t.lk.Lock()
+	defer t.lk.Unlock()
+
+	if t.err != nil {
+		return
+	}
+	t.err = err
+
+	msg := "error in transfer for proposal CID %s / payload CID %s: %s"
+	msg += "\nwaiting %s for data receiver to retry"
+	log.Infof(msg, t.ProposalCid, t.PayloadCid, err, t.retryTimeout)
+	t.retryTimer = time.AfterFunc(t.retryTimeout, func() {
+		t.onTimeout(err)
+	})
+}
+
+func (t *transferTimer) cancelTimeout() {
+	if t.retryTimer != nil {
+		t.retryTimer.Stop()
+	}
+}
+
+func (t *transferTimer) errored() bool {
+	t.lk.Lock()
+	defer t.lk.Unlock()
+
+	return t.err != nil
+}
+
+type readEmitter struct {
+	io.ReadSeeker
+	emit func(count int, err error)
+}
+
+func (e *readEmitter) Read(p []byte) (n int, err error) {
+	count, err := e.ReadSeeker.Read(p)
+	e.emit(count, err)
+	return count, err
+}
+
+type writeErrorWatcher struct {
+	http.ResponseWriter
+	onError func(err error)
+}
+
+func (w *writeErrorWatcher) Write(bz []byte) (int, error) {
+	count, err := w.ResponseWriter.Write(bz)
+	if err != nil {
+		w.onError(err)
+	}
+	return count, err
+}
+
+func transferEvent(localAddr string, remoteAddr string, transferred uint64, status types.TransferStatus, msg string) types.TransferState {
+	if msg == "" {
+		msg = fmt.Sprintf("transferred %d bytes", transferred)
+		if transferred == 0 {
+			msg = "pull data transfer queued"
+		}
+	}
+	return types.TransferState{
+		LocalAddr:  localAddr,
+		RemoteAddr: remoteAddr,
+		Status:     status,
+		Sent:       transferred,
+		Message:    msg,
+	}
+}
+
+type DealTransfer struct {
+	MultiAddress multiaddr.Multiaddr
+	AuthToken    string
+}
+
+type authValue struct {
+	CreatedAt   time.Time
+	ProposalCid cid.Cid
+	PayloadCid  cid.Cid
+	Size        uint64
+	DBID        uint
+}

--- a/transport/httptransport/libp2p_server_test.go
+++ b/transport/httptransport/libp2p_server_test.go
@@ -2,8 +2,9 @@ package httptransport
 
 import (
 	"context"
+	"io"
+	"os"
 	"testing"
-	"time"
 
 	"github.com/filecoin-project/boost/transport/types"
 	"github.com/ipfs/go-cid"
@@ -13,8 +14,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestLibp2pDataServerAuth verifies that authorization works as expected
-func TestLibp2pDataServerAuth(t *testing.T) {
+// TestLibp2pCarServerAuth verifies that authorization works as expected
+func TestLibp2pCarServerAuth(t *testing.T) {
 	ctx := context.Background()
 
 	rawSize := 2 * 1024 * 1024
@@ -24,15 +25,15 @@ func TestLibp2pDataServerAuth(t *testing.T) {
 	defer srvHost.Close()
 	defer clientHost.Close()
 
-	srv := NewLibp2pCarServer(srvHost, st.ds, st.bs, ServerConfig{
+	authDB := NewAuthTokenDB(st.ds)
+	srv := NewLibp2pCarServer(srvHost, authDB, st.bs, ServerConfig{
 		AnnounceAddr: srvHost.Addrs()[0],
-		RetryTimeout: time.Minute,
 	})
 	err := srv.Start()
 	require.NoError(t, err)
 	defer srv.Stop() //nolint:errcheck
 
-	// Add an auth token
+	// Create an auth token
 	carSize := len(st.carBytes)
 	proposalCid, err := cid.Parse("bafkqaaa")
 	require.NoError(t, err)
@@ -42,10 +43,9 @@ func TestLibp2pDataServerAuth(t *testing.T) {
 
 	srvEvts := []types.TransferState{}
 	srv.Subscribe(func(sdbid uint, st types.TransferState) {
-		if dbid != sdbid {
-			return
+		if dbid == sdbid {
+			srvEvts = append(srvEvts, st)
 		}
-		srvEvts = append(srvEvts, st)
 	})
 
 	// Perform retrieval with the auth token
@@ -66,10 +66,10 @@ func TestLibp2pDataServerAuth(t *testing.T) {
 	lastSrvEvt := srvEvts[len(srvEvts)-1]
 	require.Equal(t, types.TransferStatusStarted, srvEvts[0].Status)
 	require.Equal(t, types.TransferStatusCompleted, lastSrvEvt.Status)
-	require.EqualValues(t, lastClientEvt.NBytesReceived, lastSrvEvt.Sent)
+	require.EqualValues(t, int(lastClientEvt.NBytesReceived), int(lastSrvEvt.Sent))
 
 	// Remove the auth token from the server
-	err = srv.Cleanup(xfer.AuthToken)
+	err = authDB.Delete(ctx, xfer.AuthToken)
 	require.NoError(t, err)
 
 	// Attempt a second retrieval - it should fail with a 401 HTTP error
@@ -82,120 +82,137 @@ func TestLibp2pDataServerAuth(t *testing.T) {
 	require.Error(t, evts2[len(evts2)-1].Error)
 }
 
+// TestLibp2pCarServerResume verifies that a transfer can resume from an
+// arbitrary place in the stream
+func TestLibp2pCarServerResume(t *testing.T) {
+	ctx := context.Background()
+
+	rawSize := 2 * 1024 * 1024
+	st := newServerTest(t, rawSize)
+
+	clientHost, srvHost := setupLibp2pHosts(t)
+	defer srvHost.Close()
+	defer clientHost.Close()
+
+	authDB := NewAuthTokenDB(st.ds)
+	srv := NewLibp2pCarServer(srvHost, authDB, st.bs, ServerConfig{
+		AnnounceAddr: srvHost.Addrs()[0],
+	})
+	err := srv.Start()
+	require.NoError(t, err)
+	defer srv.Stop() //nolint:errcheck
+
+	// Create an auth token
+	carSize := len(st.carBytes)
+	proposalCid, err := cid.Parse("bafkqaaa")
+	require.NoError(t, err)
+	dbid := uint(1)
+	xfer, err := srv.PrepareForDataRequest(context.Background(), dbid, proposalCid, st.root.Cid(), uint64(carSize))
+	require.NoError(t, err)
+
+	srvEvts := []types.TransferState{}
+	srv.Subscribe(func(sdbid uint, st types.TransferState) {
+		if dbid == sdbid {
+			srvEvts = append(srvEvts, st)
+		}
+	})
+
+	outFile := getTempFilePath(t)
+	retrieveData := func(readCount int, of string) {
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
+		// Perform retrieval with the auth token
+		req := newLibp2pHttpRequest(srvHost, xfer.AuthToken)
+		th := executeTransfer(t, ctx, New(clientHost), carSize, req, of)
+		require.NotNil(t, th)
+
+		// Wait for some data to be received by the client
+		clientSub := th.Sub()
+		for i := 0; i < readCount; i++ {
+			evt := <-clientSub
+			require.NoError(t, evt.Error)
+		}
+
+		// Disconnect the connection
+		err = clientHost.Network().ClosePeer(srvHost.ID())
+		require.NoError(t, err)
+
+		// Wait for the transfer to stall on the client
+		for {
+			select {
+			case evt := <-clientSub:
+				t.Logf("performed read till offset %d", evt.NBytesReceived)
+			default:
+				t.Logf("done reading")
+				return
+			}
+		}
+	}
+
+	truncateFromEnd := func(of string, fromEnd int) []byte {
+		f, err := os.Open(of)
+		require.NoError(t, err)
+
+		bz, err := io.ReadAll(f)
+		require.NoError(t, err)
+
+		err = f.Close()
+		require.NoError(t, err)
+
+		backtrack := min(len(bz), 1024)
+		err = os.WriteFile(outFile, bz[:len(bz)-backtrack], 0666)
+		require.NoError(t, err)
+
+		return bz
+	}
+
+	// Perform approximately one read (may read a few more times before the
+	// disconnect event propagates)
+	retrieveData(1, outFile)
+
+	// Remove the last 1k bytes from the file so that the next read will be
+	// from an earlier offset
+	truncateFromEnd(outFile, 1024)
+
+	// Do the same again
+	retrieveData(1, outFile)
+	truncateFromEnd(outFile, 1024)
+
+	// Now retrieve all bytes
+	req := newLibp2pHttpRequest(srvHost, xfer.AuthToken)
+	th := executeTransfer(t, ctx, New(clientHost), carSize, req, outFile)
+	require.NotNil(t, th)
+
+	// Wait for the transfer to complete
+	clientEvts := waitForTransferComplete(th)
+
+	// Check that all bytes were transferred successfully on the client
+	require.NotEmpty(t, clientEvts)
+	lastClientEvt := clientEvts[len(clientEvts)-1]
+	require.EqualValues(t, carSize, lastClientEvt.NBytesReceived)
+	assertFileContents(t, outFile, st.carBytes)
+
+	// Check that all bytes were transferred successfully on the server
+	require.NotEmpty(t, srvEvts)
+	lastSrvEvt := srvEvts[len(srvEvts)-1]
+	require.Equal(t, types.TransferStatusCompleted, lastSrvEvt.Status)
+	require.EqualValues(t, carSize, int(lastSrvEvt.Sent))
+}
+
+func min(a int, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
 func newLibp2pHttpRequest(h host.Host, token string) types.HttpRequest {
 	return types.HttpRequest{
 		URL: "libp2p://" + h.Addrs()[0].String() + "/p2p/" + h.ID().Pretty(),
 		Headers: map[string]string{
 			"Authorization": BasicAuthHeader("", token),
 		},
-	}
-}
-
-// TestLibp2pDataServerRetry verifies that there is an error event when the
-// client does not retry downloading the data before the retry timeout
-func TestLibp2pDataServerRetry(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	rawSize := 2 * 1024 * 1024
-
-	testCases := []struct {
-		name              string
-		retryTimeout      time.Duration
-		attemptRetryAfter time.Duration
-	}{{
-		name:              "client retries before timeout",
-		attemptRetryAfter: 100 * time.Millisecond,
-		retryTimeout:      1000 * time.Millisecond,
-	}, {
-		name:              "client retries after timeout",
-		attemptRetryAfter: 500 * time.Millisecond,
-		retryTimeout:      200 * time.Millisecond,
-	}}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			expectTimeout := tc.attemptRetryAfter < tc.retryTimeout
-			st := newServerTest(t, rawSize)
-
-			clientHost, srvHost := setupLibp2pHosts(t)
-			defer srvHost.Close()
-			defer clientHost.Close()
-
-			srv := NewLibp2pCarServer(srvHost, st.ds, st.bs, ServerConfig{
-				AnnounceAddr: srvHost.Addrs()[0],
-				RetryTimeout: tc.retryTimeout,
-			})
-			err := srv.Start()
-			require.NoError(t, err)
-			defer srv.Stop() //nolint:errcheck
-
-			// Add an auth token
-			carSize := len(st.carBytes)
-			proposalCid, err := cid.Parse("bafkqaaa")
-			require.NoError(t, err)
-			dbid := uint(1)
-			xfer, err := srv.PrepareForDataRequest(context.Background(), dbid, proposalCid, st.root.Cid(), uint64(carSize))
-			require.NoError(t, err)
-
-			// Perform retrieval with the auth token
-			req := newLibp2pHttpRequest(srvHost, xfer.AuthToken)
-			of := getTempFilePath(t)
-			backoff := BackOffRetryOpt(tc.attemptRetryAfter, tc.attemptRetryAfter, 1, 5)
-			ht := New(clientHost, backoff)
-
-			// Listen for server events
-			srvEvts := make(chan types.TransferState, rawSize)
-			srv.Subscribe(func(sdbid uint, st types.TransferState) {
-				if dbid != sdbid {
-					return
-				}
-				srvEvts <- st
-				if st.Status == types.TransferStatusCompleted || st.Status == types.TransferStatusFailed {
-					close(srvEvts)
-				}
-			})
-
-			th := executeTransfer(t, ctx, ht, carSize, req, of)
-			require.NotNil(t, th)
-
-			// Wait for some data to be received by the client
-			clientSub := th.Sub()
-			evt := <-clientSub
-			require.NoError(t, evt.Error)
-
-			// Disconnect the connection
-			err = clientHost.Network().ClosePeer(srvHost.ID())
-			require.NoError(t, err)
-
-			// Wait for the transfer to complete or error out on the client
-			var lastClientEvt types.TransportEvent
-			for evt := range clientSub {
-				lastClientEvt = evt
-			}
-
-			// Wait for the transfer to complete or error out on the server
-			var lastSrvEvt types.TransferState
-			for evt := range srvEvts {
-				lastSrvEvt = evt
-			}
-
-			if expectTimeout {
-				// The client is configured to retry before the retry timeout
-				// expires, so expect the transfer to succeed
-				require.NoError(t, lastClientEvt.Error)
-				require.Equal(t, types.TransferStatusCompleted, lastSrvEvt.Status)
-			} else {
-				// The client is configured to retry after the retry timeout
-				// expires, so expect the transfer to fail.
-				require.Error(t, lastClientEvt.Error)
-				// Expect a 401 error to occur because the auth token gets
-				// deleted when the retry timeout expires.
-				require.Contains(t, lastClientEvt.Error.Error(), "401")
-				// Expect a failure event on the server
-				require.Equal(t, types.TransferStatusFailed, lastSrvEvt.Status)
-			}
-		})
 	}
 }
 

--- a/transport/httptransport/libp2p_server_test.go
+++ b/transport/httptransport/libp2p_server_test.go
@@ -1,0 +1,212 @@
+package httptransport
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/filecoin-project/boost/transport/types"
+	"github.com/ipfs/go-cid"
+	"github.com/libp2p/go-libp2p-core/host"
+	"github.com/libp2p/go-libp2p-core/peerstore"
+	"github.com/multiformats/go-multiaddr"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLibp2pDataServerAuth verifies that authorization works as expected
+func TestLibp2pDataServerAuth(t *testing.T) {
+	ctx := context.Background()
+
+	rawSize := 2 * 1024 * 1024
+	st := newServerTest(t, rawSize)
+
+	clientHost, srvHost := setupLibp2pHosts(t)
+	defer srvHost.Close()
+	defer clientHost.Close()
+
+	srv := NewLibp2pCarServer(srvHost, st.ds, st.bs, ServerConfig{
+		AnnounceAddr: srvHost.Addrs()[0],
+		RetryTimeout: time.Minute,
+	})
+	err := srv.Start()
+	require.NoError(t, err)
+	defer srv.Stop() //nolint:errcheck
+
+	// Add an auth token
+	carSize := len(st.carBytes)
+	proposalCid, err := cid.Parse("bafkqaaa")
+	require.NoError(t, err)
+	dbid := uint(1)
+	xfer, err := srv.PrepareForDataRequest(context.Background(), dbid, proposalCid, st.root.Cid(), uint64(carSize))
+	require.NoError(t, err)
+
+	srvEvts := []types.TransferState{}
+	srv.Subscribe(func(sdbid uint, st types.TransferState) {
+		if dbid != sdbid {
+			return
+		}
+		srvEvts = append(srvEvts, st)
+	})
+
+	// Perform retrieval with the auth token
+	req := newLibp2pHttpRequest(srvHost, xfer.AuthToken)
+	of := getTempFilePath(t)
+	th := executeTransfer(t, ctx, New(clientHost), carSize, req, of)
+	require.NotNil(t, th)
+
+	// Wait for the transfer to complete
+	clientEvts := waitForTransferComplete(th)
+	require.NotEmpty(t, clientEvts)
+	lastClientEvt := clientEvts[len(clientEvts)-1]
+	require.EqualValues(t, carSize, lastClientEvt.NBytesReceived)
+	assertFileContents(t, of, st.carBytes)
+
+	// Check that the server event subscription is working correctly
+	require.NotEmpty(t, srvEvts)
+	lastSrvEvt := srvEvts[len(srvEvts)-1]
+	require.Equal(t, types.TransferStatusStarted, srvEvts[0].Status)
+	require.Equal(t, types.TransferStatusCompleted, lastSrvEvt.Status)
+	require.EqualValues(t, lastClientEvt.NBytesReceived, lastSrvEvt.Sent)
+
+	// Remove the auth token from the server
+	err = srv.Cleanup(xfer.AuthToken)
+	require.NoError(t, err)
+
+	// Attempt a second retrieval - it should fail with a 401 HTTP error
+	of2 := getTempFilePath(t)
+	th2 := executeTransfer(t, ctx, New(clientHost), carSize, req, of2)
+	require.NotNil(t, th2)
+
+	evts2 := waitForTransferComplete(th2)
+	require.NotEmpty(t, evts2)
+	require.Error(t, evts2[len(evts2)-1].Error)
+}
+
+func newLibp2pHttpRequest(h host.Host, token string) types.HttpRequest {
+	return types.HttpRequest{
+		URL: "libp2p://" + h.Addrs()[0].String() + "/p2p/" + h.ID().Pretty(),
+		Headers: map[string]string{
+			"Authorization": BasicAuthHeader("", token),
+		},
+	}
+}
+
+// TestLibp2pDataServerRetry verifies that there is an error event when the
+// client does not retry downloading the data before the retry timeout
+func TestLibp2pDataServerRetry(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	rawSize := 2 * 1024 * 1024
+
+	testCases := []struct {
+		name              string
+		retryTimeout      time.Duration
+		attemptRetryAfter time.Duration
+	}{{
+		name:              "client retries before timeout",
+		attemptRetryAfter: 100 * time.Millisecond,
+		retryTimeout:      1000 * time.Millisecond,
+	}, {
+		name:              "client retries after timeout",
+		attemptRetryAfter: 500 * time.Millisecond,
+		retryTimeout:      200 * time.Millisecond,
+	}}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			expectTimeout := tc.attemptRetryAfter < tc.retryTimeout
+			st := newServerTest(t, rawSize)
+
+			clientHost, srvHost := setupLibp2pHosts(t)
+			defer srvHost.Close()
+			defer clientHost.Close()
+
+			srv := NewLibp2pCarServer(srvHost, st.ds, st.bs, ServerConfig{
+				AnnounceAddr: srvHost.Addrs()[0],
+				RetryTimeout: tc.retryTimeout,
+			})
+			err := srv.Start()
+			require.NoError(t, err)
+			defer srv.Stop() //nolint:errcheck
+
+			// Add an auth token
+			carSize := len(st.carBytes)
+			proposalCid, err := cid.Parse("bafkqaaa")
+			require.NoError(t, err)
+			dbid := uint(1)
+			xfer, err := srv.PrepareForDataRequest(context.Background(), dbid, proposalCid, st.root.Cid(), uint64(carSize))
+			require.NoError(t, err)
+
+			// Perform retrieval with the auth token
+			req := newLibp2pHttpRequest(srvHost, xfer.AuthToken)
+			of := getTempFilePath(t)
+			backoff := BackOffRetryOpt(tc.attemptRetryAfter, tc.attemptRetryAfter, 1, 5)
+			ht := New(clientHost, backoff)
+
+			// Listen for server events
+			srvEvts := make(chan types.TransferState, rawSize)
+			srv.Subscribe(func(sdbid uint, st types.TransferState) {
+				if dbid != sdbid {
+					return
+				}
+				srvEvts <- st
+				if st.Status == types.TransferStatusCompleted || st.Status == types.TransferStatusFailed {
+					close(srvEvts)
+				}
+			})
+
+			th := executeTransfer(t, ctx, ht, carSize, req, of)
+			require.NotNil(t, th)
+
+			// Wait for some data to be received by the client
+			clientSub := th.Sub()
+			evt := <-clientSub
+			require.NoError(t, evt.Error)
+
+			// Disconnect the connection
+			err = clientHost.Network().ClosePeer(srvHost.ID())
+			require.NoError(t, err)
+
+			// Wait for the transfer to complete or error out on the client
+			var lastClientEvt types.TransportEvent
+			for evt := range clientSub {
+				lastClientEvt = evt
+			}
+
+			// Wait for the transfer to complete or error out on the server
+			var lastSrvEvt types.TransferState
+			for evt := range srvEvts {
+				lastSrvEvt = evt
+			}
+
+			if expectTimeout {
+				// The client is configured to retry before the retry timeout
+				// expires, so expect the transfer to succeed
+				require.NoError(t, lastClientEvt.Error)
+				require.Equal(t, types.TransferStatusCompleted, lastSrvEvt.Status)
+			} else {
+				// The client is configured to retry after the retry timeout
+				// expires, so expect the transfer to fail.
+				require.Error(t, lastClientEvt.Error)
+				// Expect a 401 error to occur because the auth token gets
+				// deleted when the retry timeout expires.
+				require.Contains(t, lastClientEvt.Error.Error(), "401")
+				// Expect a failure event on the server
+				require.Equal(t, types.TransferStatusFailed, lastSrvEvt.Status)
+			}
+		})
+	}
+}
+
+func setupLibp2pHosts(t *testing.T) (host.Host, host.Host) {
+	m1, _ := multiaddr.NewMultiaddr("/ip4/127.0.0.1/tcp/0")
+	m2, _ := multiaddr.NewMultiaddr("/ip4/127.0.0.1/tcp/0")
+	srvHost := newHost(t, m1)
+	clientHost := newHost(t, m2)
+
+	srvHost.Peerstore().AddAddrs(clientHost.ID(), clientHost.Addrs(), peerstore.PermanentAddrTTL)
+	clientHost.Peerstore().AddAddrs(srvHost.ID(), srvHost.Addrs(), peerstore.PermanentAddrTTL)
+
+	return clientHost, srvHost
+}

--- a/transport/httptransport/util.go
+++ b/transport/httptransport/util.go
@@ -1,0 +1,84 @@
+package httptransport
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/multiformats/go-multiaddr"
+	mafmt "github.com/multiformats/go-multiaddr-fmt"
+	manet "github.com/multiformats/go-multiaddr/net"
+)
+
+type httpError struct {
+	error
+	code int
+}
+
+type transportUrl struct {
+	Scheme    string
+	URL       string
+	Host      string
+	PeerID    peer.ID
+	Multiaddr multiaddr.Multiaddr
+}
+
+func parseUrl(urlStr string) (*transportUrl, error) {
+	u, err := url.Parse(urlStr)
+	if err != nil {
+		return nil, err
+	}
+	if u.Scheme == libp2pScheme {
+		return parseLibp2pUrl(urlStr)
+	}
+	return &transportUrl{Scheme: u.Scheme, URL: urlStr}, nil
+}
+
+func parseLibp2pUrl(urlStr string) (*transportUrl, error) {
+	// Remove libp2p prefix
+	prefix := libp2pScheme + "://"
+	mastr := urlStr[len(prefix):]
+	addr, err := multiaddr.NewMultiaddr(mastr)
+	if err != nil {
+		return nil, fmt.Errorf("parsing '%s' as multiaddr: %w", mastr, err)
+	}
+
+	// Must have a P2P component so we can get the peer ID
+	httpAddr, last := multiaddr.SplitLast(addr)
+	if last.Protocol().Code != multiaddr.P_P2P {
+		return nil, fmt.Errorf("missing peerID in url '%s'", urlStr)
+	}
+	peerID := last.Value()
+
+	// If it's a DNS address like "/dnsaddr/bootstrap.libp2p.io"
+	if mafmt.DNS.Matches(httpAddr) {
+		// Get the host part of the address
+		host := ""
+		multiaddr.ForEach(httpAddr, func(c multiaddr.Component) bool {
+			host = c.Value()
+			return false
+		})
+
+		return &transportUrl{
+			Scheme:    libp2pScheme,
+			Host:      host,
+			URL:       libp2pScheme + "://" + peerID,
+			PeerID:    peer.ID(peerID),
+			Multiaddr: httpAddr,
+		}, nil
+	}
+
+	// Convert multi-address to HTTP url
+	netaddr, err := manet.ToNetAddr(httpAddr)
+	if err != nil {
+		return nil, fmt.Errorf("parsing '%s' as HTTP url: %w", httpAddr.String(), err)
+	}
+
+	return &transportUrl{
+		Scheme:    libp2pScheme,
+		Host:      netaddr.String(),
+		URL:       libp2pScheme + "://" + peerID,
+		PeerID:    peer.ID(peerID),
+		Multiaddr: httpAddr,
+	}, nil
+}

--- a/transport/httptransport/util_test.go
+++ b/transport/httptransport/util_test.go
@@ -1,0 +1,67 @@
+package httptransport
+
+import (
+	"testing"
+
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/multiformats/go-multiaddr"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseUrl(t *testing.T) {
+	tests := []struct {
+		name   string
+		url    string
+		expect *transportUrl
+	}{{
+		name: "http url",
+		url:  "http://www.test.com/path",
+		expect: &transportUrl{
+			URL:    "http://www.test.com/path",
+			Scheme: "http",
+		},
+	}, {
+		name: "https url",
+		url:  "https://www.test.com/path",
+		expect: &transportUrl{
+			URL:    "https://www.test.com/path",
+			Scheme: "https",
+		},
+	}, {
+		name: "ip4 libp2p url",
+		url:  "libp2p:///ip4/104.131.131.82/tcp/4001/ipfs/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ",
+		expect: &transportUrl{
+			Scheme:    libp2pScheme,
+			Host:      "104.131.131.82:4001",
+			URL:       libp2pScheme + "://QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ",
+			PeerID:    peer.ID("QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ"),
+			Multiaddr: MultiAddrMustParse(t, "/ip4/104.131.131.82/tcp/4001"),
+		},
+	}, {
+		name: "dns libp2p url",
+		url:  "libp2p:///dnsaddr/bootstrap.libp2p.io/ipfs/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb",
+		expect: &transportUrl{
+			Scheme:    libp2pScheme,
+			Host:      "bootstrap.libp2p.io",
+			URL:       libp2pScheme + "://QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb",
+			PeerID:    peer.ID("QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb"),
+			Multiaddr: MultiAddrMustParse(t, "/dnsaddr/bootstrap.libp2p.io"),
+		},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseUrl(tt.url)
+			require.NoError(t, err)
+			if tt.expect.Multiaddr != nil {
+				require.Equal(t, tt.expect.Multiaddr.String(), got.Multiaddr.String())
+			}
+			require.Equal(t, tt.expect, got)
+		})
+	}
+}
+
+func MultiAddrMustParse(t *testing.T, s string) multiaddr.Multiaddr {
+	ma, err := multiaddr.NewMultiaddr(s)
+	require.NoError(t, err)
+	return ma
+}

--- a/transport/httptransport/util_test.go
+++ b/transport/httptransport/util_test.go
@@ -10,57 +10,75 @@ import (
 
 func TestParseUrl(t *testing.T) {
 	tests := []struct {
-		name   string
-		url    string
-		expect *transportUrl
+		name        string
+		url         string
+		expect      *transportUrl
+		expectError bool
 	}{{
 		name: "http url",
 		url:  "http://www.test.com/path",
 		expect: &transportUrl{
-			URL:    "http://www.test.com/path",
-			Scheme: "http",
+			url:    "http://www.test.com/path",
+			scheme: "http",
 		},
 	}, {
 		name: "https url",
 		url:  "https://www.test.com/path",
 		expect: &transportUrl{
-			URL:    "https://www.test.com/path",
-			Scheme: "https",
+			url:    "https://www.test.com/path",
+			scheme: "https",
 		},
+	}, {
+		name:        "bad url",
+		url:         "badurl",
+		expectError: true,
 	}, {
 		name: "ip4 libp2p url",
 		url:  "libp2p:///ip4/104.131.131.82/tcp/4001/ipfs/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ",
 		expect: &transportUrl{
-			Scheme:    libp2pScheme,
-			Host:      "104.131.131.82:4001",
-			URL:       libp2pScheme + "://QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ",
-			PeerID:    peer.ID("QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ"),
-			Multiaddr: MultiAddrMustParse(t, "/ip4/104.131.131.82/tcp/4001"),
+			scheme:    libp2pScheme,
+			url:       libp2pScheme + "://QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ",
+			peerID:    peerMustDecode(t, "QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ"),
+			multiaddr: multiAddrMustParse(t, "/ip4/104.131.131.82/tcp/4001"),
 		},
 	}, {
 		name: "dns libp2p url",
 		url:  "libp2p:///dnsaddr/bootstrap.libp2p.io/ipfs/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb",
 		expect: &transportUrl{
-			Scheme:    libp2pScheme,
-			Host:      "bootstrap.libp2p.io",
-			URL:       libp2pScheme + "://QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb",
-			PeerID:    peer.ID("QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb"),
-			Multiaddr: MultiAddrMustParse(t, "/dnsaddr/bootstrap.libp2p.io"),
+			scheme:    libp2pScheme,
+			url:       libp2pScheme + "://QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb",
+			peerID:    peerMustDecode(t, "QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb"),
+			multiaddr: multiAddrMustParse(t, "/dnsaddr/bootstrap.libp2p.io"),
 		},
+	}, {
+		name:        "libp2p url no peer ID",
+		url:         "libp2p:///ip4/104.131.131.82/tcp/4001",
+		expectError: true,
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := parseUrl(tt.url)
-			require.NoError(t, err)
-			if tt.expect.Multiaddr != nil {
-				require.Equal(t, tt.expect.Multiaddr.String(), got.Multiaddr.String())
+			if tt.expectError {
+				require.Error(t, err)
+				return
+			} else {
+				require.NoError(t, err)
+			}
+			if tt.expect.multiaddr != nil {
+				require.Equal(t, tt.expect.multiaddr.String(), got.multiaddr.String())
 			}
 			require.Equal(t, tt.expect, got)
 		})
 	}
 }
 
-func MultiAddrMustParse(t *testing.T, s string) multiaddr.Multiaddr {
+func peerMustDecode(t *testing.T, s string) peer.ID {
+	pid, err := peer.Decode(s)
+	require.NoError(t, err)
+	return pid
+}
+
+func multiAddrMustParse(t *testing.T, s string) multiaddr.Multiaddr {
 	ma, err := multiaddr.NewMultiaddr(s)
 	require.NoError(t, err)
 	return ma

--- a/transport/types/types.go
+++ b/transport/types/types.go
@@ -4,8 +4,11 @@ import (
 	"github.com/google/uuid"
 )
 
+const DataTransferProtocol = "/fil/storage/transfer/1.0.0"
+
 type HttpRequest struct {
-	URL string
+	URL     string
+	Headers map[string]string
 }
 
 type TransportDealInfo struct {
@@ -17,4 +20,22 @@ type TransportDealInfo struct {
 type TransportEvent struct {
 	NBytesReceived int64
 	Error          error
+}
+
+type TransferStatus string
+
+const (
+	TransferStatusStarted   TransferStatus = "TransferStatusStarted"
+	TransferStatusOngoing   TransferStatus = "TransferStatusOngoing"
+	TransferStatusCompleted TransferStatus = "TransferStatusCompleted"
+	TransferStatusFailed    TransferStatus = "TransferStatusFailed"
+)
+
+type TransferState struct {
+	LocalAddr  string
+	RemoteAddr string
+	Status     TransferStatus
+	Sent       uint64
+	Received   uint64
+	Message    string
 }

--- a/transport/types/types.go
+++ b/transport/types/types.go
@@ -6,22 +6,34 @@ import (
 
 const DataTransferProtocol = "/fil/storage/transfer/1.0.0"
 
+// HttpRequest has parameters for an HTTP transfer
 type HttpRequest struct {
-	URL     string
+	// URL can be
+	// - an http URL:
+	//   "https://example.com/path"
+	// - a libp2p URL:
+	//   "libp2p:///ip4/104.131.131.82/tcp/4001/ipfs/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ"
+	//   Must include a Peer ID
+	URL string
+	// Headers are the HTTP headers that are sent as part of the request,
+	// eg "Authorization"
 	Headers map[string]string
 }
 
+// TransportDealInfo has parameters for a transfer to be executed
 type TransportDealInfo struct {
 	OutputFile string
 	DealUuid   uuid.UUID
 	DealSize   int64
 }
 
+// TransportEvent is fired as a transfer progresses
 type TransportEvent struct {
 	NBytesReceived int64
 	Error          error
 }
 
+// TransferStatus describes the status of a transfer (started, completed etc)
 type TransferStatus string
 
 const (
@@ -31,6 +43,7 @@ const (
 	TransferStatusFailed    TransferStatus = "TransferStatusFailed"
 )
 
+// TransferState describes a transfer's current state
 type TransferState struct {
 	LocalAddr  string
 	RemoteAddr string


### PR DESCRIPTION
```
=== RUN   TestBenchTransport
    bench_test.go:36: Benchmark file of size 1073741824 (1024.00 MB)
    bench_test.go:45: starting import
    bench_test.go:49: import took 3.198843181s
    bench_test.go:52: getting car file size
    bench_test.go:57: car size: 1073833069 bytes (1024.09 MB) - took 1.712249ms
--- PASS: TestBenchTransport (5.50s)
=== RUN   TestBenchTransport/http_over_libp2p
    bench_test.go:89: transfer of 1024.09 MB took 1.039332561s: 985.33 MB / s
    --- PASS: TestBenchTransport/http_over_libp2p (1.35s)
=== RUN   TestBenchTransport/raw_http
    bench_test.go:89: transfer of 1024.09 MB took 613.251281ms: 1669.93 MB / s
    --- PASS: TestBenchTransport/raw_http (0.94s)
PASS
```