### PR TITLE
Fix flaky TestDealFailuresHandlingNonRecoverableErrors

### DIFF
--- a/storagemarket/provider_test.go
+++ b/storagemarket/provider_test.go
@@ -270,7 +270,7 @@ func TestDealFailuresHandlingNonRecoverableErrors(t *testing.T) {
 	}{
 		{
 			dealBuilder: func() *testDeal {
-				return harness.newDealBuilder(t, 1).withDisconnectingHttpServer().build()
+				return harness.newDealBuilder(t, 1).withFailingHttpServer().build()
 			},
 			errContains: "failed data transfer",
 		},
@@ -478,6 +478,7 @@ type ProviderHarness struct {
 	NormalServer        *httptest.Server
 	BlockingServer      *testutil.BlockingHttpTestServer
 	DisconnectingServer *httptest.Server
+	FailingServer       *httptest.Server
 }
 
 type providerConfig struct {
@@ -564,6 +565,7 @@ func NewHarness(t *testing.T, ctx context.Context, opts ...harnessOpt) *Provider
 	normalServer := testutil.HttpTestUnstartedFileServer(t, dir)
 	blockingServer := testutil.NewBlockingHttpTestServer(t, dir)
 	disconnServer := testutil.HttpTestDisconnectingServer(t, dir, pc.disconnectAfterEvery)
+	failingServer := testutil.HttpTestUnstartedFailingServer(t)
 
 	// create a provider libp2p peer
 	mn := mocknet.New(ctx)
@@ -589,6 +591,7 @@ func NewHarness(t *testing.T, ctx context.Context, opts ...harnessOpt) *Provider
 		NormalServer:        normalServer,
 		BlockingServer:      blockingServer,
 		DisconnectingServer: disconnServer,
+		FailingServer:       failingServer,
 
 		MockFullNode:           fn,
 		MockSealingPipelineAPI: sps,
@@ -675,10 +678,12 @@ func (h *ProviderHarness) Start(t *testing.T, ctx context.Context) {
 	h.NormalServer.Start()
 	h.BlockingServer.Start()
 	h.DisconnectingServer.Start()
+	h.FailingServer.Start()
 	require.NoError(t, h.Provider.Start(ctx))
 }
 
 func (h *ProviderHarness) Stop() {
+	h.FailingServer.Close()
 	h.NormalServer.Close()
 	h.BlockingServer.Close()
 	h.DisconnectingServer.Close()
@@ -848,6 +853,11 @@ func (tbuilder *testDealBuilder) withAllMinerCallsBlocking() *testDealBuilder {
 	tbuilder.msPublishConfirm = &minerStubCall{blocking: true}
 	tbuilder.msAddPiece = &minerStubCall{blocking: true}
 
+	return tbuilder
+}
+
+func (tbuilder *testDealBuilder) withFailingHttpServer() *testDealBuilder {
+	tbuilder.setTransferParams(tbuilder.td.ph.FailingServer.URL)
 	return tbuilder
 }
 

--- a/testutil/httptestfileservers.go
+++ b/testutil/httptestfileservers.go
@@ -26,7 +26,6 @@ func HttpTestFileServer(t *testing.T, dir string) (*httptest.Server, error) {
 func HttpTestUnstartedFailingServer(t *testing.T) *httptest.Server {
 	svr := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(401)
-		return
 	}))
 	return svr
 }

--- a/testutil/httptestfileservers.go
+++ b/testutil/httptestfileservers.go
@@ -23,6 +23,14 @@ func HttpTestFileServer(t *testing.T, dir string) (*httptest.Server, error) {
 	return svr, nil
 }
 
+func HttpTestUnstartedFailingServer(t *testing.T) *httptest.Server {
+	svr := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(401)
+		return
+	}))
+	return svr
+}
+
 // HttpTestUnstartedFileServer returns a http server that serves files from the given directory
 func HttpTestUnstartedFileServer(t *testing.T, dir string) *httptest.Server {
 	handler := http.FileServer(http.Dir(dir))


### PR DESCRIPTION
There was a race where even a disconnecting server could lead to a successful transfer.