### PR TITLE
deal status: show error if deal failed

### DIFF
--- a/cmd/boost/deal_status_cmd.go
+++ b/cmd/boost/deal_status_cmd.go
@@ -138,6 +138,9 @@ func statusMessage(resp *types.DealStatusResponse) string {
 	case dealcheckpoints.IndexedAndAnnounced.String():
 		return "Sealing"
 	case dealcheckpoints.Complete.String():
+		if resp.DealStatus.Error != "" {
+			return "Error: " + resp.DealStatus.Error
+		}
 		return "Complete"
 	}
 	return resp.DealStatus.Status


### PR DESCRIPTION
```
$ ./boost deal-status --provider=t01000 --deal-uuid=1c3fdde2-2d30-4422-bab6-68aef81e118d
got deal status response
  deal uuid: 1c3fdde2-2d30-4422-bab6-68aef81e118d
  deal status: Error: failed to publish deal: failed to publish deal 1c3fdde2-2d30-4422-bab6-68aef81e118d: publish validation failed: cannot publish deal with piece CID baga6ea4seaqklovg65cl5aw3o7vmynkgenbmiaz422yyp6ooyvrzmzt5etquibq: current epoch 116815 has passed deal proposal start epoch 115792
  deal label: bafk2bzacecklzvh7bw7eyk5md34yznkeeaar4l7hauwovs5l7kquwr7i4gwb4
  publish cid: bafy2bzaced6covug2oh5cbga2lfdc43e5zpywqhbxmsd36j44t4ymiocebiwk
  chain deal id: 48
```