### PR TITLE
Send output of boostd init and boostd migrate to stdout instead of log file

### DIFF
--- a/cmd/boostd/main.go
+++ b/cmd/boostd/main.go
@@ -49,7 +49,7 @@ func main() {
 	app.Setup()
 
 	if err := app.Run(os.Args); err != nil {
-		log.Fatal(err)
+		os.Stderr.WriteString("Error: " + err.Error() + "\n")
 	}
 }
 


### PR DESCRIPTION
Also output a nicer error message if a required environment variable is not set:
```
$ ./boostd -vv init --api-sealer=$MINER_API_INFO --api-sector-index=$MINER_API_INFO --wallet-publish-storage-deals=$PUBMSG_WALLET --wallet-collateral-pledge=$COLLAT_WALLET --max-staging-deals-bytes=2000000000
Initializing boost repo
Trying to connect to full node RPC
Error: could not get API info for StorageMiner: could not determine API endpoint for node type: StorageMiner
Do you need to set the environment variable MINER_API_INFO?
```