### PR TITLE
change to "No active jobs"

### DIFF
--- a/react/src/SealingPipeline.js
+++ b/react/src/SealingPipeline.js
@@ -164,7 +164,7 @@ function SealingType(props) {
 function Workers(props) {
     return <div className="workers">
         <div className="title">Workers</div>
-        {props.workers.length === 0 ? <div className="no-workers">No active workers</div> : (
+        {props.workers.length === 0 ? <div className="no-workers">No active jobs</div> : (
             <table>
                 <tbody>
                 <tr>


### PR DESCRIPTION
"No active workers" is somewhat confusing, as reported by stuberman:

```
I also wonder why on the GUI the ‘sealing pipeline’ shows: Workers No active workers despite having a sealing worker that is standing by for sectors
```

---

So changing to "No active jobs"