### PR TITLE
feat(cli): render error outputs as JSON when the option is set

### DIFF
--- a/cmd/util.go
+++ b/cmd/util.go
@@ -39,6 +39,23 @@ func GetAddrInfo(ctx context.Context, api api.Gateway, maddr address.Address) (*
 	}, nil
 }
 
+/*
+inJson is one optional param, default to false
+*/
+func PrintError(err error, inJson ...bool) error {
+	outputInJson := false
+	if len(inJson) > 0 {
+		outputInJson = inJson[0]
+	}
+	if outputInJson {
+		return PrintJson(map[string]string{
+			"error": err.Error(),
+		})
+	} else {
+		return fmt.Errorf("%w", err)
+	}
+}
+
 func PrintJson(obj interface{}) error {
 	resJson, err := json.MarshalIndent(obj, "", "  ")
 	if err != nil {


### PR DESCRIPTION
Closes #603 

This PR aims to wrap all errors in a JSON file when the `--json` flag is set:
```json
{
    "error": "error message"
}
```
The feature was discussed here: https://github.com/filecoin-project/boost/pull/603#issuecomment-1160546599

