### PR TITLE
Deal retry web UI

### DIFF
--- a/db/fixtures.go
+++ b/db/fixtures.go
@@ -102,6 +102,7 @@ func GenerateDeals() ([]types.ProviderDealState, error) {
 			Offset:      abi.PaddedPieceSize(rand.Intn(1000000)),
 			Length:      abi.PaddedPieceSize(rand.Intn(1000000)),
 			Checkpoint:  dealcheckpoints.Accepted,
+			Retry:       types.DealRetryAuto,
 		}
 
 		deals = append(deals, deal)

--- a/gql/resolver.go
+++ b/gql/resolver.go
@@ -466,7 +466,7 @@ func (dr *dealResolver) Retry() string {
 
 func (dr *dealResolver) Message(ctx context.Context) string {
 	msg := dr.message(ctx, dr.ProviderDealState.Checkpoint)
-	if dr.ProviderDealState.Retry == types.DealRetryManual {
+	if dr.ProviderDealState.Retry != types.DealRetryFatal && dr.ProviderDealState.Err != "" {
 		msg = "Paused at '" + msg + "': " + dr.ProviderDealState.Err
 	}
 	return msg

--- a/gql/schema.graphql
+++ b/gql/schema.graphql
@@ -62,6 +62,7 @@ type Deal {
   Checkpoint: String!
   CheckpointAt: Time!
   Err: String!
+  Retry: String!
   Transferred: Uint64!
   Sector: Sector!
   Message: String!
@@ -327,6 +328,12 @@ type RootQuery {
 type RootMutation {
   """Cancel a Deal"""
   dealCancel(id: ID!): ID!
+
+  """Retry a Deal that was paused because of an error"""
+  dealRetryPaused(id: ID!): ID!
+
+  """Fail a Deal that was paused because of an error"""
+  dealFailPaused(id: ID!): ID!
 
   """Publish all pending deals now"""
   dealPublishNow: Boolean!

--- a/react/src/DealDetail.css
+++ b/react/src/DealDetail.css
@@ -93,6 +93,10 @@
     float: right;
 }
 
+.deal-detail .buttons .button {
+    display: inline-block;
+}
+
 .deal-detail h3 {
     margin-top: 2em;
 }

--- a/react/src/DealDetail.js
+++ b/react/src/DealDetail.js
@@ -106,7 +106,7 @@ export function DealDetail(props) {
         console.error("parsing transfer params: "+e.message)
     }
 
-    const showRetryFailButtons = deal.Retry === 'manual' && deal.Error != ''
+    const showRetryFailButtons = deal.Retry !== 'fatal' && deal.Err !== ''
     const showCancelButton = !showRetryFailButtons && deal.Checkpoint === 'Accepted' && !deal.IsOffline
 
     var logRowData = []

--- a/react/src/gql.js
+++ b/react/src/gql.js
@@ -157,6 +157,7 @@ const DealSubscription = gql`
             IsOffline
             Checkpoint
             CheckpointAt
+            Retry
             Message
             Transferred
             Transfer {
@@ -185,6 +186,18 @@ const DealCancelMutation = gql`
     }
 `;
 
+const DealRetryPausedMutation = gql`
+    mutation AppDealRetryMutation($id: ID!) {
+        dealRetryPaused(id: $id)
+    }
+`;
+
+const DealFailPausedMutation = gql`
+    mutation AppDealRetryMutation($id: ID!) {
+        dealFailPaused(id: $id)
+    }
+`;
+
 const NewDealsSubscription = gql`
     subscription AppNewDealsSubscription {
         dealNew {
@@ -203,6 +216,7 @@ const NewDealsSubscription = gql`
                 PublishCid
                 Checkpoint
                 CheckpointAt
+                Retry
                 Message
                 Transfer {
                     Type
@@ -464,6 +478,8 @@ export {
     LegacyDealQuery,
     DealSubscription,
     DealCancelMutation,
+    DealRetryPausedMutation,
+    DealFailPausedMutation,
     NewDealsSubscription,
     StorageQuery,
     LegacyStorageQuery,

--- a/react/src/gql.js
+++ b/react/src/gql.js
@@ -158,6 +158,7 @@ const DealSubscription = gql`
             Checkpoint
             CheckpointAt
             Retry
+            Err
             Message
             Transferred
             Transfer {
@@ -217,6 +218,7 @@ const NewDealsSubscription = gql`
                 Checkpoint
                 CheckpointAt
                 Retry
+                Err
                 Message
                 Transfer {
                     Type

--- a/storagemarket/deal_handler.go
+++ b/storagemarket/deal_handler.go
@@ -104,13 +104,14 @@ func (p *Provider) failPausedDeal(deal *smtypes.ProviderDealState) error {
 	// Update state in DB with error
 	deal.Checkpoint = dealcheckpoints.Complete
 	deal.Retry = smtypes.DealRetryFatal
-	errMsg := "user manually terminated the deal"
-	err := errors.New(errMsg)
-	if deal.Err != "" {
+	var err error
+	if deal.Err == "" {
+		err = errors.New("user manually terminated the deal")
+	} else {
 		err = errors.New(deal.Err)
 	}
-	deal.Err = errMsg
-	p.dealLogger.LogError(deal.DealUuid, errMsg, err)
+	deal.Err = "user manually terminated the deal"
+	p.dealLogger.LogError(deal.DealUuid, deal.Err, err)
 	p.saveDealToDB(dh.Publisher, deal)
 
 	// Call cleanupDeal in a go-routine because it sends a message to the provider

--- a/storagemarket/provider.go
+++ b/storagemarket/provider.go
@@ -67,11 +67,11 @@ type Provider struct {
 	newDealPS *newDealPS
 
 	// channels used to pass messages to run loop
-	acceptDealChan    chan acceptDealReq
-	finishedDealChan  chan finishedDealReq
-	publishedDealChan chan publishDealReq
-	retryDealChan     chan retryDealReq
-	storageSpaceChan  chan storageSpaceDealReq
+	acceptDealChan       chan acceptDealReq
+	finishedDealChan     chan finishedDealReq
+	publishedDealChan    chan publishDealReq
+	updateRetryStateChan chan updateRetryStateReq
+	storageSpaceChan     chan storageSpaceDealReq
 
 	// Sealing Pipeline API
 	sps sealingpipeline.API
@@ -97,13 +97,9 @@ type Provider struct {
 
 	fullnodeApi v1api.FullNode
 
-	// Map of deal handlers indexed by deal uuid.
-	dhsMu sync.RWMutex
-	dhs   map[uuid.UUID]*dealHandler
-
-	// Set of deals that are currently running in a go-routine.
-	dealThreadsLk sync.Mutex
-	dealThreads   map[uuid.UUID]struct{}
+	dhsMu       sync.RWMutex
+	dhs         map[uuid.UUID]*dealHandler // Map of deal handlers indexed by deal uuid.
+	dealThreads map[uuid.UUID]struct{}     // Set of deals that are currently running in a go-routine.
 
 	dealLogger *logs.DealLogger
 
@@ -139,11 +135,11 @@ func NewProvider(sqldb *sql.DB, dealsDB *db.DealsDB, fundMgr *fundmanager.FundMa
 		sps:       sps,
 		df:        df,
 
-		acceptDealChan:    make(chan acceptDealReq),
-		finishedDealChan:  make(chan finishedDealReq),
-		publishedDealChan: make(chan publishDealReq),
-		retryDealChan:     make(chan retryDealReq),
-		storageSpaceChan:  make(chan storageSpaceDealReq),
+		acceptDealChan:       make(chan acceptDealReq),
+		finishedDealChan:     make(chan finishedDealReq),
+		publishedDealChan:    make(chan publishDealReq),
+		updateRetryStateChan: make(chan updateRetryStateReq),
+		storageSpaceChan:     make(chan storageSpaceDealReq),
 
 		Transport:      tspt,
 		fundManager:    fundMgr,
@@ -315,19 +311,6 @@ func (p *Provider) checkForDealAcceptance(ds *types.ProviderDealState, isImport 
 	return resp, nil
 }
 
-func (p *Provider) mkAndInsertDealHandler(dealUuid uuid.UUID) *dealHandler {
-	p.dhsMu.Lock()
-	defer p.dhsMu.Unlock()
-	dh, ok := p.dhs[dealUuid]
-	if ok {
-		return dh
-	}
-
-	dh = newDealHandler(p.ctx, dealUuid)
-	p.dhs[dealUuid] = dh
-	return dh
-}
-
 func (p *Provider) Start() error {
 	log.Infow("storage provider: starting")
 
@@ -388,12 +371,17 @@ func (p *Provider) Start() error {
 			}
 		}
 
+		// Set up a deal handler so that clients can subscribe to update
+		// events about the deal
+		_, err := p.mkAndInsertDealHandler(deal.DealUuid)
+		if err != nil {
+			p.dealLogger.LogError(deal.DealUuid, "failed to restart deal", err)
+			continue
+		}
+
 		// If it's an offline deal, and the deal data hasn't yet been
 		// imported, just wait for the SP operator to import the data
 		if deal.IsOffline && deal.InboundFilePath == "" {
-			// Set up a deal handler so that clients can subscribe to update
-			// events about the deal
-			p.mkAndInsertDealHandler(deal.DealUuid)
 			p.dealLogger.Infow(deal.DealUuid, "restarted deal: waiting for offline deal data import")
 			continue
 		}
@@ -408,7 +396,10 @@ func (p *Provider) Start() error {
 
 		// Restart deal
 		p.dealLogger.Infow(deal.DealUuid, "resuming deal on boost restart", "checkpoint", deal.Checkpoint.String())
-		p.startDealThread(deal)
+		_, err = p.startDealThread(deal)
+		if err != nil {
+			p.dealLogger.LogError(deal.DealUuid, "failed to restart deal", err)
+		}
 	}
 
 	// Start provider run loop
@@ -476,11 +467,22 @@ func (p *Provider) SubscribeDealUpdates(dealUuid uuid.UUID) (event.Subscription,
 	return dh.subscribeUpdates()
 }
 
-// RetryDeal starts execution of a deal from the point at which it stopped
-func (p *Provider) RetryDeal(dealUuid uuid.UUID) error {
+// RetryPausedDeal starts execution of a deal from the point at which it stopped
+func (p *Provider) RetryPausedDeal(dealUuid uuid.UUID) error {
+	return p.updateRetryState(dealUuid, true)
+}
+
+// FailPausedDeal moves a deal from the paused state to the failed state
+func (p *Provider) FailPausedDeal(dealUuid uuid.UUID) error {
+	return p.updateRetryState(dealUuid, false)
+}
+
+// updateRetryState either retries the deal or terminates the deal
+// (depending on the value of retry)
+func (p *Provider) updateRetryState(dealUuid uuid.UUID, retry bool) error {
 	resp := make(chan error, 1)
 	select {
-	case p.retryDealChan <- retryDealReq{dealUuid: dealUuid, done: resp}:
+	case p.updateRetryStateChan <- updateRetryStateReq{dealUuid: dealUuid, retry: retry, done: resp}:
 	case <-p.ctx.Done():
 		return p.ctx.Err()
 	}
@@ -514,19 +516,6 @@ func (p *Provider) CancelDealDataTransfer(dealUuid uuid.UUID) error {
 		p.dealLogger.Warnw(dealUuid, "error when user tried to cancel deal data transfer", "err", err)
 	}
 	return err
-}
-
-func (p *Provider) getDealHandler(id uuid.UUID) *dealHandler {
-	p.dhsMu.RLock()
-	defer p.dhsMu.RUnlock()
-
-	return p.dhs[id]
-}
-
-func (p *Provider) delDealHandler(dealUuid uuid.UUID) {
-	p.dhsMu.Lock()
-	delete(p.dhs, dealUuid)
-	p.dhsMu.Unlock()
 }
 
 func (p *Provider) AddPieceToSector(ctx context.Context, deal smtypes.ProviderDealState, pieceData io.Reader) (*storagemarket.PackingResult, error) {


### PR DESCRIPTION
Updates the web UI to add buttons to retry and terminate a deal that is in the Paused state.

As part of the PR I needed to
- Add a FailPausedDeal endpoint
- Do some refactoring of the deal handler to enable this new endpoint