### PR TITLE
Simplify car read seeker

### DIFF
--- a/car/car_reader_seeker.go
+++ b/car/car_reader_seeker.go
@@ -89,7 +89,7 @@ func (c *CarReaderSeeker) Cancel(ctx context.Context) error {
 	}
 
 	pw := c.writer.Load().(*io.PipeWriter)
-	pw.CloseWithError(context.Canceled)
+	pw.CloseWithError(context.Canceled) //nolint:errcheck
 
 	// Wait for the write to complete
 	select {

--- a/car/car_reader_seeker.go
+++ b/car/car_reader_seeker.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"sync"
+	"sync/atomic"
 )
 
 // CarReaderSeeker wraps CarOffsetWriter with a ReadSeeker implementation.
@@ -18,9 +18,8 @@ type CarReaderSeeker struct {
 	offset int64
 	cow    *CarOffsetWriter // 🐮
 
-	lk              sync.Mutex
 	reader          *io.PipeReader
-	writer          *io.PipeWriter
+	writer          atomic.Value
 	writeCompleteCh chan struct{}
 }
 
@@ -29,27 +28,25 @@ var _ io.ReadSeeker = (*CarReaderSeeker)(nil)
 func NewCarReaderSeeker(ctx context.Context, cow *CarOffsetWriter, size uint64) *CarReaderSeeker {
 	ctx, cancel := context.WithCancel(ctx)
 	return &CarReaderSeeker{
-		ctx:    ctx,
-		cancel: cancel,
-		size:   size,
-		cow:    cow,
+		ctx:             ctx,
+		cancel:          cancel,
+		size:            size,
+		cow:             cow,
+		writeCompleteCh: make(chan struct{}),
 	}
 }
 
-// Read reads data into the buffer. Not thread-safe to call concurrently with Seek.
+// Read reads data into the buffer.
+// Not thread-safe to call concurrently with Seek or another Read.
+// Thread-safe to call with Cancel.
 func (c *CarReaderSeeker) Read(p []byte) (int, error) {
-	c.lk.Lock()
-
 	// Check if the CarReadSeeker has been cancelled
 	if c.ctx.Err() != nil {
-		c.lk.Unlock()
 		return 0, c.ctx.Err()
 	}
 
 	// Check if the offset is at the end of the file
 	if uint64(c.offset) >= c.size {
-		defer c.lk.Unlock()
-
 		// If the offset is exactly at the end of the file just return EOF
 		if uint64(c.offset) == c.size {
 			return 0, io.EOF
@@ -59,39 +56,53 @@ func (c *CarReaderSeeker) Read(p []byte) (int, error) {
 	}
 
 	// Check if there's already a write in progress
-	if c.writeCompleteCh == nil {
+	if c.writer.Load() == nil {
 		// No write in progress, start a new write from the current offset
 		// in a go routine
-		c.writeCompleteCh = make(chan struct{})
-
 		pr, pw := io.Pipe()
 		c.reader = pr
-		c.writer = pw
+		c.writer.Store(pw)
 
 		offset := c.offset
 		go func() {
 			err := c.cow.Write(c.ctx, pw, uint64(offset))
 			pw.CloseWithError(err) //nolint:errcheck
-
-			c.lk.Lock()
-			defer c.lk.Unlock()
-
-			// Reset and close the write complete channel
-			writeCompleteCh := c.writeCompleteCh
-			c.writeCompleteCh = nil
-			close(writeCompleteCh)
+			close(c.writeCompleteCh)
 		}()
 	}
-
-	// Don't hold the lock while reading as Read may block
-	c.lk.Unlock()
 
 	count, err := c.reader.Read(p)
 	c.offset += int64(count)
 	return count, err
 }
 
-// Seek changes the offset into the stream. Not thread-safe to call concurrently with Read.
+// Cancel aborts any read operation: Once Cancel returns, all subsequent calls
+// to Read() will return context.Canceled
+// Thread-safe to call concurrently with Read.
+func (c *CarReaderSeeker) Cancel(ctx context.Context) error {
+	// Cancel the context
+	c.cancel()
+
+	// return if there is no write in progress
+	if c.writer.Load() == nil {
+		return nil
+	}
+
+	pw := c.writer.Load().(*io.PipeWriter)
+	pw.CloseWithError(context.Canceled)
+
+	// Wait for the write to complete
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-c.writeCompleteCh:
+	}
+	return nil
+}
+
+// Seek changes the offset into the stream.
+// Not thread-safe to call concurrently with Read, Cancel or another Seek.
+// Should only be called once in the beginning before any Read call.
 func (c *CarReaderSeeker) Seek(offset int64, whence int) (int64, error) {
 	// Update the offset
 	switch whence {
@@ -112,57 +123,5 @@ func (c *CarReaderSeeker) Seek(offset int64, whence int) (int64, error) {
 		c.offset = int64(c.size) + offset
 	}
 
-	c.lk.Lock()
-	if c.writeCompleteCh == nil {
-		// No ongoing write so we can return immediately
-		c.lk.Unlock()
-		return c.offset, nil
-	}
-
-	// There is an ongoing write, so close the pipe and wait for the write to
-	// complete before returning. This is so that subsequent reads will be from
-	// the updated offset.
-	// Note: Closing the reader will cause any subsequent reads / writes on
-	// that pipe to fail.
-	c.reader.Close() //nolint:errcheck
-
-	// Release the lock while waiting for write to complete
-	writeCompleteCh := c.writeCompleteCh
-	c.lk.Unlock()
-
-	select {
-	case <-c.ctx.Done():
-		return 0, c.ctx.Err()
-	case <-writeCompleteCh:
-	}
-
 	return c.offset, nil
-}
-
-// Cancel aborts any read operation: Once Cancel returns, all subsequent calls
-// to Read() will return context.Canceled
-func (c *CarReaderSeeker) Cancel(ctx context.Context) error {
-	c.lk.Lock()
-
-	// Cancel the context
-	c.cancel()
-
-	// Check if there's an ongoing write
-	writeCompleteCh := c.writeCompleteCh
-	if writeCompleteCh != nil {
-		// Close the writer. This will cause any subsequent reads to fail.
-		c.writer.CloseWithError(context.Canceled) //nolint:errcheck
-	}
-
-	c.lk.Unlock()
-
-	// Wait for the write to complete
-	if writeCompleteCh != nil {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-writeCompleteCh:
-		}
-	}
-	return nil
 }


### PR DESCRIPTION
Simplification is based on the following assumptions for our use case of Boost data-transfers 

- `Seek` will be called only once in the beginning of a transfer before any `Read` call and never again after that.
- `Read` will never be called concurrently with another `Read` or `Seek`.
- Once a transfer is cancelled or a `Read` call errors out, the `CarReadSeeker` will not be used again.
- We spin up one `CarReadSeeker` per http request to the server: