### PR TITLE
Dagstore Shard migration for Boost deals

### DIFF
--- a/api/market.go
+++ b/api/market.go
@@ -21,10 +21,12 @@ import (
 type Market interface {
 	// MethodGroup: Market
 
-	MarketDummyDeal(context.Context, smtypes.DealParams) (*ProviderDealRejectionInfo, error)         //perm:admin
-	Deal(ctx context.Context, dealUuid uuid.UUID) (*smtypes.ProviderDealState, error)                //perm:admin
-	IndexerAnnounceAllDeals(ctx context.Context) error                                               //perm:admin
-	MakeOfflineDealWithData(dealUuid uuid.UUID, filePath string) (*ProviderDealRejectionInfo, error) //perm:admin
+	MarketDummyDeal(context.Context, smtypes.DealParams) (*ProviderDealRejectionInfo, error)                                  //perm:admin
+	Deal(ctx context.Context, dealUuid uuid.UUID) (*smtypes.ProviderDealState, error)                                         //perm:admin
+	IndexerAnnounceAllDeals(ctx context.Context) error                                                                        //perm:admin
+	MakeOfflineDealWithData(dealUuid uuid.UUID, filePath string) (*ProviderDealRejectionInfo, error)                          //perm:admin
+	DagstoreInitializeShard(ctx context.Context, key string) error                                                            //perm:admin
+	DagstoreInitializeAll(ctx context.Context, params DagstoreInitializeAllParams) (<-chan DagstoreInitializeAllEvent, error) //perm:admin
 }
 
 // ProviderDealRejectionInfo is the information sent by the Storage Provider

--- a/api/proxy_gen.go
+++ b/api/proxy_gen.go
@@ -134,6 +134,10 @@ type CommonNetStub struct {
 
 type MarketStruct struct {
 	Internal struct {
+		DagstoreInitializeAll func(p0 context.Context, p1 DagstoreInitializeAllParams) (<-chan DagstoreInitializeAllEvent, error) `perm:"admin"`
+
+		DagstoreInitializeShard func(p0 context.Context, p1 string) error `perm:"admin"`
+
 		Deal func(p0 context.Context, p1 uuid.UUID) (*smtypes.ProviderDealState, error) `perm:"admin"`
 
 		IndexerAnnounceAllDeals func(p0 context.Context) error `perm:"admin"`
@@ -513,6 +517,28 @@ func (s *CommonStruct) LogSetLevel(p0 context.Context, p1 string, p2 string) err
 }
 
 func (s *CommonStub) LogSetLevel(p0 context.Context, p1 string, p2 string) error {
+	return ErrNotSupported
+}
+
+func (s *MarketStruct) DagstoreInitializeAll(p0 context.Context, p1 DagstoreInitializeAllParams) (<-chan DagstoreInitializeAllEvent, error) {
+	if s.Internal.DagstoreInitializeAll == nil {
+		return nil, ErrNotSupported
+	}
+	return s.Internal.DagstoreInitializeAll(p0, p1)
+}
+
+func (s *MarketStub) DagstoreInitializeAll(p0 context.Context, p1 DagstoreInitializeAllParams) (<-chan DagstoreInitializeAllEvent, error) {
+	return nil, ErrNotSupported
+}
+
+func (s *MarketStruct) DagstoreInitializeShard(p0 context.Context, p1 string) error {
+	if s.Internal.DagstoreInitializeShard == nil {
+		return ErrNotSupported
+	}
+	return s.Internal.DagstoreInitializeShard(p0, p1)
+}
+
+func (s *MarketStub) DagstoreInitializeShard(p0 context.Context, p1 string) error {
 	return ErrNotSupported
 }
 

--- a/cmd/boostd/dagstore.go
+++ b/cmd/boostd/dagstore.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/fatih/color"
+	bapi "github.com/filecoin-project/boost/api"
+	bcli "github.com/filecoin-project/boost/cli"
+	lcli "github.com/filecoin-project/lotus/cli"
+	"github.com/urfave/cli/v2"
+)
+
+var dagstoreCmd = &cli.Command{
+	Name:  "dagstore",
+	Usage: "Manage the dagstore on the markets subsystem",
+	Subcommands: []*cli.Command{
+		dagstoreInitializeShardCmd,
+		dagstoreInitializeAllCmd,
+	},
+}
+
+var dagstoreInitializeShardCmd = &cli.Command{
+	Name:      "initialize-shard",
+	ArgsUsage: "[key]",
+	Usage:     "Initialize the specified shard",
+	Flags:     []cli.Flag{},
+	Action: func(cctx *cli.Context) error {
+
+		if cctx.NArg() != 1 {
+			return fmt.Errorf("must provide a single shard key")
+		}
+
+		marketsApi, closer, err := lcli.GetMarketsAPI(cctx)
+		if err != nil {
+			return err
+		}
+		defer closer()
+
+		ctx := lcli.ReqContext(cctx)
+
+		return marketsApi.DagstoreInitializeShard(ctx, cctx.Args().First())
+	},
+}
+
+var dagstoreInitializeAllCmd = &cli.Command{
+	Name:  "initialize-all",
+	Usage: "Initialize all uninitialized shards, streaming results as they're produced; only shards for unsealed pieces are initialized by default",
+	Flags: []cli.Flag{
+		&cli.UintFlag{
+			Name:     "concurrency",
+			Usage:    "maximum shards to initialize concurrently at a time; use 0 for unlimited",
+			Required: true,
+		},
+		&cli.BoolFlag{
+			Name:  "include-sealed",
+			Usage: "initialize sealed pieces as well",
+		},
+	},
+	Action: func(cctx *cli.Context) error {
+		concurrency := cctx.Uint("concurrency")
+		sealed := cctx.Bool("sealed")
+
+		ctx := lcli.ReqContext(cctx)
+
+		// announce markets and boost deals
+		napi, closer, err := bcli.GetBoostAPI(cctx)
+		if err != nil {
+			return err
+		}
+		defer closer()
+
+		params := bapi.DagstoreInitializeAllParams{
+			MaxConcurrency: int(concurrency),
+			IncludeSealed:  sealed,
+		}
+
+		ch, err := napi.DagstoreInitializeAll(ctx, params)
+		if err != nil {
+			return err
+		}
+
+		for {
+			select {
+			case evt, ok := <-ch:
+				if !ok {
+					return nil
+				}
+				_, _ = fmt.Fprint(os.Stdout, color.New(color.BgHiBlack).Sprintf("(%d/%d)", evt.Current, evt.Total))
+				_, _ = fmt.Fprint(os.Stdout, " ")
+				if evt.Event == "start" {
+					_, _ = fmt.Fprintln(os.Stdout, evt.Key, color.New(color.Reset).Sprint("STARTING"))
+				} else {
+					if evt.Success {
+						_, _ = fmt.Fprintln(os.Stdout, evt.Key, color.New(color.FgGreen).Sprint("SUCCESS"))
+					} else {
+						_, _ = fmt.Fprintln(os.Stdout, evt.Key, color.New(color.FgRed).Sprint("ERROR"), evt.Error)
+					}
+				}
+
+			case <-ctx.Done():
+				return fmt.Errorf("aborted")
+			}
+		}
+	},
+}

--- a/cmd/boostd/index.go
+++ b/cmd/boostd/index.go
@@ -17,8 +17,7 @@ var indexProvCmd = &cli.Command{
 var indexProvAnnounceAllCmd = &cli.Command{
 	Name:  "announce-all",
 	Usage: "Announce all active deals to indexers so they can download the indices",
-	Flags: []cli.Flag{
-	},
+	Flags: []cli.Flag{},
 	Action: func(cctx *cli.Context) error {
 		ctx := lcli.ReqContext(cctx)
 

--- a/cmd/boostd/main.go
+++ b/cmd/boostd/main.go
@@ -62,6 +62,8 @@ func before(cctx *cli.Context) error {
 		_ = logging.SetLogLevel("gql", "DEBUG")
 		_ = logging.SetLogLevel("boost-provider", "DEBUG")
 		_ = logging.SetLogLevel("storagemanager", "DEBUG")
+		_ = logging.SetLogLevel("index-provider-wrapper", "DEBUG")
+		_ = logging.SetLogLevel("boost-migrator", "DEBUG")
 	}
 
 	return nil

--- a/cmd/boostd/main.go
+++ b/cmd/boostd/main.go
@@ -64,6 +64,9 @@ func before(cctx *cli.Context) error {
 		_ = logging.SetLogLevel("storagemanager", "DEBUG")
 		_ = logging.SetLogLevel("index-provider-wrapper", "DEBUG")
 		_ = logging.SetLogLevel("boost-migrator", "DEBUG")
+		_ = logging.SetLogLevel("dagstore", "DEBUG")
+		_ = logging.SetLogLevel("storagemarket_impl", "DEBUG")
+		_ = logging.SetLogLevel("migrator", "DEBUG")
 	}
 
 	return nil

--- a/cmd/boostd/main.go
+++ b/cmd/boostd/main.go
@@ -43,6 +43,7 @@ func main() {
 			indexProvCmd,
 			offlineDealCmd,
 			logCmd,
+			dagstoreCmd,
 		},
 	}
 	app.Setup()

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/docker/go-units v0.4.0
 	github.com/dustin/go-humanize v1.0.0
+	github.com/fatih/color v1.13.0
 	github.com/filecoin-project/dagstore v0.5.2
 	github.com/filecoin-project/go-address v0.0.6
 	github.com/filecoin-project/go-bitfield v0.2.4

--- a/indexprovider/wrapper.go
+++ b/indexprovider/wrapper.go
@@ -176,6 +176,7 @@ func (w *Wrapper) DagstoreReinitBoostDeals(ctx context.Context) (bool, error) {
 	}
 
 	log := log.Named("boost-migrator")
+	log.Infof("dagstore root is %s", w.cfg.RootDir)
 
 	// Check if all deals have already been registered as shards
 	isComplete, err := w.boostRegistrationComplete()

--- a/node/builder.go
+++ b/node/builder.go
@@ -146,6 +146,7 @@ const (
 	// boost -> should be started after markets
 	HandleBoostDealsKey
 
+	// index-provider should be started after Boost
 	HandleIndexProviderKey
 
 	// daemon
@@ -435,7 +436,7 @@ func ConfigBoost(c interface{}) Option {
 		// Sealing Pipeline State API
 		Override(new(sealingpipeline.API), From(new(lotus_modules.MinerStorageService))),
 
-		Override(new(*indexprovider.Wrapper), indexprovider.NewWrapper),
+		Override(new(*indexprovider.Wrapper), indexprovider.NewWrapper(cfg.DAGStore)),
 
 		Override(new(*storagemarket.Provider), modules.NewStorageMarketProvider(walletMiner)),
 

--- a/node/modules/storageminer.go
+++ b/node/modules/storageminer.go
@@ -487,7 +487,7 @@ func HandleBoostDeals(lc fx.Lifecycle, h host.Host, prov *storagemarket.Provider
 func HandleIndexProvider(lc fx.Lifecycle, prov *indexprovider.Wrapper) {
 	lc.Append(fx.Hook{
 		OnStart: func(ctx context.Context) error {
-			prov.Start()
+			prov.Start(ctx)
 			return nil
 		},
 		OnStop: func(ctx context.Context) error {

--- a/storagemarket/provider_loop.go
+++ b/storagemarket/provider_loop.go
@@ -37,7 +37,6 @@ type publishDealReq struct {
 	done chan struct{}
 }
 
-
 type storageSpaceDealReq struct {
 	deal *types.ProviderDealState
 	done chan struct{}
@@ -137,8 +136,7 @@ func (p *Provider) processOfflineDealRequest(deal *types.ProviderDealState) (boo
 		if errf != nil && !xerrors.Is(errf, db.ErrNotFound) {
 			p.dealLogger.LogError(deal.DealUuid, "failed to untag funds during deal cleanup", errf)
 		} else if errf == nil {
-			p.dealLogger.Infow(deal.DealUuid, "untagged funds for deal cleanup", "untagged publish", pub, "untagged collateral", collat,
-				)
+			p.dealLogger.Infow(deal.DealUuid, "untagged funds for deal cleanup", "untagged publish", pub, "untagged collateral", collat)
 		}
 	}
 

--- a/storagemarket/provider_test.go
+++ b/storagemarket/provider_test.go
@@ -1170,6 +1170,6 @@ func (n *NoOpIndexProvider) AnnounceBoostDeal(ctx context.Context, pds *types.Pr
 	return testutil.GenerateCid(), nil
 }
 
-func (n *NoOpIndexProvider) Start() {
+func (n *NoOpIndexProvider) Start(_ context.Context) {
 
 }

--- a/storagemarket/types/types.go
+++ b/storagemarket/types/types.go
@@ -111,5 +111,5 @@ type ChainDealManager interface {
 
 type IndexProvider interface {
 	AnnounceBoostDeal(ctx context.Context, pds *ProviderDealState) (cid.Cid, error)
-	Start()
+	Start(ctx context.Context)
 }


### PR DESCRIPTION
- Starting legacy markets will take care of marking legacy deals for dagstore migration.

### TODO
- [x] CLI command to reinit all dagstore shards (copy over `lotus dagstore initialize-all`)
- [ ] Test on Sofia Miner.