### PR TITLE
add market-withdraw cmd to boostx

### DIFF
--- a/cmd/boostx/confirm.go
+++ b/cmd/boostx/confirm.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/chzyer/readline"
+	"golang.org/x/xerrors"
+)
+
+func confirm(ctx context.Context) (bool, error) {
+	cs := readline.NewCancelableStdin(os.Stdin)
+	go func() {
+		<-ctx.Done()
+		cs.Close() // nolint:errcheck
+	}()
+	rl := bufio.NewReader(cs)
+	for {
+		fmt.Printf("Proceed? Yes [y] / No [n]:\n")
+
+		line, _, err := rl.ReadLine()
+		if err != nil {
+			if xerrors.Is(err, io.EOF) {
+				return false, fmt.Errorf("request canceled: %w", err)
+			}
+
+			return false, fmt.Errorf("reading input: %w", err)
+		}
+
+		switch string(line) {
+		case "yes", "y":
+			return true, nil
+		case "n":
+			return false, nil
+		default:
+			return false, nil
+		}
+	}
+}

--- a/cmd/boostx/main.go
+++ b/cmd/boostx/main.go
@@ -31,7 +31,8 @@ func main() {
 		Commands: []*cli.Command{
 			commpCmd,
 			generatecarCmd,
-			marketCmd,
+			marketAddCmd,
+			marketWithdrawCmd,
 		},
 	}
 	app.Setup()

--- a/cmd/boostx/utils_cmd.go
+++ b/cmd/boostx/utils_cmd.go
@@ -122,6 +122,20 @@ var marketAddCmd = &cli.Command{
 			return err
 		}
 
+		fmt.Println("about to send message with the following gas costs")
+		fmt.Println("gas fee cap: ", types.FIL(smsg.Message.GasFeeCap))
+		fmt.Println("gas limit:   ", smsg.Message.GasLimit)
+		fmt.Println("gas premium: ", types.FIL(smsg.Message.GasPremium))
+		fmt.Println("basefee:     ", types.FIL(basefee))
+		fmt.Println()
+		process, err := confirm(ctx)
+		if err != nil {
+			return err
+		}
+		if !process {
+			return nil
+		}
+
 		cid, err := api.MpoolPush(ctx, smsg)
 		if err != nil {
 			return xerrors.Errorf("mpool push: failed to push message: %w", err)
@@ -218,6 +232,20 @@ var marketWithdrawCmd = &cli.Command{
 		smsg, err := messagesigner.SignMessage(ctx, msg, func(*types.SignedMessage) error { return nil })
 		if err != nil {
 			return err
+		}
+
+		fmt.Println("about to send message with the following gas costs")
+		fmt.Println("gas fee cap: ", types.FIL(smsg.Message.GasFeeCap))
+		fmt.Println("gas limit:   ", smsg.Message.GasLimit)
+		fmt.Println("gas premium: ", types.FIL(smsg.Message.GasPremium))
+		fmt.Println("basefee:     ", types.FIL(basefee))
+		fmt.Println()
+		process, err := confirm(ctx)
+		if err != nil {
+			return err
+		}
+		if !process {
+			return nil
 		}
 
 		cid, err := api.MpoolPush(ctx, smsg)

--- a/cmd/boostx/utils_cmd.go
+++ b/cmd/boostx/utils_cmd.go
@@ -111,7 +111,9 @@ var marketAddCmd = &cli.Command{
 			return xerrors.Errorf("GasEstimateMessageGas error: %w", err)
 		}
 
-		newGasFeeCap := big.Mul(big.Int(basefee), big.NewInt(2)) // use 2*basefee, so that this message confirms quickly
+		// use basefee + 20%
+		newGasFeeCap := big.Mul(big.Int(basefee), big.NewInt(6))
+		newGasFeeCap = big.Div(newGasFeeCap, big.NewInt(5))
 
 		if big.Cmp(msg.GasFeeCap, newGasFeeCap) < 0 {
 			msg.GasFeeCap = newGasFeeCap
@@ -123,6 +125,8 @@ var marketAddCmd = &cli.Command{
 		}
 
 		fmt.Println("about to send message with the following gas costs")
+		maxFee := big.Mul(smsg.Message.GasFeeCap, big.NewInt(smsg.Message.GasLimit))
+		fmt.Println("max fee:     ", types.FIL(maxFee), "(absolute maximum amount you are willing to pay to get your transaction confirmed)")
 		fmt.Println("gas fee cap: ", types.FIL(smsg.Message.GasFeeCap))
 		fmt.Println("gas limit:   ", smsg.Message.GasLimit)
 		fmt.Println("gas premium: ", types.FIL(smsg.Message.GasPremium))
@@ -223,7 +227,9 @@ var marketWithdrawCmd = &cli.Command{
 			return xerrors.Errorf("GasEstimateMessageGas error: %w", err)
 		}
 
-		newGasFeeCap := big.Mul(big.Int(basefee), big.NewInt(2)) // use 2*basefee, so that this message confirms quickly
+		// use basefee + 20%
+		newGasFeeCap := big.Mul(big.Int(basefee), big.NewInt(6))
+		newGasFeeCap = big.Div(newGasFeeCap, big.NewInt(5))
 
 		if big.Cmp(msg.GasFeeCap, newGasFeeCap) < 0 {
 			msg.GasFeeCap = newGasFeeCap
@@ -235,6 +241,8 @@ var marketWithdrawCmd = &cli.Command{
 		}
 
 		fmt.Println("about to send message with the following gas costs")
+		maxFee := big.Mul(smsg.Message.GasFeeCap, big.NewInt(smsg.Message.GasLimit))
+		fmt.Println("max fee:     ", types.FIL(maxFee), "(absolute maximum amount you are willing to pay to get your transaction confirmed)")
 		fmt.Println("gas fee cap: ", types.FIL(smsg.Message.GasFeeCap))
 		fmt.Println("gas limit:   ", smsg.Message.GasLimit)
 		fmt.Println("gas premium: ", types.FIL(smsg.Message.GasPremium))


### PR DESCRIPTION
Fixes: https://github.com/filecoin-project/boost/issues/450

---

Also adding a `confirm` interactive screen:

```
➜  boostx market-add --wallet=f1sw5zjcyo4mff5cbvgsgmm7uoko6gcr4tptvtkhy 0.3
2022-04-21T14:16:59.059+0300    INFO    boostx  boostx/utils_cmd.go:82  selected wallet {"wallet": "f1sw5zjcyo4mff5cbvgsgmm7uoko6gcr4tptvtkhy"}
about to send message with the following gas costs
gas fee cap:  0.000000000307874188 FIL
gas limit:    13517058
gas premium:  0.000000000000000073 FIL
basefee:      0.000000000153937094 FIL

Proceed? Yes [y] / No [n]:
```