### PR TITLE
Cleanup completed deals on restart

### DIFF
--- a/db/deals.go
+++ b/db/deals.go
@@ -209,6 +209,10 @@ func (d *DealsDB) ListActive(ctx context.Context) ([]*types.ProviderDealState, e
 	return d.list(ctx, 0, 0, "Checkpoint != ?", dealcheckpoints.Complete.String())
 }
 
+func (d *DealsDB) ListCompleted(ctx context.Context) ([]*types.ProviderDealState, error) {
+	return d.list(ctx, 0, 0, "Checkpoint = ?", dealcheckpoints.Complete.String())
+}
+
 func (d *DealsDB) List(ctx context.Context, first *graphql.ID, offset int, limit int) ([]*types.ProviderDealState, error) {
 	where := ""
 	whereArgs := []interface{}{}

--- a/db/deals_test.go
+++ b/db/deals_test.go
@@ -77,4 +77,16 @@ func TestDealsDB(t *testing.T) {
 	storedDeal.CreatedAt = time.Time{}
 	req.Equal(deal, *storedDeal)
 	req.True(deal.IsOffline)
+
+	finished, err := GenerateDeals()
+	require.NoError(t, err)
+	for _, deal := range finished {
+		deal.Checkpoint = dealcheckpoints.Complete
+		err = db.Insert(ctx, &deal)
+		req.NoError(err)
+	}
+
+	fds, err := db.ListCompleted(ctx)
+	req.NoError(err)
+	req.Len(fds, len(finished))
 }

--- a/storagemarket/provider.go
+++ b/storagemarket/provider.go
@@ -387,8 +387,8 @@ func (p *Provider) Start() ([]*dealHandler, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to list completed deals: %w", err)
 	}
-	for _, ds := range finished {
-		p.cleanupDeal(ds)
+	for i := range finished {
+		p.cleanupDealOnRestart(finished[i])
 	}
 	log.Info("finished cleaning up completed deals")
 
@@ -398,10 +398,23 @@ func (p *Provider) Start() ([]*dealHandler, error) {
 		return nil, fmt.Errorf("failed to list active deals: %w", err)
 	}
 
-	var dhs []*dealHandler
+	// cleanup all deals that have finished successfully
+	for i := range pds {
+		deal := pds[i]
+		// TODO Update this once we start listening for expired/slashed deals etc
+		if deal.Checkpoint >= dealcheckpoints.IndexedAndAnnounced {
+			// cleanup if cleanup didn't finish before we restarted
+			p.cleanupDealOnRestart(deal)
+		}
+	}
 
+	// resume all in-progress deals
+	var dhs []*dealHandler
 	for _, ds := range pds {
 		d := ds
+		if d.Checkpoint >= dealcheckpoints.IndexedAndAnnounced {
+			continue
+		}
 		dh := p.mkAndInsertDealHandler(d.DealUuid)
 		p.wg.Add(1)
 		dhs = append(dhs, dh)
@@ -411,15 +424,6 @@ func (p *Provider) Start() ([]*dealHandler, error) {
 				p.wg.Done()
 				log.Infow("finished running deal", "id", d.DealUuid)
 			}()
-
-			// Check if deal is already complete
-			// TODO Update this once we start listening for expired/slashed deals etc
-			if d.Checkpoint >= dealcheckpoints.IndexedAndAnnounced {
-				// cleanup if cleanup didn't finish before we restarted
-				p.cleanupDeal(d)
-				return
-			}
-
 			p.dealLogger.Infow(d.DealUuid, "resuming deal on boost restart", "checkpoint on resumption", d.Checkpoint.String())
 			p.doDeal(d, dh)
 		}()
@@ -431,6 +435,26 @@ func (p *Provider) Start() ([]*dealHandler, error) {
 
 	log.Infow("storage provider: started")
 	return dhs, nil
+}
+
+func (p *Provider) cleanupDealOnRestart(deal *types.ProviderDealState) {
+	// remove the temp file created for inbound deal data if it is not an offline deal
+	if !deal.IsOffline {
+		_ = os.Remove(deal.InboundFilePath)
+	}
+
+	// untag storage space
+	errs := p.storageManager.Untag(p.ctx, deal.DealUuid)
+	if errs == nil {
+		p.dealLogger.Infow(deal.DealUuid, "untagged storage space")
+	}
+
+	// untag funds
+	collat, pub, errf := p.fundManager.UntagFunds(p.ctx, deal.DealUuid)
+	if errf == nil {
+		p.dealLogger.Infow(deal.DealUuid, "untagged funds for deal as deal finished", "untagged publish", pub, "untagged collateral", collat,
+			"err", errf)
+	}
 }
 
 func (p *Provider) Stop() {

--- a/storagemarket/provider.go
+++ b/storagemarket/provider.go
@@ -410,8 +410,8 @@ func (p *Provider) Start() ([]*dealHandler, error) {
 
 	// resume all in-progress deals
 	var dhs []*dealHandler
-	for _, ds := range pds {
-		d := ds
+	for _, d := range pds {
+		d := d
 		if d.Checkpoint >= dealcheckpoints.IndexedAndAnnounced {
 			continue
 		}

--- a/storagemarket/provider_loop.go
+++ b/storagemarket/provider_loop.go
@@ -218,7 +218,7 @@ func (p *Provider) loop() {
 			collat, pub, errf := p.fundManager.UntagFunds(p.ctx, deal.DealUuid)
 			if errf != nil && !xerrors.Is(errf, db.ErrNotFound) {
 				p.dealLogger.LogError(deal.DealUuid, "failed to untag funds", errf)
-			} else {
+			} else if errf == nil {
 				p.dealLogger.Infow(deal.DealUuid, "untagged funds for deal as deal finished", "untagged publish", pub, "untagged collateral", collat,
 					"err", errf)
 			}
@@ -226,6 +226,8 @@ func (p *Provider) loop() {
 			errs := p.storageManager.Untag(p.ctx, deal.DealUuid)
 			if errs != nil && !xerrors.Is(errs, db.ErrNotFound) {
 				p.dealLogger.LogError(deal.DealUuid, "failed to untag storage", errs)
+			} else if errs == nil {
+				p.dealLogger.Infow(deal.DealUuid, "untagged storage space for deal")
 			}
 			finishedDeal.done <- struct{}{}
 


### PR DESCRIPTION
There's a edge case where we wont cleanup a deal on resumption if it has already been marked completed even though Boost restarted after the deal was previously marked as completed but not cleaned up.