### PR TITLE
cli: add boost provider libp2p-info command

### DIFF
--- a/cli/node/node.go
+++ b/cli/node/node.go
@@ -18,6 +18,7 @@ import (
 	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/libp2p/go-libp2p-core/host"
+	"github.com/mitchellh/go-homedir"
 )
 
 type Node struct {
@@ -25,8 +26,13 @@ type Node struct {
 	Wallet *wallet.LocalWallet
 }
 
-func Setup(ctx context.Context, cfgdir string) (*Node, error) {
-	_, err := os.Stat(cfgdir)
+func Setup(cfgdir string) (*Node, error) {
+	cfgdir, err := homedir.Expand(cfgdir)
+	if err != nil {
+		return nil, fmt.Errorf("getting homedir: %w", err)
+	}
+
+	_, err = os.Stat(cfgdir)
 	if err != nil && errors.Is(err, os.ErrNotExist) {
 		return nil, errors.New("repo dir doesn't exist. run `boost init` first.")
 	}

--- a/cmd/boost/deal_status_cmd.go
+++ b/cmd/boost/deal_status_cmd.go
@@ -6,25 +6,21 @@ import (
 	bcli "github.com/filecoin-project/boost/cli"
 	"github.com/filecoin-project/boost/cli/node"
 	clinode "github.com/filecoin-project/boost/cli/node"
+	"github.com/filecoin-project/boost/cmd"
 	"github.com/filecoin-project/boost/storagemarket/lp2pimpl"
 	"github.com/filecoin-project/boost/storagemarket/types"
 	"github.com/filecoin-project/boost/storagemarket/types/dealcheckpoints"
 	"github.com/filecoin-project/go-address"
 	lcli "github.com/filecoin-project/lotus/cli"
 	"github.com/google/uuid"
-	"github.com/mitchellh/go-homedir"
-	cli "github.com/urfave/cli/v2"
+	"github.com/urfave/cli/v2"
 )
 
 var dealStatusCmd = &cli.Command{
 	Name:  "deal-status",
 	Usage: "",
 	Flags: []cli.Flag{
-		&cli.StringFlag{
-			Name:  "repo",
-			Usage: "repo directory for Boost client",
-			Value: "~/.boost-client",
-		},
+		cmd.FlagRepo,
 		&cli.StringFlag{
 			Name:     "provider",
 			Usage:    "storage provider on-chain address",
@@ -49,12 +45,7 @@ var dealStatusCmd = &cli.Command{
 			return err
 		}
 
-		sdir, err := homedir.Expand(cctx.String("repo"))
-		if err != nil {
-			return err
-		}
-
-		n, err := clinode.Setup(ctx, sdir)
+		n, err := clinode.Setup(cctx.String(cmd.FlagRepo.Name))
 		if err != nil {
 			return err
 		}
@@ -77,7 +68,7 @@ var dealStatusCmd = &cli.Command{
 			return err
 		}
 
-		addrInfo, err := getAddrInfo(cctx, ctx, api, maddr)
+		addrInfo, err := cmd.GetAddrInfo(ctx, api, maddr)
 		if err != nil {
 			return err
 		}

--- a/cmd/boost/init_cmd.go
+++ b/cmd/boost/init_cmd.go
@@ -5,36 +5,30 @@ import (
 	"os"
 	"strings"
 
-	"github.com/mitchellh/go-homedir"
-
 	"github.com/filecoin-project/boost/cli/node"
+	"github.com/filecoin-project/boost/cmd"
 	"github.com/filecoin-project/lotus/chain/types"
 	lcli "github.com/filecoin-project/lotus/cli"
+	"github.com/mitchellh/go-homedir"
 	cli "github.com/urfave/cli/v2"
 )
 
 var initCmd = &cli.Command{
-	Name:  "init",
-	Usage: "Initialise Boost client repo",
-	Flags: []cli.Flag{
-		&cli.StringFlag{
-			Name:  "repo",
-			Usage: "repo directory for Boost client",
-			Value: "~/.boost-client",
-		},
-	},
+	Name:   "init",
+	Usage:  "Initialise Boost client repo",
+	Flags:  []cli.Flag{cmd.FlagRepo},
 	Before: before,
 	Action: func(cctx *cli.Context) error {
 		ctx := lcli.ReqContext(cctx)
 
-		sdir, err := homedir.Expand(cctx.String("repo"))
+		sdir, err := homedir.Expand(cmd.FlagRepo.Name)
 		if err != nil {
 			return err
 		}
 
 		os.Mkdir(sdir, 0755) //nolint:errcheck
 
-		n, err := node.Setup(ctx, sdir)
+		n, err := node.Setup(cmd.FlagRepo.Name)
 		if err != nil {
 			return err
 		}

--- a/cmd/boost/provider_cmd.go
+++ b/cmd/boost/provider_cmd.go
@@ -18,15 +18,15 @@ var providerCmd = &cli.Command{
 	Usage: "Info about Storage Providers",
 	Flags: []cli.Flag{cmd.FlagRepo},
 	Subcommands: []*cli.Command{
-		protocolsCmd,
+		libp2pInfoCmd,
 	},
 }
 
-var protocolsCmd = &cli.Command{
-	Name:        "protocols",
+var libp2pInfoCmd = &cli.Command{
+	Name:        "libp2p-info",
 	Usage:       "",
 	ArgsUsage:   "<provider address>",
-	Description: "Lists the libp2p protocols supported by the Storage Provider",
+	Description: "Lists the libp2p address and protocols supported by the Storage Provider",
 	Before:      before,
 	Action: func(cctx *cli.Context) error {
 		ctx := cliutil.ReqContext(cctx)
@@ -54,7 +54,7 @@ var protocolsCmd = &cli.Command{
 
 		addrInfo, err := cmd.GetAddrInfo(ctx, api, maddr)
 		if err != nil {
-			return fmt.Errorf("getting provider address: %w", err)
+			return fmt.Errorf("getting provider multi-address: %w", err)
 		}
 
 		log.Debugw("connecting to storage provider",
@@ -72,10 +72,21 @@ var protocolsCmd = &cli.Command{
 		sort.Strings(protos)
 
 		if cctx.Bool("json") {
-			return cmd.PrintJson(map[string]interface{}{"provider": addrStr, "protocols": protos})
+			return cmd.PrintJson(map[string]interface{}{
+				"provider":   addrStr,
+				"id":         addrInfo.ID.String(),
+				"multiaddrs": addrInfo.Addrs,
+				"protocols":  protos,
+			})
 		}
 
-		fmt.Println(strings.Join(protos, "\n"))
+		fmt.Println("Provider: " + addrStr)
+		fmt.Println("Peer ID: " + addrInfo.ID.String())
+		fmt.Println("Peer Addresses:")
+		for _, addr := range addrInfo.Addrs {
+			fmt.Println("  " + addr.String())
+		}
+		fmt.Println("Protocols:\n" + "  " + strings.Join(protos, "\n  "))
 		return nil
 	},
 }

--- a/cmd/boost/provider_cmd.go
+++ b/cmd/boost/provider_cmd.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	clinode "github.com/filecoin-project/boost/cli/node"
+	cliutil "github.com/filecoin-project/boost/cli/util"
+	"github.com/filecoin-project/boost/cmd"
+	"github.com/filecoin-project/go-address"
+	lcli "github.com/filecoin-project/lotus/cli"
+	"github.com/urfave/cli/v2"
+)
+
+var providerCmd = &cli.Command{
+	Name:  "provider",
+	Usage: "Info about Storage Providers",
+	Flags: []cli.Flag{cmd.FlagRepo},
+	Subcommands: []*cli.Command{
+		protocolsCmd,
+	},
+}
+
+var protocolsCmd = &cli.Command{
+	Name:        "protocols",
+	Usage:       "",
+	ArgsUsage:   "<provider address>",
+	Description: "Lists the libp2p protocols supported by the Storage Provider",
+	Before:      before,
+	Action: func(cctx *cli.Context) error {
+		ctx := cliutil.ReqContext(cctx)
+
+		if cctx.Args().Len() != 1 {
+			return fmt.Errorf("usage: protocols <provider address>")
+		}
+
+		n, err := clinode.Setup(cctx.String(cmd.FlagRepo.Name))
+		if err != nil {
+			return fmt.Errorf("setting up CLI node: %w", err)
+		}
+
+		api, closer, err := lcli.GetGatewayAPI(cctx)
+		if err != nil {
+			return fmt.Errorf("settings up gateway connection: %w", err)
+		}
+		defer closer()
+
+		addrStr := cctx.Args().Get(0)
+		maddr, err := address.NewFromString(addrStr)
+		if err != nil {
+			return fmt.Errorf("parsing provider on-chain address %s: %w", addrStr, err)
+		}
+
+		addrInfo, err := cmd.GetAddrInfo(ctx, api, maddr)
+		if err != nil {
+			return fmt.Errorf("getting provider address: %w", err)
+		}
+
+		log.Debugw("connecting to storage provider",
+			"id", addrInfo.ID, "multiaddrs", addrInfo.Addrs, "addr", maddr)
+
+		if err := n.Host.Connect(ctx, *addrInfo); err != nil {
+			return fmt.Errorf("connecting to peer %s: %w", addrInfo.ID, err)
+		}
+
+		protos, err := n.Host.Peerstore().GetProtocols(addrInfo.ID)
+		if err != nil {
+			return fmt.Errorf("getting protocols for peer %s: %w", addrInfo.ID, err)
+		}
+
+		sort.Strings(protos)
+
+		if cctx.Bool("json") {
+			return cmd.PrintJson(map[string]interface{}{"provider": addrStr, "protocols": protos})
+		}
+
+		fmt.Println(strings.Join(protos, "\n"))
+		return nil
+	},
+}

--- a/cmd/boost/wallet_cmd.go
+++ b/cmd/boost/wallet_cmd.go
@@ -9,13 +9,14 @@ import (
 	"os"
 	"strings"
 
+	"github.com/filecoin-project/boost/cmd"
+
 	"github.com/filecoin-project/boost/cli/node"
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/lotus/chain/types"
 	lcli "github.com/filecoin-project/lotus/cli"
 	"github.com/filecoin-project/lotus/lib/tablewriter"
-	"github.com/mitchellh/go-homedir"
 	cli "github.com/urfave/cli/v2"
 	"golang.org/x/xerrors"
 )
@@ -23,13 +24,7 @@ import (
 var walletCmd = &cli.Command{
 	Name:  "wallet",
 	Usage: "Manage wallets with Boost",
-	Flags: []cli.Flag{
-		&cli.StringFlag{
-			Name:  "repo",
-			Usage: "repo directory for Boost client",
-			Value: "~/.boost-client",
-		},
-	},
+	Flags: []cli.Flag{cmd.FlagRepo},
 	Subcommands: []*cli.Command{
 		walletNew,
 		walletList,
@@ -49,12 +44,7 @@ var walletNew = &cli.Command{
 	Action: func(cctx *cli.Context) error {
 		ctx := lcli.ReqContext(cctx)
 
-		sdir, err := homedir.Expand(cctx.String("repo"))
-		if err != nil {
-			return err
-		}
-
-		n, err := node.Setup(ctx, sdir)
+		n, err := node.Setup(cctx.String(cmd.FlagRepo.Name))
 		if err != nil {
 			return err
 		}
@@ -93,12 +83,7 @@ var walletList = &cli.Command{
 	Action: func(cctx *cli.Context) error {
 		ctx := lcli.ReqContext(cctx)
 
-		sdir, err := homedir.Expand(cctx.String("repo"))
-		if err != nil {
-			return err
-		}
-
-		n, err := node.Setup(ctx, sdir)
+		n, err := node.Setup(cctx.String(cmd.FlagRepo.Name))
 		if err != nil {
 			return err
 		}
@@ -191,12 +176,7 @@ var walletBalance = &cli.Command{
 	Action: func(cctx *cli.Context) error {
 		ctx := lcli.ReqContext(cctx)
 
-		sdir, err := homedir.Expand(cctx.String("repo"))
-		if err != nil {
-			return err
-		}
-
-		n, err := node.Setup(ctx, sdir)
+		n, err := node.Setup(cctx.String(cmd.FlagRepo.Name))
 		if err != nil {
 			return err
 		}
@@ -241,12 +221,7 @@ var walletExport = &cli.Command{
 	Action: func(cctx *cli.Context) error {
 		ctx := lcli.ReqContext(cctx)
 
-		sdir, err := homedir.Expand(cctx.String("repo"))
-		if err != nil {
-			return err
-		}
-
-		n, err := node.Setup(ctx, sdir)
+		n, err := node.Setup(cctx.String(cmd.FlagRepo.Name))
 		if err != nil {
 			return err
 		}
@@ -295,12 +270,7 @@ var walletImport = &cli.Command{
 	Action: func(cctx *cli.Context) error {
 		ctx := lcli.ReqContext(cctx)
 
-		sdir, err := homedir.Expand(cctx.String("repo"))
-		if err != nil {
-			return err
-		}
-
-		n, err := node.Setup(ctx, sdir)
+		n, err := node.Setup(cctx.String(cmd.FlagRepo.Name))
 		if err != nil {
 			return err
 		}
@@ -384,14 +354,7 @@ var walletGetDefault = &cli.Command{
 	Usage:   "Get default wallet address",
 	Aliases: []string{"get-default"},
 	Action: func(cctx *cli.Context) error {
-		ctx := lcli.ReqContext(cctx)
-
-		sdir, err := homedir.Expand(cctx.String("repo"))
-		if err != nil {
-			return err
-		}
-
-		n, err := node.Setup(ctx, sdir)
+		n, err := node.Setup(cctx.String(cmd.FlagRepo.Name))
 		if err != nil {
 			return err
 		}
@@ -413,14 +376,7 @@ var walletSetDefault = &cli.Command{
 	Usage:     "Set default wallet address",
 	ArgsUsage: "[address]",
 	Action: func(cctx *cli.Context) error {
-		ctx := lcli.ReqContext(cctx)
-
-		sdir, err := homedir.Expand(cctx.String("repo"))
-		if err != nil {
-			return err
-		}
-
-		n, err := node.Setup(ctx, sdir)
+		n, err := node.Setup(cctx.String(cmd.FlagRepo.Name))
 		if err != nil {
 			return err
 		}
@@ -445,12 +401,7 @@ var walletDelete = &cli.Command{
 	Action: func(cctx *cli.Context) error {
 		ctx := lcli.ReqContext(cctx)
 
-		sdir, err := homedir.Expand(cctx.String("repo"))
-		if err != nil {
-			return err
-		}
-
-		n, err := node.Setup(ctx, sdir)
+		n, err := node.Setup(cctx.String(cmd.FlagRepo.Name))
 		if err != nil {
 			return err
 		}

--- a/cmd/boostx/utils_cmd.go
+++ b/cmd/boostx/utils_cmd.go
@@ -7,24 +7,24 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/docker/go-units"
 	clinode "github.com/filecoin-project/boost/cli/node"
+	"github.com/filecoin-project/boost/cmd"
 	"github.com/filecoin-project/boost/node"
 	"github.com/filecoin-project/boost/node/config"
 	"github.com/filecoin-project/go-commp-utils/writer"
 	"github.com/filecoin-project/go-fil-markets/stores"
+	"github.com/filecoin-project/go-paramfetch"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 	lapi "github.com/filecoin-project/lotus/api"
+	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain/actors"
 	marketactor "github.com/filecoin-project/lotus/chain/actors/builtin/market"
 	"github.com/filecoin-project/lotus/chain/messagesigner"
 	"github.com/filecoin-project/lotus/chain/types"
 	lcli "github.com/filecoin-project/lotus/cli"
 	"github.com/filecoin-project/lotus/lib/backupds"
-
-	"github.com/docker/go-units"
-	paramfetch "github.com/filecoin-project/go-paramfetch"
-	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/lib/unixfs"
 	"github.com/filecoin-project/lotus/node/modules"
 	lotus_repo "github.com/filecoin-project/lotus/node/repo"
@@ -35,7 +35,6 @@ import (
 	ds_sync "github.com/ipfs/go-datastore/sync"
 	"github.com/ipld/go-car"
 	selectorparse "github.com/ipld/go-ipld-prime/traversal/selector/parse"
-	"github.com/mitchellh/go-homedir"
 	"github.com/multiformats/go-multibase"
 	"github.com/urfave/cli/v2"
 	"golang.org/x/xerrors"
@@ -46,11 +45,7 @@ var marketCmd = &cli.Command{
 	Usage:       "Add funds to the Storage Market actor",
 	Description: "Send signed message to add funds for the default wallet to the Storage Market actor. Uses 2x current BaseFee and a maximum fee of 1 nFIL. This is an experimental utility, do not use in production.",
 	Flags: []cli.Flag{
-		&cli.StringFlag{
-			Name:  "repo",
-			Usage: "repo directory for Boost client",
-			Value: "~/.boost-client",
-		},
+		cmd.FlagRepo,
 		&cli.StringFlag{
 			Name:  "wallet",
 			Usage: "move balance from this wallet address to its market actor",
@@ -71,12 +66,7 @@ var marketCmd = &cli.Command{
 
 		ctx := lcli.ReqContext(cctx)
 
-		sdir, err := homedir.Expand(cctx.String("repo"))
-		if err != nil {
-			return err
-		}
-
-		n, err := clinode.Setup(ctx, sdir)
+		n, err := clinode.Setup(cctx.String(cmd.FlagRepo.Name))
 		if err != nil {
 			return err
 		}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1,0 +1,15 @@
+package cmd
+
+import "github.com/urfave/cli/v2"
+
+var FlagRepo = &cli.StringFlag{
+	Name:  "repo",
+	Usage: "repo directory for Boost client",
+	Value: "~/.boost-client",
+}
+
+var FlagJson = &cli.BoolFlag{
+	Name:  "json",
+	Usage: "output results in json format",
+	Value: false,
+}

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -1,0 +1,50 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/lotus/api"
+	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/multiformats/go-multiaddr"
+)
+
+func GetAddrInfo(ctx context.Context, api api.Gateway, maddr address.Address) (*peer.AddrInfo, error) {
+	minfo, err := api.StateMinerInfo(ctx, maddr, types.EmptyTSK)
+	if err != nil {
+		return nil, err
+	}
+	if minfo.PeerId == nil {
+		return nil, fmt.Errorf("storage provider %s has no peer ID set on-chain", maddr)
+	}
+
+	var maddrs []multiaddr.Multiaddr
+	for _, mma := range minfo.Multiaddrs {
+		ma, err := multiaddr.NewMultiaddrBytes(mma)
+		if err != nil {
+			return nil, fmt.Errorf("storage provider %s had invalid multiaddrs in their info: %w", maddr, err)
+		}
+		maddrs = append(maddrs, ma)
+	}
+	if len(maddrs) == 0 {
+		return nil, fmt.Errorf("storage provider %s has no multiaddrs set on-chain", maddr)
+	}
+
+	return &peer.AddrInfo{
+		ID:    *minfo.PeerId,
+		Addrs: maddrs,
+	}, nil
+}
+
+func PrintJson(obj interface{}) error {
+	resJson, err := json.MarshalIndent(obj, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshalling json: %w", err)
+	}
+
+	fmt.Println(string(resJson))
+	return nil
+}


### PR DESCRIPTION
Adds a `provider` category with a `libp2p-info` command:

```
$ FULLNODE_API_INFO="https://api.node.glif.io" ./boost provider libp2p-info f0127896
Provider: f0127896
Peer ID: 12D3KooWE8yt84RVwW3sFcd6WMjbUdWrZer2YtT4dmtj3dHdahSZ
Peer Addresses:
  /ip4/85.11.148.122/tcp/24001
Protocols:
  /fil/datatransfer/1.2.0
  /fil/kad/testnetnet/kad/1.0.0
  /fil/retrieval/qry/0.0.1
  /fil/retrieval/qry/1.0.0
  /fil/storage/ask/1.0.1
  /fil/storage/ask/1.1.0
  /fil/storage/mk/1.0.1
  /fil/storage/mk/1.1.0
  /fil/storage/mk/1.2.0
  /fil/storage/status/1.0.1
  /fil/storage/status/1.1.0
  /fil/storage/status/1.2.0
  /floodsub/1.0.0
  /ipfs/graphsync/1.0.0
  /ipfs/graphsync/2.0.0
  /ipfs/id/1.0.0
  /ipfs/id/push/1.0.0
  /ipfs/ping/1.0.0
  /legs/head//indexer/ingest/mainnet/0.0.1
  /libp2p/autonat/1.0.0
  /meshsub/1.0.0
  /meshsub/1.1.0
  /p2p/id/delta/1.0.0
```

```
$ FULLNODE_API_INFO="https://api.node.glif.io" ./boost --json provider libp2p-info f0127896
{
  "id": "12D3KooWE8yt84RVwW3sFcd6WMjbUdWrZer2YtT4dmtj3dHdahSZ",
  "multiaddrs": [
    "/ip4/85.11.148.122/tcp/24001"
  ],
  "protocols": [
    "/fil/datatransfer/1.2.0",
    "/fil/kad/testnetnet/kad/1.0.0",
    "/fil/retrieval/qry/0.0.1",
    "/fil/retrieval/qry/1.0.0",
    "/fil/storage/ask/1.0.1",
    "/fil/storage/ask/1.1.0",
    "/fil/storage/mk/1.0.1",
    "/fil/storage/mk/1.1.0",
    "/fil/storage/mk/1.2.0",
    "/fil/storage/status/1.0.1",
    "/fil/storage/status/1.1.0",
    "/fil/storage/status/1.2.0",
    "/floodsub/1.0.0",
    "/ipfs/graphsync/1.0.0",
    "/ipfs/graphsync/2.0.0",
    "/ipfs/id/1.0.0",
    "/ipfs/id/push/1.0.0",
    "/ipfs/ping/1.0.0",
    "/legs/head//indexer/ingest/mainnet/0.0.1",
    "/libp2p/autonat/1.0.0",
    "/meshsub/1.0.0",
    "/meshsub/1.1.0",
    "/p2p/id/delta/1.0.0"
  ],
  "provider": "f0127896"
}
```