### PR TITLE
chore: add dependabot.yml file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# This file is currently restricting to just Lotus, and is
+# running daily to help catch any unexpected releases for API compat
+# checks. If we decide to add more modules later, we could switch this
+# to run on Wednesday's UTC mornings, to catch the Tuesday RC releases from
+# lotus, and avoid daily dependabot spam.
+
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-name: "github.com/filecoin-project/lotus"
+        dependency-type: "direct"


### PR DESCRIPTION
This is intended to catch any updates to lotus that cause a break in the API versioning so that we can cut a release as needed. Ideally we'd be able to map to Major semver versions but there is currently no guarantee that minor versions won't be breaking. This should at least allow us to catch any releases that fall outside of the unscheduled process.