### PR TITLE
Fix 'database is locked' error

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -19,7 +19,12 @@ type Scannable interface {
 }
 
 func SqlDB(dbPath string) (*sql.DB, error) {
-	return sql.Open("sqlite3", "file:"+dbPath)
+	db, err := sql.Open("sqlite3", "file:"+dbPath)
+	if err == nil {
+		db.SetMaxOpenConns(1)
+	}
+
+	return db, err
 }
 
 //go:embed create_main_db.sql


### PR DESCRIPTION
Fixes https://github.com/filecoin-project/boost/issues/652

Caused by concurrent access from deal goroutines to a single sqlite3 DB connection. By default, this will cause the 'database is locked' error, and it is the reason for failures in deal status updates and deal log appends. The fix comes from suggestions in https://github.com/mattn/go-sqlite3#:~:text=Error%3A%20database%20is%20locked and https://github.com/mattn/go-sqlite3/issues/209.

I wrote a toy program to reproduce the error and confirmed that this change fixes the error, and does the same to my boost daemon instance.