### PR TITLE
fix: dont use the gostream patch

### DIFF
--- a/transport/httptransport/libp2p_server.go
+++ b/transport/httptransport/libp2p_server.go
@@ -248,7 +248,7 @@ func (s *Libp2pCarServer) sendCar(r *http.Request, w http.ResponseWriter, val *A
 	}}
 
 	// Get a channel that will be closed when the client closes the connection
-	stream := getConn(r).(gostream.Stream)
+	stream := getConn(r).(network.Stream)
 	closeCh := s.streamMonitor.getCloseChan(stream.ID())
 
 	// Send the content


### PR DESCRIPTION
We can just use the libp2p network Stream