### PR TITLE
Dont over-write log level set by env vars

### DIFF
--- a/cmd/boost/main.go
+++ b/cmd/boost/main.go
@@ -17,8 +17,6 @@ const (
 )
 
 func main() {
-	_ = logging.SetLogLevel("*", "INFO")
-
 	app := &cli.App{
 		Name:                 "boost",
 		Usage:                "Markets V2 module for Filecoin",


### PR DESCRIPTION
If we don't over-write the setting it allows us to set the log level via env vars, eg:
```
GOLOG_LOG_LEVEL=info,connmgr=warn,net/identify=warn,dht/RtRefreshManager=warn boost run
```