### PR TITLE
Require specific node version for Make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,14 @@ $(warning Your Golang version is go$(shell expr $(GOVERSION) / 1000000).$(shell 
 $(error Update Golang to version to at least 1.16.0)
 endif
 
+LTS_NODE_VER=16
+NODE_VER=$(shell node -v)
+ifeq ($(patsubst v$(LTS_NODE_VER).%,matched,$(NODE_VER)), matched)
+	NODE_LTS=true
+else
+	NODE_LTS=false
+endif
+
 # git modules that need to be loaded
 MODULES:=
 
@@ -92,10 +100,15 @@ boostci: $(BUILD_DEPS)
 	$(GOCC) build $(GOFLAGS) -o boostci ./cmd/boostci
 .PHONY: boostci
 
-react:
+react: check-node-lts
 	npm install --prefix react
 	npm run --prefix react build
 .PHONY: react
+
+.PHONY: check-node-lts
+check-node-lts:
+	@$(NODE_LTS) || echo Build requires Node v$(LTS_NODE_VER) \(detected Node $(NODE_VER)\)
+	@$(NODE_LTS) && echo Building using Node v$(LTS_NODE_VER)
 
 build-go: boost devnet
 .PHONY: build-go


### PR DESCRIPTION
```
$ nvm use v17.0.1
Now using node v17.0.1 (npm v8.1.0)

$ make
Build requires Node v16 (detected Node v17.0.1)
make: *** [check-node-lts] Error 1

$ nvm use v16.12.0
Now using node v16.12.0 (npm v8.1.0)

$ make
Building using Node v16
npm install --prefix react
...
```