### PR TITLE
Resume publish confirmation

### DIFF
--- a/storagemarket/deal_execution.go
+++ b/storagemarket/deal_execution.go
@@ -378,7 +378,7 @@ func (p *Provider) publishDeal(ctx context.Context, pub event.Emitter, deal *typ
 	// may be for a batch of deals.
 	p.dealLogger.Infow(deal.DealUuid, "awaiting deal publish confirmation")
 	res, err := p.chainDealManager.WaitForPublishDeals(p.ctx, *deal.PublishCID, deal.ClientDealProposal.Proposal)
-	if err != nil && p.ctx.Err() != nil {
+	if err != nil && ctx.Err() != nil {
 		p.dealLogger.Warnw(deal.DealUuid, "context timed out while waiting for publish confirmation")
 		return fmt.Errorf("wait for publish confirmation failed: %w", ctx.Err())
 	}

--- a/storagemarket/deal_execution.go
+++ b/storagemarket/deal_execution.go
@@ -362,7 +362,7 @@ func (p *Provider) publishDeal(ctx context.Context, pub event.Emitter, deal *typ
 		mcid, err := p.dealPublisher.Publish(p.ctx, deal.DealUuid, deal.ClientDealProposal)
 		if err != nil && ctx.Err() != nil {
 			p.dealLogger.Warnw(deal.DealUuid, "context timed out while waiting for publish")
-			return fmt.Errorf("publish failed: %w", ctx.Err())
+			return fmt.Errorf("publish did not complete: boost shutdown")
 		}
 
 		if err != nil {
@@ -385,7 +385,7 @@ func (p *Provider) publishDeal(ctx context.Context, pub event.Emitter, deal *typ
 	res, err := p.chainDealManager.WaitForPublishDeals(p.ctx, *deal.PublishCID, deal.ClientDealProposal.Proposal)
 
 	// The `WaitForPublishDeals` call above is a remote RPC call to the full node
-	// and if it fails because of a context cancellation, the error we get back dosen't
+	// and if it fails because of a context cancellation, the error we get back doesn't
 	// unwrap into a context cancelled error because of how error handling is implemented in the RPC layer.
 	// The below check is a work around for that.
 	if err != nil && ctx.Err() != nil {

--- a/storagemarket/deal_execution.go
+++ b/storagemarket/deal_execution.go
@@ -390,7 +390,7 @@ func (p *Provider) publishDeal(ctx context.Context, pub event.Emitter, deal *typ
 	// The below check is a work around for that.
 	if err != nil && ctx.Err() != nil {
 		p.dealLogger.Warnw(deal.DealUuid, "context timed out while waiting for publish confirmation")
-		return fmt.Errorf("wait for publish confirmation failed: %w", ctx.Err())
+		return fmt.Errorf("wait for publish confirmation did not complete: boost shutdown")
 	}
 	if err != nil {
 		p.dealLogger.LogError(deal.DealUuid, "error while waiting for publish confirm", err)

--- a/storagemarket/deal_execution.go
+++ b/storagemarket/deal_execution.go
@@ -383,6 +383,7 @@ func (p *Provider) publishDeal(ctx context.Context, pub event.Emitter, deal *typ
 		return err
 	}
 	if err != nil {
+		p.dealLogger.LogError(deal.DealUuid, "error while waiting for publish confirm", err)
 		return fmt.Errorf("wait for publish message %s failed: %w", deal.PublishCID, err)
 	}
 	p.dealLogger.Infow(deal.DealUuid, "successfully finished deal publish confirmation")

--- a/storagemarket/provider_test.go
+++ b/storagemarket/provider_test.go
@@ -230,7 +230,7 @@ func TestDealsRejectedForFunds(t *testing.T) {
 	var successTds []*testDeal
 
 	for i := 0; i < nDeals; i++ {
-		td := harness.newDealBuilder(t, i).withBlockingHttpServer().build()
+		td := harness.newDealBuilder(t, i).withNoOpMinerStub().withBlockingHttpServer().build()
 		errg.Go(func() error {
 			if err := td.execute(); err != nil {
 				// deal should be rejected only for lack of funds

--- a/storagemarket/provider_test.go
+++ b/storagemarket/provider_test.go
@@ -230,10 +230,9 @@ func TestDealsRejectedForFunds(t *testing.T) {
 	var successTds []*testDeal
 
 	for i := 0; i < nDeals; i++ {
-		td := harness.newDealBuilder(t, i).withNoOpMinerStub().withBlockingHttpServer().build()
-
+		td := harness.newDealBuilder(t, i).withBlockingHttpServer().build()
 		errg.Go(func() error {
-			if err := td.executeAndSubscribeToNotifs(); err != nil {
+			if err := td.execute(); err != nil {
 				// deal should be rejected only for lack of funds
 				if !strings.Contains(err.Error(), "available funds") {
 					return errors.New("did not get expected error")
@@ -247,6 +246,7 @@ func TestDealsRejectedForFunds(t *testing.T) {
 				successTds = append(successTds, td)
 				mu.Unlock()
 			}
+
 			return nil
 		})
 	}
@@ -255,6 +255,11 @@ func TestDealsRejectedForFunds(t *testing.T) {
 	require.Len(t, successTds, 10)
 	require.Len(t, failedTds, 5)
 
+	// cancel all transfers so all deals finish and db files can be deleted
+	for i := range successTds {
+		td := successTds[i]
+		require.NoError(t, harness.Provider.CancelDealDataTransfer(td.params.DealUUID))
+	}
 }
 
 func TestDealFailuresHandlingNonRecoverableErrors(t *testing.T) {


### PR DESCRIPTION
For some reason, the Miner API's error isn't unwrapping as a context cancellation so need to do this.
Also fixes the flaky deal funds test by ensuring the deals terminate so db files can be cleanedup.