### PR TITLE
replace npm install with npm ci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,11 @@ boostci: $(BUILD_DEPS)
 .PHONY: boostci
 
 react: check-node-lts
+	npm_config_legacy_peer_deps=yes npm ci --no-audit --prefix react
+	npm run --prefix react build
+.PHONY: react
+
+update-react: check-node-lts
 	npm_config_legacy_peer_deps=yes npm install --no-audit --prefix react
 	npm run --prefix react build
 .PHONY: react


### PR DESCRIPTION
Since not all of our node dependencies are locked in `package.json`, `npm install` upgrades them whenever possible. (more background at: https://stackoverflow.com/questions/45022048/why-does-npm-install-rewrite-package-lock-json)

I think it is preferable that we have reproducible builds and build packages as they are defined in `package-lock.json`, so I suggest we change to `npm ci` and occasionally on-demand upgrade our dependencies.