### PR TITLE
bench test car and transport

### DIFF
--- a/car/bench_test.go
+++ b/car/bench_test.go
@@ -1,0 +1,82 @@
+package car
+
+import (
+	"context"
+	"io"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/filecoin-project/boost/testutil"
+	"github.com/ipfs/go-blockservice"
+	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-datastore"
+	dssync "github.com/ipfs/go-datastore/sync"
+	bstore "github.com/ipfs/go-ipfs-blockstore"
+	"github.com/ipfs/go-merkledag"
+	"github.com/ipld/go-car"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBenchCarReaderSeeker(t *testing.T) {
+	ctx := context.Background()
+
+	rawSize := 1024 * 1024 * 1024
+	//rawSize := 2 * 1024 * 1024
+	t.Logf("Benchmark file of size %d (%.2f MB)", rawSize, float64(rawSize)/(1024*1024))
+
+	rseed := 5
+	source := io.LimitReader(rand.New(rand.NewSource(int64(rseed))), int64(rawSize))
+	ds := dssync.MutexWrap(datastore.NewMapDatastore())
+	bs := bstore.NewBlockstore(ds)
+	bserv := blockservice.New(bs, nil)
+	dserv := merkledag.NewDAGService(bserv)
+
+	t.Log("starting import")
+	importStart := time.Now()
+	nd, err := DAGImport(dserv, source)
+	require.NoError(t, err)
+	t.Logf("import took %s", time.Since(importStart))
+
+	// Get the size of the CAR file
+	t.Log("getting car file size")
+	carSizeStart := time.Now()
+	cw := &testutil.CountWriter{}
+	err = car.WriteCar(context.Background(), dserv, []cid.Cid{nd.Cid()}, cw)
+	require.NoError(t, err)
+	t.Logf("car size: %d bytes (%.2f MB) - took %s", cw.Total, float64(cw.Total)/(1024*1024), time.Since(carSizeStart))
+
+	// Just write to io.Discard
+	t.Run("car offset writer", func(t *testing.T) {
+		cow := NewCarOffsetWriter(nd.Cid(), bs, NewBlockInfoCache())
+		start := time.Now()
+		err := cow.Write(ctx, io.Discard, 0)
+		elapsed := time.Now().Sub(start)
+		require.NoError(t, err)
+		mbPerS := (float64(cw.Total) / (1024 * 1024)) / (float64(elapsed) / float64(time.Second))
+		t.Logf("write of %.2f MB took %s: %.2f MB / s", float64(cw.Total)/(1024*1024), elapsed, mbPerS)
+	})
+
+	// Read with CarReadSeeker
+	t.Run("car read seeker", func(t *testing.T) {
+		cow := NewCarOffsetWriter(nd.Cid(), bs, NewBlockInfoCache())
+		crs := NewCarReaderSeeker(ctx, cow, uint64(cw.Total))
+		buff := make([]byte, 100*1024*1024)
+		var totalRead int
+		start := time.Now()
+		for {
+			count, err := crs.Read(buff)
+			totalRead += count
+			if err != nil {
+				if err == io.EOF {
+					break
+				}
+				require.NoError(t, err)
+			}
+		}
+		elapsed := time.Now().Sub(start)
+		require.Equal(t, cw.Total, totalRead)
+		mbPerS := (float64(cw.Total) / (1024 * 1024)) / (float64(elapsed) / float64(time.Second))
+		t.Logf("read of %.2f MB took %s: %.2f MB / s", float64(cw.Total)/(1024*1024), elapsed, mbPerS)
+	})
+}

--- a/testutil/io.go
+++ b/testutil/io.go
@@ -1,0 +1,13 @@
+package testutil
+
+import "io/ioutil"
+
+type CountWriter struct {
+	Total int
+}
+
+func (cw *CountWriter) Write(p []byte) (int, error) {
+	n, err := ioutil.Discard.Write(p)
+	cw.Total += n
+	return n, err
+}

--- a/transport/httptransport/bench_test.go
+++ b/transport/httptransport/bench_test.go
@@ -1,0 +1,196 @@
+package httptransport
+
+import (
+	"context"
+	"io"
+	"math/rand"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/filecoin-project/boost/testutil"
+
+	"github.com/filecoin-project/boost/transport/types"
+	"github.com/ipfs/go-blockservice"
+	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-datastore"
+	dssync "github.com/ipfs/go-datastore/sync"
+	bstore "github.com/ipfs/go-ipfs-blockstore"
+	"github.com/ipfs/go-merkledag"
+	"github.com/ipld/go-car"
+	"github.com/libp2p/go-libp2p-core/host"
+	"github.com/stretchr/testify/require"
+)
+
+type testServer interface {
+	Request(authToken string) types.HttpRequest
+	Client() *httpTransport
+	Server() *Libp2pCarServer
+	Stop() error
+}
+
+func TestBenchTransport(t *testing.T) {
+	ctx := context.Background()
+
+	rawSize := 1024 * 1024 * 1024
+	//rawSize := 2 * 1024 * 1024
+	t.Logf("Benchmark file of size %d (%.2f MB)", rawSize, float64(rawSize)/(1024*1024))
+
+	rseed := 5
+	source := io.LimitReader(rand.New(rand.NewSource(int64(rseed))), int64(rawSize))
+	ds := dssync.MutexWrap(datastore.NewMapDatastore())
+	bs := bstore.NewBlockstore(ds)
+	bserv := blockservice.New(bs, nil)
+	dserv := merkledag.NewDAGService(bserv)
+
+	t.Log("starting import")
+	importStart := time.Now()
+	nd, err := DagImport(dserv, source)
+	require.NoError(t, err)
+	t.Logf("import took %s", time.Since(importStart))
+
+	// Get the size of the CAR file
+	t.Log("getting car file size")
+	carSizeStart := time.Now()
+	cw := &testutil.CountWriter{}
+	err = car.WriteCar(context.Background(), dserv, []cid.Cid{nd.Cid()}, cw)
+	require.NoError(t, err)
+	t.Logf("car size: %d bytes (%.2f MB) - took %s", cw.Total, float64(cw.Total)/(1024*1024), time.Since(carSizeStart))
+
+	performTransfer := func(t *testing.T, ts testServer, authDB *AuthTokenDB) {
+		defer ts.Stop() //nolint:errcheck
+
+		// Create an auth token
+		id := "1"
+		authToken, err := GenerateAuthToken()
+		require.NoError(t, err)
+		carSize := cw.Total
+		proposalCid, err := cid.Parse("bafkqaaa")
+		require.NoError(t, err)
+		err = authDB.Put(ctx, authToken, AuthValue{
+			ID:          id,
+			ProposalCid: proposalCid,
+			PayloadCid:  nd.Cid(),
+			Size:        uint64(carSize),
+		})
+		require.NoError(t, err)
+
+		// Perform retrieval with the auth token
+		req := ts.Request(authToken)
+		of := getTempFilePath(t)
+
+		xferStart := time.Now()
+		th := executeTransfer(t, ctx, ts.Client(), carSize, req, of)
+		require.NotNil(t, th)
+
+		// Wait for the transfer to complete
+		clientEvts := waitForTransferComplete(th)
+		end := time.Now()
+
+		require.NotEmpty(t, clientEvts)
+		lastClientEvt := clientEvts[len(clientEvts)-1]
+		require.EqualValues(t, carSize, lastClientEvt.NBytesReceived)
+
+		xferTime := end.Sub(xferStart)
+		mbPerS := (float64(cw.Total) / (1024 * 1024)) / (float64(xferTime) / float64(time.Second))
+		t.Logf("transfer of %.2f MB took %s: %.2f MB / s", float64(cw.Total)/(1024*1024), xferTime, mbPerS)
+	}
+
+	t.Run("http over libp2p", func(t *testing.T) {
+		clientHost, srvHost := setupLibp2pHosts(t)
+		defer srvHost.Close()
+		defer clientHost.Close()
+
+		authDB := NewAuthTokenDB(ds)
+		srv := NewLibp2pCarServer(srvHost, authDB, bs, ServerConfig{
+			AnnounceAddr: srvHost.Addrs()[0],
+		})
+		err = srv.Start(ctx)
+		require.NoError(t, err)
+
+		bsrv := &benchLibp2pHttpServer{
+			srvHost:    srvHost,
+			clientHost: clientHost,
+			srv:        srv,
+		}
+
+		performTransfer(t, bsrv, authDB)
+	})
+
+	t.Run("raw http", func(t *testing.T) {
+		clientHost, srvHost := setupLibp2pHosts(t)
+		defer srvHost.Close()
+		defer clientHost.Close()
+
+		authDB := NewAuthTokenDB(ds)
+		srv := NewLibp2pCarServer(srvHost, authDB, bs, ServerConfig{
+			AnnounceAddr: srvHost.Addrs()[0],
+		})
+		srv.transfersMgr.start(ctx)
+
+		http.HandleFunc("/", srv.handler)
+		listenAddr := "127.0.0.1:8080"
+		go func() {
+			_ = http.ListenAndServe(listenAddr, nil)
+		}()
+
+		bsrv := &benchRawHttpServer{
+			srvHost:    srvHost,
+			clientHost: clientHost,
+			srv:        srv,
+			listenAddr: listenAddr,
+		}
+
+		performTransfer(t, bsrv, authDB)
+	})
+}
+
+type benchRawHttpServer struct {
+	srvHost    host.Host
+	clientHost host.Host
+	srv        *Libp2pCarServer
+	listenAddr string
+}
+
+func (s *benchRawHttpServer) Request(authToken string) types.HttpRequest {
+	return types.HttpRequest{
+		URL: "http://" + s.listenAddr,
+		Headers: map[string]string{
+			"Authorization": BasicAuthHeader("", authToken),
+		},
+	}
+}
+
+func (s *benchRawHttpServer) Client() *httpTransport {
+	return New(nil)
+}
+
+func (s *benchRawHttpServer) Server() *Libp2pCarServer {
+	return s.srv
+}
+
+func (s *benchRawHttpServer) Stop() error {
+	return nil
+}
+
+type benchLibp2pHttpServer struct {
+	srvHost    host.Host
+	clientHost host.Host
+	srv        *Libp2pCarServer
+}
+
+func (s *benchLibp2pHttpServer) Request(authToken string) types.HttpRequest {
+	return newLibp2pHttpRequest(s.srvHost, authToken)
+}
+
+func (s *benchLibp2pHttpServer) Client() *httpTransport {
+	return New(s.clientHost)
+}
+
+func (s *benchLibp2pHttpServer) Server() *Libp2pCarServer {
+	return s.srv
+}
+
+func (s *benchLibp2pHttpServer) Stop() error {
+	return s.srv.Stop(context.Background())
+}

--- a/transport/httptransport/http_transport_test.go
+++ b/transport/httptransport/http_transport_test.go
@@ -71,7 +71,7 @@ func newServerTest(t *testing.T, size int) *serverTest {
 	dserv := merkledag.NewDAGService(bserv)
 	source := bytes.NewBuffer(data)
 
-	nd, err := dagImport(dserv, source)
+	nd, err := DagImport(dserv, source)
 	require.NoError(t, err)
 
 	var buff bytes.Buffer
@@ -498,7 +498,7 @@ func newLibp2pHttpServer(st *serverTest) (func() types.HttpRequest, func(), host
 
 var defaultHashFunction = uint64(multihash.SHA2_256)
 
-func dagImport(dserv format.DAGService, fi io.Reader) (format.Node, error) {
+func DagImport(dserv format.DAGService, fi io.Reader) (format.Node, error) {
 	prefix, err := merkledag.PrefixForCidVersion(1)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
```
=== RUN   TestBenchCarReaderSeeker
    bench_test.go:26: Benchmark file of size 1073741824 (1024.00 MB)
    bench_test.go:35: starting import
    bench_test.go:39: import took 3.290636696s
    bench_test.go:42: getting car file size
    bench_test.go:47: car size: 1073833069 bytes (1024.09 MB) - took 2.074927ms
--- PASS: TestBenchCarReaderSeeker (3.43s)
=== RUN   TestBenchCarReaderSeeker/car_offset_writer
    bench_test.go:57: write of 1024.09 MB took 3.448297ms: 296983.41 MB / s
    --- PASS: TestBenchCarReaderSeeker/car_offset_writer (0.00s)
=== RUN   TestBenchCarReaderSeeker/car_read_seeker
    bench_test.go:80: read of 1024.09 MB took 130.172526ms: 7867.15 MB / s
    --- PASS: TestBenchCarReaderSeeker/car_read_seeker (0.13s)
PASS
```