### PR TITLE
fix spurious node warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ boostci: $(BUILD_DEPS)
 .PHONY: boostci
 
 react: check-node-lts
-	npm install --prefix react
+	npm install --no-audit --prefix react
 	npm run --prefix react build
 .PHONY: react
 


### PR DESCRIPTION
Fixes https://github.com/filecoin-project/boost/issues/567

Unfortunately it's not really possible to fix this properly, as explained in https://github.com/facebook/create-react-app/issues/11174

Because the web interface is not exposed to the internet anyway we can just suppress the audit warnings.