### PR TITLE
fix index provider register multihash lister

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/filecoin-project/go-fil-commcid v0.1.0
 	github.com/filecoin-project/go-fil-commp-hashhash v0.1.0
 	// go-fil-markets boost/main branch
-	github.com/filecoin-project/go-fil-markets v1.20.2-0.20220415100246-742e1400623d
+	github.com/filecoin-project/go-fil-markets v1.20.2-0.20220509100709-5b96975b1577
 	github.com/filecoin-project/go-jsonrpc v0.1.5
 	github.com/filecoin-project/go-padreader v0.0.1
 	github.com/filecoin-project/go-paramfetch v0.0.4

--- a/go.sum
+++ b/go.sum
@@ -373,8 +373,8 @@ github.com/filecoin-project/go-fil-commcid v0.1.0/go.mod h1:Eaox7Hvus1JgPrL5+M3+
 github.com/filecoin-project/go-fil-commp-hashhash v0.1.0 h1:imrrpZWEHRnNqqv0tN7LXep5bFEVOVmQWHJvl2mgsGo=
 github.com/filecoin-project/go-fil-commp-hashhash v0.1.0/go.mod h1:73S8WSEWh9vr0fDJVnKADhfIv/d6dCbAGaAGWbdJEI8=
 github.com/filecoin-project/go-fil-markets v1.20.1/go.mod h1:QV767KIWHrikVK8R0u2wTc5wkee4gXOf5/AfxDoQckw=
-github.com/filecoin-project/go-fil-markets v1.20.2-0.20220415100246-742e1400623d h1:ReJhwpB4uUJKIkGkmk5CW1NAyOMKbCmag/8jJPCgNfY=
-github.com/filecoin-project/go-fil-markets v1.20.2-0.20220415100246-742e1400623d/go.mod h1:Oknh4H28OpnkH+vAC+AtMmjC9sudzFNtb8Q183pPsfs=
+github.com/filecoin-project/go-fil-markets v1.20.2-0.20220509100709-5b96975b1577 h1:XhMdOdceZj0KPiELQROoj+LCJkpiWmzPixchfQ3sICw=
+github.com/filecoin-project/go-fil-markets v1.20.2-0.20220509100709-5b96975b1577/go.mod h1:Oknh4H28OpnkH+vAC+AtMmjC9sudzFNtb8Q183pPsfs=
 github.com/filecoin-project/go-hamt-ipld v0.1.5 h1:uoXrKbCQZ49OHpsTCkrThPNelC4W3LPEk0OrS/ytIBM=
 github.com/filecoin-project/go-hamt-ipld v0.1.5/go.mod h1:6Is+ONR5Cd5R6XZoCse1CWaXZc0Hdb/JeX+EQCQzX24=
 github.com/filecoin-project/go-hamt-ipld/v2 v2.0.0 h1:b3UDemBYN2HNfk3KOXNuxgTTxlWi3xVvbQP0IT38fvM=

--- a/itests/dummydeal_test.go
+++ b/itests/dummydeal_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDummydeal(t *testing.T) {
+func TestDummydealOnline(t *testing.T) {
 	ctx := context.Background()
 	log := framework.Log
 

--- a/node/builder.go
+++ b/node/builder.go
@@ -140,11 +140,8 @@ const (
 	HandleRetrievalKey
 	RunSectorServiceKey
 
-	// boost -> should be started after markets
+	// boost should be started after legacy markets (HandleDealsKey)
 	HandleBoostDealsKey
-
-	// index-provider should be started after Boost
-	HandleIndexProviderKey
 
 	// daemon
 	ExtractApiKey
@@ -511,10 +508,8 @@ func ConfigBoost(c interface{}) Option {
 
 		Override(new(lotus_storagemarket.StorageProviderNode), lotus_storageadapter.NewProviderNodeAdapter(&cfg.LotusFees, &cfg.LotusDealmaking)),
 		Override(new(lotus_storagemarket.StorageProvider), lotus_modules.StorageProvider),
-		Override(HandleDealsKey, lotus_modules.HandleDeals),
-
+		Override(HandleDealsKey, modules.HandleLegacyDeals),
 		Override(HandleBoostDealsKey, modules.HandleBoostDeals),
-		Override(HandleIndexProviderKey, modules.HandleIndexProvider),
 
 		// Boost storage deal filter
 		Override(new(dtypes.StorageDealFilter), modules.BasicDealFilter(cfg.Dealmaking, nil)),


### PR DESCRIPTION
Fixes https://github.com/filecoin-project/boost/issues/492

- The legacy StorageProvider returns from it's Start method before registering the multihash lister for the DAG store
- The boost StorageProvider should overwrite the multihash lister, but sometimes Boost's start method will run before legacy StorageProvider has registered its multihash lister
- The solution is to
  - ensure that the legacy SP only fires the `ready` event after the multihash lister has been registered https://github.com/filecoin-project/go-fil-markets/pull/708
  - ensure that Boost SP waits to start until the `ready` event has been fired by the legacy SP (this PR)