### PR TITLE
Add agent version to boost provider libp2p-info

### DIFF
--- a/cmd/boost/main.go
+++ b/cmd/boost/main.go
@@ -44,7 +44,7 @@ func main() {
 	app.Setup()
 
 	if err := app.Run(os.Args); err != nil {
-		if app.Metadata["json"].(bool) {
+		if isJson, ok := app.Metadata["json"].(bool); isJson && ok {
 			resJson, err := json.Marshal(map[string]string{"error": err.Error()})
 			if err != nil {
 				fmt.Fprintln(os.Stderr, fmt.Errorf("marshalling json: %w", err))

--- a/cmd/boost/provider_cmd.go
+++ b/cmd/boost/provider_cmd.go
@@ -42,7 +42,7 @@ var libp2pInfoCmd = &cli.Command{
 
 		api, closer, err := lcli.GetGatewayAPI(cctx)
 		if err != nil {
-			return fmt.Errorf("settings up gateway connection: %w", err)
+			return fmt.Errorf("setting up gateway connection: %w", err)
 		}
 		defer closer()
 
@@ -68,12 +68,18 @@ var libp2pInfoCmd = &cli.Command{
 		if err != nil {
 			return fmt.Errorf("getting protocols for peer %s: %w", addrInfo.ID, err)
 		}
-
 		sort.Strings(protos)
+
+		agentVersionI, err := n.Host.Peerstore().Get(addrInfo.ID, "AgentVersion")
+		if err != nil {
+			return fmt.Errorf("getting agent version for peer %s: %w", addrInfo.ID, err)
+		}
+		agentVersion, _ := agentVersionI.(string)
 
 		if cctx.Bool("json") {
 			return cmd.PrintJson(map[string]interface{}{
 				"provider":   addrStr,
+				"agent":      agentVersion,
 				"id":         addrInfo.ID.String(),
 				"multiaddrs": addrInfo.Addrs,
 				"protocols":  protos,
@@ -81,6 +87,7 @@ var libp2pInfoCmd = &cli.Command{
 		}
 
 		fmt.Println("Provider: " + addrStr)
+		fmt.Println("Agent: " + agentVersion)
 		fmt.Println("Peer ID: " + addrInfo.ID.String())
 		fmt.Println("Peer Addresses:")
 		for _, addr := range addrInfo.Addrs {


### PR DESCRIPTION
```
$ FULLNODE_API_INFO="https://api.node.glif.io" ./boost --json provider libp2p-info f01234
{
  "agent": "lotus-1.15.2-dev+mainnet",
  "id": "12D3KooWE8yt84RVwW3sFcd6WMjbUdWrZer2YtT4dmtj3dHdahSZ",
  "multiaddrs": [
    "/ip4/85.11.148.122/tcp/24001"
  ],
  "protocols": [
    "/fil/datatransfer/1.2.0",
    "/fil/kad/testnetnet/kad/1.0.0",
    "/fil/retrieval/qry/0.0.1",
    "/fil/retrieval/qry/1.0.0",
    "/fil/storage/ask/1.0.1",
    "/fil/storage/ask/1.1.0",
    "/fil/storage/mk/1.0.1",
    "/fil/storage/mk/1.1.0",
    "/fil/storage/mk/1.2.0",
    "/fil/storage/status/1.0.1",
    "/fil/storage/status/1.1.0",
    "/fil/storage/status/1.2.0",
    "/floodsub/1.0.0",
    "/ipfs/graphsync/1.0.0",
    "/ipfs/graphsync/2.0.0",
    "/ipfs/id/1.0.0",
    "/ipfs/id/push/1.0.0",
    "/ipfs/ping/1.0.0",
    "/legs/head//indexer/ingest/mainnet/0.0.1",
    "/libp2p/autonat/1.0.0",
    "/meshsub/1.0.0",
    "/meshsub/1.1.0",
    "/p2p/id/delta/1.0.0"
  ],
  "provider": "f01234"
}
```