### PR TITLE
make react

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,7 @@ jobs:
       - run: sudo apt-get update
       - run: sudo apt-get install npm
       - run:
-          command: make buildall
+          command: make build-go
       - store_artifacts:
           path: boost
       - run: mkdir linux && mv boost linux/

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,12 @@ devnet: $(BUILD_DEPS)
 .PHONY: devnet
 BINS+=devnet
 
-build: boost devnet
+react:
+	npm install --prefix react
+	npm run --prefix react build
+.PHONY: react
+
+build: boost devnet react
 .PHONY: build
 
 install: install-boost install-devnet

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ build/.update-modules:
 CLEAN+=build/.update-modules
 
 debug: GOFLAGS+=-tags=debug
-debug: build
+debug: build-go
 
 deps: $(BUILD_DEPS)
 .PHONY: deps
@@ -86,7 +86,10 @@ react:
 	npm run --prefix react build
 .PHONY: react
 
-build: boost devnet react
+build-go: boost devnet
+.PHONY: build-go
+
+build: build-go react
 .PHONY: build
 
 install: install-boost install-devnet


### PR DESCRIPTION
This PR adds the following targets to Makefile:
- `make react` - Building all React source
- `make build` - React target is now part of `make build`