### PR TITLE
timeout of 5sec. for datatransfer.Manager.Stop()

### DIFF
--- a/node/builder.go
+++ b/node/builder.go
@@ -480,7 +480,7 @@ func ConfigBoost(c interface{}) Option {
 		// Lotus Markets (storage)
 		Override(new(lotus_dtypes.ProviderTransferNetwork), lotus_modules.NewProviderTransferNetwork),
 		Override(new(lotus_dtypes.ProviderTransport), lotus_modules.NewProviderTransport),
-		Override(new(lotus_dtypes.ProviderDataTransfer), lotus_modules.NewProviderDataTransfer),
+		Override(new(lotus_dtypes.ProviderDataTransfer), modules.NewProviderDataTransfer),
 		Override(new(*storedask.StoredAsk), lotus_modules.NewStorageAsk),
 
 		Override(new(lotus_storagemarket.StorageProviderNode), lotus_storageadapter.NewProviderNodeAdapter(&cfg.LotusFees, &cfg.LotusDealmaking)),

--- a/node/modules/provider_data_transfer.go
+++ b/node/modules/provider_data_transfer.go
@@ -1,0 +1,48 @@
+package modules
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	dtimpl "github.com/filecoin-project/go-data-transfer/impl"
+	marketevents "github.com/filecoin-project/lotus/markets/loggers"
+	"github.com/filecoin-project/lotus/node/modules/dtypes"
+	"github.com/filecoin-project/lotus/node/repo"
+	"github.com/ipfs/go-datastore"
+	"github.com/ipfs/go-datastore/namespace"
+	"go.uber.org/fx"
+)
+
+// NewProviderDataTransfer returns a data transfer manager
+func NewProviderDataTransfer(lc fx.Lifecycle, net dtypes.ProviderTransferNetwork, transport dtypes.ProviderTransport, ds dtypes.MetadataDS, r repo.LockedRepo) (dtypes.ProviderDataTransfer, error) {
+	dtDs := namespace.Wrap(ds, datastore.NewKey("/datatransfer/provider/transfers"))
+
+	dt, err := dtimpl.NewDataTransfer(dtDs, net, transport)
+	if err != nil {
+		return nil, err
+	}
+
+	dt.OnReady(marketevents.ReadyLogger("provider data transfer"))
+	lc.Append(fx.Hook{
+		OnStart: func(ctx context.Context) error {
+			dt.SubscribeToEvents(marketevents.DataTransferLogger)
+			return dt.Start(ctx)
+		},
+		OnStop: func(ctx context.Context) error {
+			errc := make(chan error)
+
+			go func() {
+				errc <- dt.Stop(ctx)
+			}()
+
+			select {
+			case err := <-errc:
+				return err
+			case <-time.After(5 * time.Second):
+				return errors.New("couldnt stop datatransfer.Manager in 5 seconds. forcing an App.Stop")
+			}
+		},
+	})
+	return dt, nil
+}


### PR DESCRIPTION
Ideally we shouldn't have to do that, and maybe we can achieve the same thing with: https://github.com/uber-go/fx/blob/v1.17.1/app.go#L151

However it'd be nice to know if we mess up a shutdown elsewhere, so I'd rather just isolate the `datatransfer.Manager` for now.

---

```
goroutine 420444 [semacquire, 1 minutes]:
sync.runtime_Semacquire(0xc019a6c9a0)
        /usr/local/go/src/runtime/sema.go:56 +0x45
sync.(*WaitGroup).Wait(0xc019a6c998)
        /usr/local/go/src/sync/waitgroup.go:130 +0x65
golang.org/x/sync/errgroup.(*Group).Wait(0xc019a6c990, 0xc01da64e20, 0xc0600ebbd8)
        /root/code/pkg/mod/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/errgroup/errgroup.go:40 +0x31
github.com/filecoin-project/go-data-transfer/transport/graphsync.(*Transport).Shutdown(0xc014fc4a00, 0x4b11358, 0xc000058120, 0x0, 0x0)
        /root/code/pkg/mod/github.com/filecoin-project/go-data-transfer@v1.15.0/transport/graphsync/graphsync.go:331 +0x210
github.com/filecoin-project/go-data-transfer/impl.(*manager).Stop(0xc014fd0870, 0x4b11358, 0xc000058120, 0x293500c5, 0x22e5ea15144cd)
        /root/code/pkg/mod/github.com/filecoin-project/go-data-transfer@v1.15.0/impl/impl.go:173 +0xdc
github.com/filecoin-project/lotus/node/modules.NewProviderDataTransfer.func2(0x4b11358, 0xc000058120, 0xa3508c0, 0x4e)
        /root/code/pkg/mod/github.com/filecoin-project/lotus@v1.15.1-0.20220321111228-3c1edca90295/node/modules/storageminer.go:366 +0x46
go.uber.org/fx/internal/lifecycle.(*Lifecycle).runStopHook(0xc0001fe460, 0x4b11358, 0xc000058120, 0xc00149cac8, 0xc00149cae0, 0xc014ff0410, 0x46, 0x90c91ae, 0x77, 0x168, ...)
        /root/code/pkg/mod/go.uber.org/fx@v1.15.0/internal/lifecycle/lifecycle.go:176 +0x218
go.uber.org/fx/internal/lifecycle.(*Lifecycle).Stop(0xc0001fe460, 0x4b11358, 0xc000058120, 0xc019fb27c8, 0xc05d263810)
        /root/code/pkg/mod/go.uber.org/fx@v1.15.0/internal/lifecycle/lifecycle.go:141 +0x24a
go.uber.org/fx.withTimeout.func1(0xc0129e9ce0, 0xc018e3fc80, 0x4b11358, 0xc000058120)
        /root/code/pkg/mod/go.uber.org/fx@v1.15.0/app.go:977 +0x3e
created by go.uber.org/fx.withTimeout
        /root/code/pkg/mod/go.uber.org/fx@v1.15.0/app.go:977 +0x97
```