### PR TITLE
Retrieval query ask v2

### DIFF
--- a/client/retrieval.go
+++ b/client/retrieval.go
@@ -1,0 +1,51 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/filecoin-project/boost/retrievalmarket/lp2pimpl"
+	"github.com/filecoin-project/boost/retrievalmarket/types"
+	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/libp2p/go-libp2p-core/peerstore"
+	"github.com/libp2p/go-libp2p-peerstore/pstoremem"
+)
+
+// RetrievalClient runs retrieval queries with Boost over libp2p
+type RetrievalClient struct {
+	PeerStore   peerstore.Peerstore
+	queryClient *lp2pimpl.QueryClient
+}
+
+// NewRetrievalClient sets up a libp2p host to run retrieval query ask v2 queries
+func NewRetrievalClient() (*RetrievalClient, error) {
+	pstore, err := pstoremem.NewPeerstore()
+	if err != nil {
+		return nil, fmt.Errorf("creating peer store: %w", err)
+	}
+	opts := []libp2p.Option{
+		libp2p.DefaultTransports,
+		libp2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/0"),
+		libp2p.Peerstore(pstore),
+		libp2p.NoListenAddrs,
+	}
+
+	h, err := libp2p.New(opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	retryOpts := lp2pimpl.RetryParameters(time.Millisecond, time.Millisecond, 1, 1)
+	return &RetrievalClient{
+		queryClient: lp2pimpl.NewQueryClient(h, retryOpts),
+		PeerStore:   pstore,
+	}, nil
+}
+
+// Query sends a retrieval query v2 to another peer
+func (c *RetrievalClient) Query(ctx context.Context, providerID peer.ID, query types.Query) (*types.QueryResponse, error) {
+	// Send the deal proposal to the provider
+	return c.queryClient.SendQuery(ctx, providerID, query)
+}

--- a/cmd/boost/main.go
+++ b/cmd/boost/main.go
@@ -40,6 +40,7 @@ func main() {
 			offlineDealCmd,
 			providerCmd,
 			walletCmd,
+			retrievePieceCmd,
 		},
 	}
 	app.Setup()

--- a/cmd/boost/retrieve_piece_cmd.go
+++ b/cmd/boost/retrieve_piece_cmd.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"fmt"
+
+	bcli "github.com/filecoin-project/boost/cli"
+	clinode "github.com/filecoin-project/boost/cli/node"
+	"github.com/filecoin-project/boost/cmd"
+	"github.com/filecoin-project/boost/retrievalmarket/lp2pimpl"
+	"github.com/filecoin-project/boost/retrievalmarket/types"
+	"github.com/filecoin-project/go-address"
+	lcli "github.com/filecoin-project/lotus/cli"
+	"github.com/ipfs/go-cid"
+	"github.com/urfave/cli/v2"
+)
+
+var retrievePieceCmd = &cli.Command{
+	Name:  "retrieve-piece",
+	Usage: "",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:     "provider",
+			Usage:    "storage provider on-chain address",
+			Required: true,
+		},
+		&cli.StringFlag{
+			Name:     "piece-cid",
+			Usage:    "",
+			Required: true,
+		},
+	},
+	Before: before,
+	Action: func(cctx *cli.Context) error {
+		ctx := bcli.ReqContext(cctx)
+
+		pieceCID, err := cid.Parse(cctx.String("piece-cid"))
+		if err != nil {
+			return err
+		}
+
+		n, err := clinode.Setup(cctx.String(cmd.FlagRepo.Name))
+		if err != nil {
+			return err
+		}
+
+		api, closer, err := lcli.GetGatewayAPI(cctx)
+		if err != nil {
+			return fmt.Errorf("cant setup gateway connection: %w", err)
+		}
+		defer closer()
+
+		maddr, err := address.NewFromString(cctx.String("provider"))
+		if err != nil {
+			return err
+		}
+
+		addrInfo, err := cmd.GetAddrInfo(ctx, api, maddr)
+		if err != nil {
+			return err
+		}
+
+		log.Debugw("found storage provider", "id", addrInfo.ID, "multiaddrs", addrInfo.Addrs, "addr", maddr)
+
+		if err := n.Host.Connect(ctx, *addrInfo); err != nil {
+			return fmt.Errorf("failed to connect to peer %s: %w", addrInfo.ID, err)
+		}
+
+		dc := lp2pimpl.NewQueryClient(n.Host)
+		resp, err := dc.SendQuery(ctx, addrInfo.ID, types.Query{
+			PieceCID: &pieceCID,
+		})
+		if err != nil {
+			return fmt.Errorf("send deal status request failed: %w", err)
+		}
+
+		if resp.Error != "" {
+			return fmt.Errorf("query response error: %s", resp.Error)
+		}
+		fmt.Println(resp.Protocols.HTTPFilecoinV1.URL)
+		return nil
+	},
+}

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/filecoin-project/go-data-transfer v1.15.2
 	github.com/filecoin-project/go-fil-commcid v0.1.0
 	github.com/filecoin-project/go-fil-commp-hashhash v0.1.0
-	github.com/filecoin-project/go-fil-markets v1.23.2
+	github.com/filecoin-project/go-fil-markets v1.23.3-0.20220816074508-e7b2b38251f7
 	github.com/filecoin-project/go-jsonrpc v0.1.5
 	github.com/filecoin-project/go-padreader v0.0.1
 	github.com/filecoin-project/go-paramfetch v0.0.4

--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/ipfs/go-unixfs v0.3.1
 	github.com/ipld/go-car v0.4.1-0.20220707083113-89de8134e58e
 	github.com/ipld/go-car/v2 v2.4.2-0.20220707083113-89de8134e58e
-	github.com/ipld/go-ipld-prime v0.17.0
+	github.com/ipld/go-ipld-prime v0.17.1-0.20220627233435-adf99676901e
 	github.com/ipld/go-ipld-selector-text-lite v0.0.1
 	github.com/jbenet/go-random v0.0.0-20190219211222-123a90aedc0c
 	github.com/jpillora/backoff v1.0.0
@@ -83,7 +83,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/multiformats/go-multiaddr v0.5.0
 	github.com/multiformats/go-multibase v0.0.3
-	github.com/multiformats/go-multihash v0.1.0
+	github.com/multiformats/go-multihash v0.2.0
 	github.com/multiformats/go-varint v0.0.6
 	github.com/open-rpc/meta-schema v0.0.0-20201029221707-1b72ef2ea333
 	github.com/pressly/goose/v3 v3.5.3

--- a/go.sum
+++ b/go.sum
@@ -1022,8 +1022,9 @@ github.com/ipld/go-ipld-prime v0.14.1/go.mod h1:QcE4Y9n/ZZr8Ijg5bGPT0GqYWgZ1704n
 github.com/ipld/go-ipld-prime v0.14.2/go.mod h1:QcE4Y9n/ZZr8Ijg5bGPT0GqYWgZ1704nH0RDcQtgTP0=
 github.com/ipld/go-ipld-prime v0.14.4-0.20211217152141-008fd70fc96f/go.mod h1:QcE4Y9n/ZZr8Ijg5bGPT0GqYWgZ1704nH0RDcQtgTP0=
 github.com/ipld/go-ipld-prime v0.16.0/go.mod h1:axSCuOCBPqrH+gvXr2w9uAOulJqBPhHPT2PjoiiU1qA=
-github.com/ipld/go-ipld-prime v0.17.0 h1:+U2peiA3aQsE7mrXjD2nYZaZrCcakoz2Wge8K42Ld8g=
 github.com/ipld/go-ipld-prime v0.17.0/go.mod h1:aYcKm5TIvGfY8P3QBKz/2gKcLxzJ1zDaD+o0bOowhgs=
+github.com/ipld/go-ipld-prime v0.17.1-0.20220627233435-adf99676901e h1:p5qepdt1UEk6UadNwNBFDlm/uC+GwSmdVB4wqyt2JLA=
+github.com/ipld/go-ipld-prime v0.17.1-0.20220627233435-adf99676901e/go.mod h1:735yXW548CKrLwVCYXzqx90p5deRJMVVxM9eJ4Qe+qE=
 github.com/ipld/go-ipld-prime-proto v0.0.0-20191113031812-e32bd156a1e5/go.mod h1:gcvzoEDBjwycpXt3LBE061wT9f46szXGHAmj9uoP6fU=
 github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20211210234204-ce2a1c70cd73 h1:TsyATB2ZRRQGTwafJdgEUQkmjOExRV0DNokcihZxbnQ=
 github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20211210234204-ce2a1c70cd73/go.mod h1:2PJ0JgxyB08t0b2WKrcuqI3di0V+5n6RS/LTUJhkoxY=
@@ -1736,8 +1737,9 @@ github.com/multiformats/go-multihash v0.0.13/go.mod h1:VdAWLKTwram9oKAatUcLxBNUj
 github.com/multiformats/go-multihash v0.0.14/go.mod h1:VdAWLKTwram9oKAatUcLxBNUjdtcVwxObEQBtRfuyjc=
 github.com/multiformats/go-multihash v0.0.15/go.mod h1:D6aZrWNLFTV/ynMpKsNtB40mJzmCl4jb1alC0OvHiHg=
 github.com/multiformats/go-multihash v0.0.16/go.mod h1:zhfEIgVnB/rPMfxgFw15ZmGoNaKyNUIE4IWHG/kC+Ag=
-github.com/multiformats/go-multihash v0.1.0 h1:CgAgwqk3//SVEw3T+6DqI4mWMyRuDwZtOWcJT0q9+EA=
 github.com/multiformats/go-multihash v0.1.0/go.mod h1:RJlXsxt6vHGaia+S8We0ErjhojtKzPP2AH4+kYM7k84=
+github.com/multiformats/go-multihash v0.2.0 h1:oytJb9ZA1OUW0r0f9ea18GiaPOo4SXyc7p2movyUuo4=
+github.com/multiformats/go-multihash v0.2.0/go.mod h1:WxoMcYG85AZVQUyRyo9s4wULvW5qrI9vb2Lt6evduFc=
 github.com/multiformats/go-multistream v0.0.1/go.mod h1:fJTiDfXJVmItycydCnNx4+wSzZ5NwG2FEVAI30fiovg=
 github.com/multiformats/go-multistream v0.0.4/go.mod h1:fJTiDfXJVmItycydCnNx4+wSzZ5NwG2FEVAI30fiovg=
 github.com/multiformats/go-multistream v0.1.0/go.mod h1:fJTiDfXJVmItycydCnNx4+wSzZ5NwG2FEVAI30fiovg=
@@ -2296,8 +2298,9 @@ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20211209193657-4570a0811e8b/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220210151621-f4118a5b28e2/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
-golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4 h1:kUhD7nTDoI3fVd9G4ORWrbV5NY0liEs/Jg2pv5f+bBA=
 golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e h1:T8NU3HyQ8ClP4SEE+KbFlg6n0NhuTsN4MyznaarGsZM=
+golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20180807140117-3d87b88a115f/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20181106170214-d68db9428509/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=

--- a/go.sum
+++ b/go.sum
@@ -386,8 +386,8 @@ github.com/filecoin-project/go-fil-commcid v0.1.0/go.mod h1:Eaox7Hvus1JgPrL5+M3+
 github.com/filecoin-project/go-fil-commp-hashhash v0.1.0 h1:imrrpZWEHRnNqqv0tN7LXep5bFEVOVmQWHJvl2mgsGo=
 github.com/filecoin-project/go-fil-commp-hashhash v0.1.0/go.mod h1:73S8WSEWh9vr0fDJVnKADhfIv/d6dCbAGaAGWbdJEI8=
 github.com/filecoin-project/go-fil-markets v1.23.1/go.mod h1:V+1vFO34RZmpdECdikKGiyWhSNJK81Q89Kn0egA9iAk=
-github.com/filecoin-project/go-fil-markets v1.23.2 h1:9+5CCliLVoTbq3qffT2xZMuGjyl2HyR0RJ7x29ywRi8=
-github.com/filecoin-project/go-fil-markets v1.23.2/go.mod h1:V+1vFO34RZmpdECdikKGiyWhSNJK81Q89Kn0egA9iAk=
+github.com/filecoin-project/go-fil-markets v1.23.3-0.20220816074508-e7b2b38251f7 h1:TvaIZYQ7OK55kA5HFImQTV3AT6+A7hrH3jOySl9unjY=
+github.com/filecoin-project/go-fil-markets v1.23.3-0.20220816074508-e7b2b38251f7/go.mod h1:V+1vFO34RZmpdECdikKGiyWhSNJK81Q89Kn0egA9iAk=
 github.com/filecoin-project/go-hamt-ipld v0.1.5 h1:uoXrKbCQZ49OHpsTCkrThPNelC4W3LPEk0OrS/ytIBM=
 github.com/filecoin-project/go-hamt-ipld v0.1.5/go.mod h1:6Is+ONR5Cd5R6XZoCse1CWaXZc0Hdb/JeX+EQCQzX24=
 github.com/filecoin-project/go-hamt-ipld/v2 v2.0.0 h1:b3UDemBYN2HNfk3KOXNuxgTTxlWi3xVvbQP0IT38fvM=

--- a/node/builder.go
+++ b/node/builder.go
@@ -478,7 +478,7 @@ func ConfigBoost(cfg *config.Boost) Option {
 		Override(new(*storagemarket.ChainDealManager), modules.NewChainDealManager),
 
 		Override(new(*storagemarket.Provider), modules.NewStorageMarketProvider(walletMiner, cfg)),
-		Override(new(*retrievalmarket.Provider), modules.NewStorageMarketProvider(walletMiner, cfg)),
+		Override(new(*retrievalmarket.Provider), modules.NewRetrievalMarketProvider(walletMiner, cfg)),
 
 		// GraphQL server
 		Override(new(*gql.Server), modules.NewGraphqlServer(cfg)),

--- a/node/builder.go
+++ b/node/builder.go
@@ -514,10 +514,11 @@ func ConfigBoost(cfg *config.Boost) Option {
 		Override(new(lotus_retrievalmarket.RetrievalProviderNode), retrievaladapter.NewRetrievalProviderNode),
 		Override(new(rmnet.RetrievalMarketNetwork), lotus_modules.RetrievalNetwork),
 		Override(new(lotus_retrievalmarket.RetrievalProvider), lotus_modules.RetrievalProvider),
-		Override(HandleRetrievalKey, lotus_modules.HandleRetrieval),
+		Override(HandleRetrievalKey, modules.HandleLegacyRetrievals),
+		Override(HandleBoostRetrievalsKey, modules.HandleBoostRetrievals),
+
 		Override(new(idxprov.MeshCreator), idxprov.NewMeshCreator),
 		Override(new(provider.Interface), modules.IndexProvider(cfg.IndexProvider)),
-		Override(HandleBoostRetrievalsKey, modules.HandleBoostRetrievals),
 
 		// Lotus Markets (storage)
 		Override(new(lotus_dtypes.ProviderTransferNetwork), lotus_modules.NewProviderTransferNetwork),

--- a/node/config/doc_gen.go
+++ b/node/config/doc_gen.go
@@ -253,6 +253,12 @@ see https://docs.filecoin.io/mine/lotus/miner-configuration/#using-filters-for-f
 
 			Comment: `The maximum amount of time a transfer can take before it fails`,
 		},
+		{
+			Name: "HTTPRetrievalURL",
+			Type: "string",
+
+			Comment: `The public URL for retrieving deals with booster-http`,
+		},
 	},
 	"FeeConfig": []DocField{
 		{

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -175,6 +175,9 @@ type DealmakingConfig struct {
 
 	// The maximum amount of time a transfer can take before it fails
 	MaxTransferDuration Duration
+
+	// The public URL for retrieving deals with booster-http
+	HTTPRetrievalURL string
 }
 
 type FeeConfig struct {

--- a/node/modules/storageminer.go
+++ b/node/modules/storageminer.go
@@ -379,6 +379,11 @@ func HandleBoostDeals(lc fx.Lifecycle, h host.Host, prov *storagemarket.Provider
 	})
 }
 
+func HandleLegacyRetrievals(host host.Host, lc fx.Lifecycle, lrp lotus_retrievalmarket.RetrievalProvider, j journal.Journal) error {
+	log.Info("starting legacy retrieval provider")
+	modules.HandleRetrieval(host, lc, lrp, j)
+	return nil
+}
 func HandleBoostRetrievals(lc fx.Lifecycle, h host.Host, prov *retrievalmarket.Provider, legacyRP lotus_retrievalmarket.RetrievalProvider) {
 	lp2pnet := rlp2pimpl.NewQueryProvider(h, prov)
 

--- a/retrievalmarket/lp2pimpl/net.go
+++ b/retrievalmarket/lp2pimpl/net.go
@@ -1,0 +1,138 @@
+package lp2pimpl
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/filecoin-project/boost/retrievalmarket"
+	"github.com/filecoin-project/boost/retrievalmarket/types"
+	"github.com/filecoin-project/go-fil-markets/shared"
+	logging "github.com/ipfs/go-log/v2"
+	"github.com/ipld/go-ipld-prime/codec/dagcbor"
+	host "github.com/libp2p/go-libp2p-core/host"
+	"github.com/libp2p/go-libp2p-core/network"
+	peer "github.com/libp2p/go-libp2p-core/peer"
+	protocol "github.com/libp2p/go-libp2p-core/protocol"
+)
+
+var log = logging.Logger("boost-net")
+
+// QueryV2ProtocolID is the protocol for querying information about retrieval
+// deal parameters
+const QueryV2ProtocolID = protocol.ID("/fil/retrieval/qry/2.0.0")
+
+// QueryProvider listens for incoming deal proposals over libp2p
+type QueryProvider struct {
+	ctx  context.Context
+	host host.Host
+	prov *retrievalmarket.Provider
+}
+
+const providerReadDeadline = 10 * time.Second
+const providerWriteDeadline = 10 * time.Second
+const clientReadDeadline = 10 * time.Second
+const clientWriteDeadline = 10 * time.Second
+
+// QueryClientOption is an option for configuring the libp2p storage deal client
+type QueryClientOption func(*QueryClient)
+
+// RetryParameters changes the default parameters around connection reopening
+func RetryParameters(minDuration time.Duration, maxDuration time.Duration, attempts float64, backoffFactor float64) QueryClientOption {
+	return func(c *QueryClient) {
+		c.retryStream.SetOptions(shared.RetryParameters(minDuration, maxDuration, attempts, backoffFactor))
+	}
+}
+
+// QueryClient sends retrieval queries over libp2p
+type QueryClient struct {
+	retryStream *shared.RetryStream
+}
+
+// SendQuery sends a retrieval query over a libp2p stream to the peer
+func (c *QueryClient) SendQuery(ctx context.Context, id peer.ID, query types.Query) (*types.QueryResponse, error) {
+	log.Debugw("send query", "pieceCID", query.PieceCID, "payloadCID", query.PayloadCID, "provider-peer", id)
+
+	// Create a libp2p stream to the provider
+	s, err := c.retryStream.OpenStream(ctx, id, []protocol.ID{QueryV2ProtocolID})
+	if err != nil {
+		return nil, err
+	}
+
+	defer s.Close() // nolint
+
+	// Set a deadline on writing to the stream so it doesn't hang
+	_ = s.SetWriteDeadline(time.Now().Add(clientWriteDeadline))
+	defer s.SetWriteDeadline(time.Time{}) // nolint
+
+	// Write the retrieval query to the stream
+	// Write the re to the client
+	err = types.BindnodeRegistry.TypeToWriter(query, s, dagcbor.Encode)
+	if err != nil {
+
+		return nil, fmt.Errorf("sending query: %w", err)
+	}
+
+	// Set a deadline on reading from the stream so it doesn't hang
+	_ = s.SetReadDeadline(time.Now().Add(clientReadDeadline))
+	defer s.SetReadDeadline(time.Time{}) // nolint
+
+	// Read the response from the stream
+	queryResponsei, err := types.BindnodeRegistry.TypeFromReader(s, (*types.QueryResponse)(nil), dagcbor.Decode)
+	if err != nil {
+		return nil, fmt.Errorf("reading query response: %w", err)
+	}
+	queryResponse := queryResponsei.(*types.QueryResponse)
+
+	log.Debugw("received queryresponse", "pieceCID", query.PieceCID, "payloadCID", query.PayloadCID, "status", queryResponse.Status, "error", queryResponse.Error)
+
+	return queryResponse, nil
+}
+
+func NewQueryProvider(h host.Host, prov *retrievalmarket.Provider) *QueryProvider {
+	p := &QueryProvider{
+		host: h,
+		prov: prov,
+	}
+	return p
+}
+
+func (p *QueryProvider) Start(ctx context.Context) {
+	p.ctx = ctx
+	p.host.SetStreamHandler(QueryV2ProtocolID, p.handleNewQueryStream)
+}
+
+func (p *QueryProvider) Stop() {
+	p.host.RemoveStreamHandler(QueryV2ProtocolID)
+}
+
+// Called when the client opens a libp2p stream with a new deal proposal
+func (p *QueryProvider) handleNewQueryStream(s network.Stream) {
+	defer s.Close()
+
+	// Set a deadline on reading from the stream so it doesn't hang
+	_ = s.SetReadDeadline(time.Now().Add(providerReadDeadline))
+	defer s.SetReadDeadline(time.Time{}) // nolint
+
+	// Read the query from the stream
+	queryi, err := types.BindnodeRegistry.TypeFromReader(s, (*types.Query)(nil), dagcbor.Decode)
+	if err != nil {
+		log.Warnw("reading query from stream", "err", err)
+		return
+	}
+	query := queryi.(*types.Query)
+
+	// run the query to generate a response
+	queryResponse := p.prov.ExecuteQuery(query, s.Conn().RemotePeer())
+
+	// Set a deadline on writing to the stream so it doesn't hang
+	_ = s.SetWriteDeadline(time.Now().Add(providerWriteDeadline))
+	defer s.SetWriteDeadline(time.Time{}) // nolint
+
+	// Write the response to the client
+	err = types.BindnodeRegistry.TypeToWriter(queryResponse, s, dagcbor.Encode)
+	if err != nil {
+		log.Warnw("writing query response", "pieceCID", query.PieceCID, "payloadCID", query.PayloadCID, "err", err)
+		return
+	}
+}

--- a/retrievalmarket/lp2pimpl/net.go
+++ b/retrievalmarket/lp2pimpl/net.go
@@ -49,6 +49,16 @@ type QueryClient struct {
 	retryStream *shared.RetryStream
 }
 
+func NewQueryClient(h host.Host, options ...QueryClientOption) *QueryClient {
+	c := &QueryClient{
+		retryStream: shared.NewRetryStream(h),
+	}
+	for _, option := range options {
+		option(c)
+	}
+	return c
+}
+
 // SendQuery sends a retrieval query over a libp2p stream to the peer
 func (c *QueryClient) SendQuery(ctx context.Context, id peer.ID, query types.Query) (*types.QueryResponse, error) {
 	log.Debugw("send query", "pieceCID", query.PieceCID, "payloadCID", query.PayloadCID, "provider-peer", id)

--- a/retrievalmarket/provider.go
+++ b/retrievalmarket/provider.go
@@ -167,7 +167,7 @@ func (p *Provider) ExecuteQuery(q *types.Query, remote peer.ID) *types.QueryResp
 	// we have the piece, but do we have it unsealed?
 	if !p.pieceInUnsealedSector(p.ctx, pieceInfo) {
 		answer.Status = types.QueryResponseError
-		answer.Error = fmt.Sprintf("piece not avialable in unsealed sector")
+		answer.Error = "piece not avialable in unsealed sector"
 		return &answer
 	}
 

--- a/retrievalmarket/provider.go
+++ b/retrievalmarket/provider.go
@@ -1,0 +1,435 @@
+package retrievalmarket
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/filecoin-project/boost/retrievalmarket/types"
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-fil-markets/piecestore"
+	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
+	"github.com/filecoin-project/go-fil-markets/stores"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/lotus/api/v1api"
+	ctypes "github.com/filecoin-project/lotus/chain/types"
+	"github.com/filecoin-project/lotus/markets/dagstore"
+	"github.com/hashicorp/go-multierror"
+	"github.com/ipfs/go-cid"
+	logging "github.com/ipfs/go-log/v2"
+	peer "github.com/libp2p/go-libp2p-core/peer"
+)
+
+var log = logging.Logger("boost-provider")
+
+// Config is config vars that are used by the provider
+type Config struct {
+	// HTTP Retrievals URL -- if blank HTTP retrieval is considered "off"
+	HTTPRetrievalURL string
+}
+
+// RetrievalPricingFunc is a custom function that sets retrieval pricing
+type RetrievalPricingFunc func(ctx context.Context, dealPricingParams retrievalmarket.PricingInput) (retrievalmarket.Ask, error)
+
+// Provider is the boost implementation of the retrieval provider, which currently
+// only implements the QueryAsk v2 protocol
+type Provider struct {
+	ctx                  context.Context
+	cancel               context.CancelFunc
+	Address              address.Address
+	config               Config
+	fullnodeAPI          v1api.FullNode
+	dagStore             stores.DAGStoreWrapper
+	pieceStore           piecestore.PieceStore
+	sa                   dagstore.SectorAccessor
+	askStore             retrievalmarket.AskStore
+	retrievalPricingFunc RetrievalPricingFunc
+}
+
+// NewProvider returns a new retrieval Provider
+func NewProvider(config Config,
+	address address.Address,
+	fullnodeAPI v1api.FullNode,
+	sa dagstore.SectorAccessor,
+	pieceStore piecestore.PieceStore,
+	dagStore stores.DAGStoreWrapper,
+	askStore retrievalmarket.AskStore,
+	retrievalPricingFunc RetrievalPricingFunc,
+) (*Provider, error) {
+
+	if retrievalPricingFunc == nil {
+		return nil, errors.New("retrievalPricingFunc is nil")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	return &Provider{
+		config:               config,
+		Address:              address,
+		sa:                   sa,
+		pieceStore:           pieceStore,
+		retrievalPricingFunc: retrievalPricingFunc,
+		dagStore:             dagStore,
+		askStore:             askStore,
+		fullnodeAPI:          fullnodeAPI,
+		ctx:                  ctx,
+		cancel:               cancel,
+	}, nil
+}
+
+// stop shuts down the retreival provider
+func (p *Provider) Stop() {
+	p.cancel()
+}
+
+// ExecuteQuery generates a query response for the queryAsk v2 protocol
+func (p *Provider) ExecuteQuery(q *types.Query, remote peer.ID) *types.QueryResponse {
+
+	answer := types.QueryResponse{
+		Status: types.QueryResponseUnavailable,
+	}
+
+	if q.PayloadCID != nil {
+
+		// payload present, process as payload query
+
+		// fetch the piece from which the payload will be retrieved.
+
+		// if user has specified the Piece in the request, we use that.
+		// Otherwise, we prefer a Piece which can retrieved from an unsealed sector.
+		pieceCID := cid.Undef
+		if q.PieceCID != nil {
+			pieceCID = *q.PieceCID
+		}
+		pieceInfo, isUnsealed, err := p.getPieceInfoFromCid(p.ctx, *q.PayloadCID, pieceCID)
+		// did we find a piece with this payload CID?
+		if err != nil {
+			log.Errorf("Retrieval query: getPieceInfoFromCid: %s", err)
+			if !errors.Is(err, retrievalmarket.ErrNotFound) {
+				answer.Status = types.QueryResponseError
+				answer.Error = fmt.Sprintf("failed to fetch piece to retrieve from: %s", err)
+			} else {
+				answer.Error = "piece info for cid not found (deal has not been added to a piece yet)"
+			}
+			return &answer
+		}
+
+		// graphsync is always available for payloads, so assemble response -- we'll need
+		graphsyncFilecoinV1Response, err := p.graphsyncQueryResponse(q, remote, pieceInfo, isUnsealed)
+		if err != nil {
+			answer.Status = types.QueryResponseError
+			answer.Error = err.Error()
+			return &answer
+		}
+
+		answer.Status = types.QueryResponseAvailable
+		answer.Protocols.GraphsyncFilecoinV1 = &graphsyncFilecoinV1Response
+
+		// add http payload url if we are supporting HTTP retrievals
+		if p.config.HTTPRetrievalURL != "" {
+			answer.Protocols.HTTPFilecoinV1 = &types.HTTPFilecoinV1Response{
+				URL:  p.config.HTTPRetrievalURL + "/payload/" + q.PayloadCID.String() + ".car",
+				Size: uint64(pieceInfo.Deals[0].Length.Unpadded()),
+			}
+		}
+
+		return &answer
+	}
+
+	if q.PieceCID == nil {
+		// payload cid & piece cid are both nil, error
+		answer.Status = types.QueryResponseError
+		answer.Error = "either piece CID or payload CID must be present"
+		return &answer
+	}
+
+	// piece cid only is present, process as piece retrieval, meaning only HTTP is available
+
+	// if http retrieval is not available, there is no piece retrieval supported
+	if p.config.HTTPRetrievalURL == "" {
+		answer.Status = types.QueryResponseError
+		answer.Error = "piece only retrieval not supported"
+		return &answer
+	}
+
+	// lookup information on this piece, determine if there is an unsealed sector
+	pieceInfo, err := p.pieceStore.GetPieceInfo(*q.PieceCID)
+	if err != nil {
+		if !errors.Is(err, retrievalmarket.ErrNotFound) {
+			answer.Status = types.QueryResponseError
+			answer.Error = fmt.Sprintf("failed to fetch piece to retrieve from: %s", err)
+		} else {
+			answer.Error = "piece info for cid not found (deal has not been added to a piece yet)"
+		}
+		return &answer
+	}
+
+	// we have the piece, but do we have it unsealed?
+	if !p.pieceInUnsealedSector(p.ctx, pieceInfo) {
+		answer.Status = types.QueryResponseError
+		answer.Error = fmt.Sprintf("piece not avialable in unsealed sector")
+		return &answer
+	}
+
+	// ok we have an unsealed sector with the piece and HTTP retrieval is on, we're good to go
+	answer.Status = types.QueryResponseAvailable
+	answer.Protocols.HTTPFilecoinV1 = &types.HTTPFilecoinV1Response{
+		URL:  p.config.HTTPRetrievalURL + "/piece/" + q.PieceCID.String(),
+		Size: uint64(pieceInfo.Deals[0].Length.Unpadded()),
+	}
+	return &answer
+
+}
+
+// graphsyncQueryResponse returns graphsync response params for a payload retireval
+func (p *Provider) graphsyncQueryResponse(q *types.Query, remote peer.ID, pieceInfo piecestore.PieceInfo, isUnsealed bool) (types.GraphsyncFilecoinV1Response, error) {
+	graphsyncFilecoinV1Response := &types.GraphsyncFilecoinV1Response{
+		MinPricePerByte: big.Zero(),
+		UnsealPrice:     big.Zero(),
+	}
+	// fetch the payment address the client should send the payment to.
+	minerInfo, err := p.fullnodeAPI.StateMinerInfo(p.ctx, p.Address, ctypes.EmptyTSK)
+	if err != nil {
+		log.Errorf("Retrieval query: Lookup Payment Address: %s", err)
+		return types.GraphsyncFilecoinV1Response{}, fmt.Errorf("failed to look up payment address: %w", err)
+	}
+	graphsyncFilecoinV1Response.PaymentAddress = minerInfo.Worker
+
+	// set the size
+	graphsyncFilecoinV1Response.Size = uint64(pieceInfo.Deals[0].Length.Unpadded()) // TODO: verify on intermediate
+
+	// look up associated storage deals
+	storageDeals, err := p.storageDealsForPiece(q.PieceCID != nil, *q.PayloadCID, pieceInfo)
+	if err != nil {
+		log.Errorf("Retrieval query: storageDealsForPiece: %s", err)
+		return types.GraphsyncFilecoinV1Response{}, fmt.Errorf("failed to fetch storage deals containing payload: %w", err)
+	}
+
+	// get pricing based on dynamic parameters & associated storage deals
+	input := retrievalmarket.PricingInput{
+		// piece from which the payload will be retrieved
+		// If user hasn't given a PieceCID, we try to choose an unsealed piece in the call to `getPieceInfoFromCid` above.
+		PieceCID: pieceInfo.PieceCID,
+
+		PayloadCID: *q.PayloadCID,
+		Unsealed:   isUnsealed,
+		Client:     remote,
+	}
+	ask, err := p.GetDynamicAsk(p.ctx, input, storageDeals)
+	if err != nil {
+		log.Errorf("Retrieval query: GetAsk: %s", err)
+		return types.GraphsyncFilecoinV1Response{}, fmt.Errorf("failed to price deal: %w", err)
+	}
+
+	// set pricing params
+	graphsyncFilecoinV1Response.MinPricePerByte = ask.PricePerByte
+	graphsyncFilecoinV1Response.MaxPaymentInterval = ask.PaymentInterval
+	graphsyncFilecoinV1Response.MaxPaymentIntervalIncrease = ask.PaymentIntervalIncrease
+	graphsyncFilecoinV1Response.UnsealPrice = ask.UnsealPrice
+
+	return *graphsyncFilecoinV1Response, nil
+}
+
+// Given the CID of a block, find a piece that contains that block.
+// If the client has specified which piece they want, return that piece.
+// Otherwise prefer pieces that are already unsealed.
+func (p *Provider) getPieceInfoFromCid(ctx context.Context, payloadCID, clientPieceCID cid.Cid) (piecestore.PieceInfo, bool, error) {
+	// Get all pieces that contain the target block
+	piecesWithTargetBlock, err := p.dagStore.GetPiecesContainingBlock(payloadCID)
+	if err != nil {
+		return piecestore.PieceInfoUndefined, false, fmt.Errorf("getting pieces for cid %s: %w", payloadCID, err)
+	}
+
+	// For each piece that contains the target block
+	var lastErr error
+	var sealedPieceInfo *piecestore.PieceInfo
+	for _, pieceWithTargetBlock := range piecesWithTargetBlock {
+		// Get the deals for the piece
+		pieceInfo, err := p.pieceStore.GetPieceInfo(pieceWithTargetBlock)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+
+		// if client wants to retrieve the payload from a specific piece, just return that piece.
+		if clientPieceCID.Defined() && pieceInfo.PieceCID.Equals(clientPieceCID) {
+			return pieceInfo, p.pieceInUnsealedSector(ctx, pieceInfo), nil
+		}
+
+		// if client doesn't have a preference for a particular piece, prefer a piece
+		// for which an unsealed sector exists.
+		if clientPieceCID.Equals(cid.Undef) {
+			if p.pieceInUnsealedSector(ctx, pieceInfo) {
+				// The piece is in an unsealed sector, so just return it
+				return pieceInfo, true, nil
+			}
+
+			if sealedPieceInfo == nil {
+				// The piece is not in an unsealed sector, so save it but keep
+				// checking other pieces to see if there is one that is in an
+				// unsealed sector
+				sealedPieceInfo = &pieceInfo
+			}
+		}
+
+	}
+
+	// Found a piece containing the target block, piece is in a sealed sector
+	if sealedPieceInfo != nil {
+		return *sealedPieceInfo, false, nil
+	}
+
+	// Couldn't find a piece containing the target block
+	if lastErr == nil {
+		lastErr = fmt.Errorf("unknown pieceCID %s", clientPieceCID.String())
+	}
+
+	// Error finding a piece containing the target block
+	return piecestore.PieceInfoUndefined, false, fmt.Errorf("could not locate piece: %w", lastErr)
+}
+
+func (p *Provider) pieceInUnsealedSector(ctx context.Context, pieceInfo piecestore.PieceInfo) bool {
+	for _, di := range pieceInfo.Deals {
+		isUnsealed, err := p.sa.IsUnsealed(ctx, di.SectorID, di.Offset.Unpadded(), di.Length.Unpadded())
+		if err != nil {
+			log.Errorf("failed to find out if sector %d is unsealed, err=%s", di.SectorID, err)
+			continue
+		}
+		if isUnsealed {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (p *Provider) storageDealsForPiece(clientSpecificPiece bool, payloadCID cid.Cid, pieceInfo piecestore.PieceInfo) ([]abi.DealID, error) {
+	var storageDeals []abi.DealID
+	var err error
+	if clientSpecificPiece {
+		// If the user wants to retrieve the payload from a specific piece,
+		// we only need to inspect storage deals made for that piece to quote a price.
+		for _, d := range pieceInfo.Deals {
+			storageDeals = append(storageDeals, d.DealID)
+		}
+	} else {
+		// If the user does NOT want to retrieve from a specific piece, we'll have to inspect all storage deals
+		// made for that piece to quote a price.
+		storageDeals, err = p.getAllDealsContainingPayload(payloadCID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch deals for payload: %w", err)
+		}
+	}
+
+	if len(storageDeals) == 0 {
+		return nil, errors.New("no storage deals found")
+	}
+
+	return storageDeals, nil
+}
+
+func (p *Provider) getAllDealsContainingPayload(payloadCID cid.Cid) ([]abi.DealID, error) {
+	// Get all pieces that contain the target block
+	piecesWithTargetBlock, err := p.dagStore.GetPiecesContainingBlock(payloadCID)
+	if err != nil {
+		return nil, fmt.Errorf("getting pieces for cid %s: %w", payloadCID, err)
+	}
+
+	// For each piece that contains the target block
+	var lastErr error
+	var dealsIds []abi.DealID
+	for _, pieceWithTargetBlock := range piecesWithTargetBlock {
+		// Get the deals for the piece
+		pieceInfo, err := p.pieceStore.GetPieceInfo(pieceWithTargetBlock)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+
+		for _, d := range pieceInfo.Deals {
+			dealsIds = append(dealsIds, d.DealID)
+		}
+	}
+
+	if lastErr == nil && len(dealsIds) == 0 {
+		return nil, errors.New("no deals found")
+	}
+
+	if lastErr != nil && len(dealsIds) == 0 {
+		return nil, fmt.Errorf("failed to fetch deals containing payload %s: %w", payloadCID, lastErr)
+	}
+
+	return dealsIds, nil
+}
+
+func (p *Provider) getRetrievalPricingInput(ctx context.Context, pieceCID cid.Cid, storageDeals []abi.DealID) (retrievalmarket.PricingInput, error) {
+	resp := retrievalmarket.PricingInput{}
+
+	var mErr error
+
+	for _, dealID := range storageDeals {
+		ds, err := p.fullnodeAPI.StateMarketStorageDeal(ctx, dealID, ctypes.EmptyTSK)
+		if err != nil {
+			log.Warnf("failed to look up deal %d on chain: err=%w", dealID, err)
+			mErr = multierror.Append(mErr, err)
+			continue
+		}
+		if ds.Proposal.VerifiedDeal {
+			resp.VerifiedDeal = true
+		}
+
+		if ds.Proposal.PieceCID.Equals(pieceCID) {
+			resp.PieceSize = ds.Proposal.PieceSize.Unpadded()
+		}
+
+		// If we've discovered a verified deal with the required PieceCID, we don't need
+		// to lookup more deals and we're done.
+		if resp.VerifiedDeal && resp.PieceSize != 0 {
+			break
+		}
+	}
+
+	// Note: The piece size can never actually be zero. We only use it to here
+	// to assert that we didn't find a matching piece.
+	if resp.PieceSize == 0 {
+		if mErr == nil {
+			return resp, errors.New("failed to find matching piece")
+		}
+
+		return resp, fmt.Errorf("failed to fetch storage deal state: %w", mErr)
+	}
+
+	return resp, nil
+}
+
+// GetDynamicAsk quotes a dynamic price for the retrieval deal by calling the user configured
+// dynamic pricing function. It passes the static price parameters set in the Ask Store to the pricing function.
+func (p *Provider) GetDynamicAsk(ctx context.Context, input retrievalmarket.PricingInput, storageDeals []abi.DealID) (retrievalmarket.Ask, error) {
+	dp, err := p.getRetrievalPricingInput(ctx, input.PieceCID, storageDeals)
+	if err != nil {
+		return retrievalmarket.Ask{}, fmt.Errorf("GetRetrievalPricingInput: %s", err)
+	}
+	// currAsk cannot be nil as we initialize the ask store with a default ask.
+	// Users can then change the values in the ask store using SetAsk but not remove it.
+	currAsk := p.GetAsk()
+	if currAsk == nil {
+		return retrievalmarket.Ask{}, errors.New("no ask configured in ask-store")
+	}
+
+	dp.PayloadCID = input.PayloadCID
+	dp.PieceCID = input.PieceCID
+	dp.Unsealed = input.Unsealed
+	dp.Client = input.Client
+	dp.CurrentAsk = *currAsk
+
+	ask, err := p.retrievalPricingFunc(ctx, dp)
+	if err != nil {
+		return retrievalmarket.Ask{}, fmt.Errorf("retrievalPricingFunc: %w", err)
+	}
+	return ask, nil
+}
+
+// GetAsk returns the current deal parameters this provider accepts
+func (p *Provider) GetAsk() *retrievalmarket.Ask {
+	return p.askStore.GetAsk()
+}

--- a/retrievalmarket/provider_test.go
+++ b/retrievalmarket/provider_test.go
@@ -1,0 +1,1060 @@
+package retrievalmarket
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/filecoin-project/boost/retrievalmarket/types"
+	"github.com/filecoin-project/boost/testutil"
+	"github.com/filecoin-project/dagstore/mount"
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-fil-markets/piecestore"
+	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
+	retrievalimpl "github.com/filecoin-project/go-fil-markets/retrievalmarket/impl"
+	"github.com/filecoin-project/go-fil-markets/retrievalmarket/impl/askstore"
+	tut "github.com/filecoin-project/go-fil-markets/shared_testutil"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/go-state-types/builtin/v8/market"
+	"github.com/filecoin-project/lotus/api"
+	lotusmocks "github.com/filecoin-project/lotus/api/mocks"
+	"github.com/filecoin-project/lotus/api/v1api"
+	ctypes "github.com/filecoin-project/lotus/chain/types"
+	"github.com/filecoin-project/lotus/markets/dagstore"
+	"github.com/golang/mock/gomock"
+	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-datastore"
+	"github.com/ipfs/go-datastore/namespace"
+	dss "github.com/ipfs/go-datastore/sync"
+	peer "github.com/libp2p/go-libp2p-core/peer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDynamicPricing(t *testing.T) {
+	expectedAddress := address.TestAddress2
+	expectedMinerWallet := address.TestAddress
+	expectedConfig := Config{
+		HTTPRetrievalURL: "",
+	}
+	payloadCID := testutil.GenerateCids(1)[0]
+	peer1 := peer.ID("peer1")
+	peer2 := peer.ID("peer2")
+
+	// differential price per byte
+	expectedppbUnVerified := abi.NewTokenAmount(4321)
+	expectedppbVerified := abi.NewTokenAmount(2)
+
+	// differential sealing/unsealing price
+	expectedUnsealPrice := abi.NewTokenAmount(100)
+	expectedUnsealDiscount := abi.NewTokenAmount(1)
+
+	// differential payment interval
+	expectedpiPeer1 := uint64(4567)
+	expectedpiPeer2 := uint64(20)
+
+	expectedPaymentIntervalIncrease := uint64(100)
+
+	// multiple pieces have the same payload
+	expectedPieceCID1 := testutil.GenerateCids(1)[0]
+	expectedPieceCID2 := testutil.GenerateCids(1)[0]
+
+	// sizes
+	piece1SizePadded := uint64(1234)
+	piece1Size := uint64(abi.PaddedPieceSize(piece1SizePadded).Unpadded())
+
+	piece2SizePadded := uint64(2234)
+	piece2Size := uint64(abi.PaddedPieceSize(piece2SizePadded).Unpadded())
+
+	piece1 := piecestore.PieceInfo{
+		PieceCID: expectedPieceCID1,
+		Deals: []piecestore.DealInfo{
+			{
+				DealID: abi.DealID(1),
+				Length: abi.PaddedPieceSize(piece1SizePadded),
+			},
+			{
+				DealID: abi.DealID(11),
+				Length: abi.PaddedPieceSize(piece1SizePadded),
+			},
+		},
+	}
+
+	piece2 := piecestore.PieceInfo{
+		PieceCID: expectedPieceCID2,
+		Deals: []piecestore.DealInfo{
+			{
+				DealID: abi.DealID(2),
+				Length: abi.PaddedPieceSize(piece2SizePadded),
+			},
+			{
+				DealID: abi.DealID(22),
+				Length: abi.PaddedPieceSize(piece2SizePadded),
+			},
+			{
+				DealID: abi.DealID(222),
+				Length: abi.PaddedPieceSize(piece2SizePadded),
+			},
+		},
+	}
+
+	dPriceFunc := func(ctx context.Context, dealPricingParams retrievalmarket.PricingInput) (retrievalmarket.Ask, error) {
+		ask := retrievalmarket.Ask{}
+
+		if dealPricingParams.VerifiedDeal {
+			ask.PricePerByte = expectedppbVerified
+		} else {
+			ask.PricePerByte = expectedppbUnVerified
+		}
+
+		if dealPricingParams.Unsealed {
+			ask.UnsealPrice = expectedUnsealDiscount
+		} else {
+			ask.UnsealPrice = expectedUnsealPrice
+		}
+
+		fmt.Println("\n client is", dealPricingParams.Client.String())
+		if dealPricingParams.Client == peer2 {
+			ask.PaymentInterval = expectedpiPeer2
+		} else {
+			ask.PaymentInterval = expectedpiPeer1
+		}
+		ask.PaymentIntervalIncrease = expectedPaymentIntervalIncrease
+
+		return ask, nil
+	}
+
+	buildProvider := func(
+		t *testing.T,
+		sa dagstore.SectorAccessor,
+		fn v1api.FullNode,
+		pieceStore piecestore.PieceStore,
+		dagStore *tut.MockDagStoreWrapper,
+		pFnc RetrievalPricingFunc,
+		askStore retrievalmarket.AskStore,
+	) *Provider {
+		c, err := NewProvider(expectedConfig, expectedAddress, fn, sa, pieceStore, dagStore, askStore, pFnc)
+		require.NoError(t, err)
+		return c
+	}
+
+	mockStorageDealResults := func(n *lotusmocks.MockFullNode, pieceInfo piecestore.PieceInfo, verified bool) {
+		for _, deal := range pieceInfo.Deals {
+			n.EXPECT().StateMarketStorageDeal(gomock.Any(), deal.DealID, ctypes.EmptyTSK).AnyTimes().Return(&api.MarketDeal{
+				Proposal: market.DealProposal{
+					PieceCID:     pieceInfo.PieceCID,
+					PieceSize:    deal.Length,
+					VerifiedDeal: verified,
+				},
+			}, nil)
+		}
+	}
+
+	tcs := map[string]struct {
+		query              types.Query
+		peerID             peer.ID
+		nodeFunc           func(n *lotusmocks.MockFullNode)
+		expFunc            func(t *testing.T, pieceStore *tut.TestPieceStore, dagStore *tut.MockDagStoreWrapper)
+		sectorAccessorFunc func(sa *TestSectorAccessor)
+		setAsk             func(ask *retrievalmarket.Ask)
+		pricingFnc         RetrievalPricingFunc
+
+		expectedPricePerByte            abi.TokenAmount
+		expectedPaymentInterval         uint64
+		expectedPaymentIntervalIncrease uint64
+		expectedUnsealPrice             abi.TokenAmount
+		expectedSize                    uint64
+	}{
+		// Retrieval request for a payloadCid without a pieceCid
+		"pieceCid no-op: quote correct price for sealed, unverified, peer1": {
+			query:  types.Query{PayloadCID: &payloadCID},
+			peerID: peer1,
+			nodeFunc: func(n *lotusmocks.MockFullNode) {
+				mockStorageDealResults(n, piece1, false)
+				mockStorageDealResults(n, piece2, false)
+			},
+			expFunc: func(t *testing.T, pieceStore *tut.TestPieceStore, dagStore *tut.MockDagStoreWrapper) {
+				pieceStore.ExpectPiece(expectedPieceCID1, piece1)
+				pieceStore.ExpectPiece(expectedPieceCID2, piece2)
+				dagStore.AddBlockToPieceIndex(payloadCID, expectedPieceCID1)
+				dagStore.AddBlockToPieceIndex(payloadCID, expectedPieceCID2)
+			},
+			pricingFnc: dPriceFunc,
+
+			expectedPricePerByte:            expectedppbUnVerified,
+			expectedPaymentInterval:         expectedpiPeer1,
+			expectedUnsealPrice:             expectedUnsealPrice,
+			expectedPaymentIntervalIncrease: expectedPaymentIntervalIncrease,
+			expectedSize:                    piece1Size,
+		},
+
+		"pieceCid no-op: quote correct price for sealed, unverified, peer2": {
+			query:  types.Query{PayloadCID: &payloadCID},
+			peerID: peer2,
+			nodeFunc: func(n *lotusmocks.MockFullNode) {
+				mockStorageDealResults(n, piece1, false)
+				mockStorageDealResults(n, piece2, false)
+			},
+			expFunc: func(t *testing.T, pieceStore *tut.TestPieceStore, dagStore *tut.MockDagStoreWrapper) {
+				pieceStore.ExpectPiece(expectedPieceCID1, piece1)
+				pieceStore.ExpectPiece(expectedPieceCID2, piece2)
+				dagStore.AddBlockToPieceIndex(payloadCID, expectedPieceCID1)
+				dagStore.AddBlockToPieceIndex(payloadCID, expectedPieceCID2)
+			},
+			pricingFnc: dPriceFunc,
+
+			expectedPricePerByte:            expectedppbUnVerified,
+			expectedPaymentInterval:         expectedpiPeer2,
+			expectedUnsealPrice:             expectedUnsealPrice,
+			expectedPaymentIntervalIncrease: expectedPaymentIntervalIncrease,
+			expectedSize:                    piece1Size,
+		},
+
+		"pieceCid no-op: quote correct price for sealed, verified, peer1": {
+			query:  types.Query{PayloadCID: &payloadCID},
+			peerID: peer1,
+			nodeFunc: func(n *lotusmocks.MockFullNode) {
+				mockStorageDealResults(n, piece1, true)
+				mockStorageDealResults(n, piece2, true)
+			},
+			expFunc: func(t *testing.T, pieceStore *tut.TestPieceStore, dagStore *tut.MockDagStoreWrapper) {
+				pieceStore.ExpectPiece(expectedPieceCID1, piece1)
+				pieceStore.ExpectPiece(expectedPieceCID2, piece2)
+				dagStore.AddBlockToPieceIndex(payloadCID, expectedPieceCID1)
+				dagStore.AddBlockToPieceIndex(payloadCID, expectedPieceCID2)
+			},
+			pricingFnc: dPriceFunc,
+
+			expectedPricePerByte:            expectedppbVerified,
+			expectedPaymentInterval:         expectedpiPeer1,
+			expectedUnsealPrice:             expectedUnsealPrice,
+			expectedPaymentIntervalIncrease: expectedPaymentIntervalIncrease,
+			expectedSize:                    piece1Size,
+		},
+
+		"pieceCid no-op: quote correct price for unsealed, unverified, peer1": {
+			query:  types.Query{PayloadCID: &payloadCID},
+			peerID: peer1,
+			nodeFunc: func(n *lotusmocks.MockFullNode) {
+				mockStorageDealResults(n, piece1, false)
+				mockStorageDealResults(n, piece2, false)
+			},
+			sectorAccessorFunc: func(sa *TestSectorAccessor) {
+				p := piece2.Deals[0]
+				sa.MarkUnsealed(context.TODO(), p.SectorID, p.Offset.Unpadded(), p.Length.Unpadded())
+			},
+			expFunc: func(t *testing.T, pieceStore *tut.TestPieceStore, dagStore *tut.MockDagStoreWrapper) {
+				//pieceStore.ExpectCID(payloadCID, expectedCIDInfo)
+				pieceStore.ExpectPiece(expectedPieceCID1, piece1)
+				pieceStore.ExpectPiece(expectedPieceCID2, piece2)
+				dagStore.AddBlockToPieceIndex(payloadCID, expectedPieceCID1)
+				dagStore.AddBlockToPieceIndex(payloadCID, expectedPieceCID2)
+			},
+			pricingFnc: dPriceFunc,
+
+			expectedPricePerByte:            expectedppbUnVerified,
+			expectedPaymentInterval:         expectedpiPeer1,
+			expectedUnsealPrice:             expectedUnsealDiscount,
+			expectedPaymentIntervalIncrease: expectedPaymentIntervalIncrease,
+			expectedSize:                    piece2Size,
+		},
+
+		"pieceCid no-op: quote correct price for unsealed, verified, peer1": {
+			query:  types.Query{PayloadCID: &payloadCID},
+			peerID: peer1,
+			nodeFunc: func(n *lotusmocks.MockFullNode) {
+				mockStorageDealResults(n, piece1, true)
+				mockStorageDealResults(n, piece2, true)
+			},
+			sectorAccessorFunc: func(sa *TestSectorAccessor) {
+				p := piece2.Deals[0]
+				sa.MarkUnsealed(context.TODO(), p.SectorID, p.Offset.Unpadded(), p.Length.Unpadded())
+			},
+			expFunc: func(t *testing.T, pieceStore *tut.TestPieceStore, dagStore *tut.MockDagStoreWrapper) {
+				pieceStore.ExpectPiece(expectedPieceCID1, piece1)
+				pieceStore.ExpectPiece(expectedPieceCID2, piece2)
+				dagStore.AddBlockToPieceIndex(payloadCID, expectedPieceCID1)
+				dagStore.AddBlockToPieceIndex(payloadCID, expectedPieceCID2)
+			},
+			pricingFnc: dPriceFunc,
+
+			expectedPricePerByte:            expectedppbVerified,
+			expectedPaymentInterval:         expectedpiPeer1,
+			expectedUnsealPrice:             expectedUnsealDiscount,
+			expectedPaymentIntervalIncrease: expectedPaymentIntervalIncrease,
+			expectedSize:                    piece2Size,
+		},
+
+		"pieceCid no-op: quote correct price for unsealed, verified, peer1 using default pricing policy if data transfer fee set to zero for verified deals": {
+			query:  types.Query{PayloadCID: &payloadCID},
+			peerID: peer1,
+			nodeFunc: func(n *lotusmocks.MockFullNode) {
+				mockStorageDealResults(n, piece1, true)
+				mockStorageDealResults(n, piece2, true)
+			},
+			sectorAccessorFunc: func(sa *TestSectorAccessor) {
+				p := piece2.Deals[0]
+				sa.MarkUnsealed(context.TODO(), p.SectorID, p.Offset.Unpadded(), p.Length.Unpadded())
+			},
+			expFunc: func(t *testing.T, pieceStore *tut.TestPieceStore, dagStore *tut.MockDagStoreWrapper) {
+				pieceStore.ExpectPiece(expectedPieceCID1, piece1)
+				pieceStore.ExpectPiece(expectedPieceCID2, piece2)
+				dagStore.AddBlockToPieceIndex(payloadCID, expectedPieceCID1)
+				dagStore.AddBlockToPieceIndex(payloadCID, expectedPieceCID2)
+			},
+
+			setAsk: func(ask *retrievalmarket.Ask) {
+				ask.PaymentInterval = expectedpiPeer1
+				ask.PaymentIntervalIncrease = expectedPaymentIntervalIncrease
+			},
+
+			pricingFnc: retrievalimpl.DefaultPricingFunc(true),
+
+			expectedPricePerByte:            big.Zero(),
+			expectedUnsealPrice:             big.Zero(),
+			expectedPaymentInterval:         expectedpiPeer1,
+			expectedPaymentIntervalIncrease: expectedPaymentIntervalIncrease,
+			expectedSize:                    piece2Size,
+		},
+
+		"pieceCid no-op: quote correct price for unsealed, verified, peer1 using default pricing policy if data transfer fee not set to zero for verified deals": {
+			query:  types.Query{PayloadCID: &payloadCID},
+			peerID: peer1,
+			nodeFunc: func(n *lotusmocks.MockFullNode) {
+				mockStorageDealResults(n, piece1, true)
+				mockStorageDealResults(n, piece2, true)
+			},
+			sectorAccessorFunc: func(sa *TestSectorAccessor) {
+				p := piece2.Deals[0]
+				sa.MarkUnsealed(context.TODO(), p.SectorID, p.Offset.Unpadded(), p.Length.Unpadded())
+			},
+			expFunc: func(t *testing.T, pieceStore *tut.TestPieceStore, dagStore *tut.MockDagStoreWrapper) {
+				pieceStore.ExpectPiece(expectedPieceCID1, piece1)
+				pieceStore.ExpectPiece(expectedPieceCID2, piece2)
+				dagStore.AddBlockToPieceIndex(payloadCID, expectedPieceCID1)
+				dagStore.AddBlockToPieceIndex(payloadCID, expectedPieceCID2)
+			},
+
+			setAsk: func(ask *retrievalmarket.Ask) {
+				ask.PricePerByte = expectedppbVerified
+				ask.PaymentInterval = expectedpiPeer1
+				ask.PaymentIntervalIncrease = expectedPaymentIntervalIncrease
+			},
+
+			pricingFnc: retrievalimpl.DefaultPricingFunc(false),
+
+			expectedPricePerByte:            expectedppbVerified,
+			expectedUnsealPrice:             big.Zero(),
+			expectedPaymentInterval:         expectedpiPeer1,
+			expectedPaymentIntervalIncrease: expectedPaymentIntervalIncrease,
+			expectedSize:                    piece2Size,
+		},
+
+		"pieceCid no-op: quote correct price for sealed, verified, peer1 using default pricing policy": {
+			query:  types.Query{PayloadCID: &payloadCID},
+			peerID: peer1,
+			nodeFunc: func(n *lotusmocks.MockFullNode) {
+				mockStorageDealResults(n, piece1, true)
+				mockStorageDealResults(n, piece2, true)
+			},
+			expFunc: func(t *testing.T, pieceStore *tut.TestPieceStore, dagStore *tut.MockDagStoreWrapper) {
+				pieceStore.ExpectPiece(expectedPieceCID1, piece1)
+				pieceStore.ExpectPiece(expectedPieceCID2, piece2)
+				dagStore.AddBlockToPieceIndex(payloadCID, expectedPieceCID1)
+				dagStore.AddBlockToPieceIndex(payloadCID, expectedPieceCID2)
+			},
+			setAsk: func(ask *retrievalmarket.Ask) {
+				ask.PricePerByte = expectedppbVerified
+				ask.PaymentInterval = expectedpiPeer1
+				ask.PaymentIntervalIncrease = expectedPaymentIntervalIncrease
+				ask.UnsealPrice = expectedUnsealPrice
+			},
+			pricingFnc: retrievalimpl.DefaultPricingFunc(false),
+
+			expectedPricePerByte:            expectedppbVerified,
+			expectedPaymentInterval:         expectedpiPeer1,
+			expectedUnsealPrice:             expectedUnsealPrice,
+			expectedPaymentIntervalIncrease: expectedPaymentIntervalIncrease,
+			expectedSize:                    piece1Size,
+		},
+
+		// Retrieval requests for a payloadCid inside a specific piece Cid
+		"specific sealed piece Cid, first piece Cid matches: quote correct price for sealed, unverified, peer1": {
+			query: types.Query{
+				PayloadCID: &payloadCID,
+				PieceCID:   &expectedPieceCID1,
+			},
+			peerID: peer1,
+			nodeFunc: func(n *lotusmocks.MockFullNode) {
+				mockStorageDealResults(n, piece1, false)
+			},
+			sectorAccessorFunc: func(sa *TestSectorAccessor) {
+				p := piece2.Deals[0]
+				sa.MarkUnsealed(context.TODO(), p.SectorID, p.Offset.Unpadded(), p.Length.Unpadded())
+			},
+			expFunc: func(t *testing.T, pieceStore *tut.TestPieceStore, dagStore *tut.MockDagStoreWrapper) {
+				pieceStore.ExpectPiece(expectedPieceCID1, piece1)
+				dagStore.AddBlockToPieceIndex(payloadCID, expectedPieceCID1)
+			},
+			pricingFnc: dPriceFunc,
+
+			expectedPricePerByte:            expectedppbUnVerified,
+			expectedPaymentInterval:         expectedpiPeer1,
+			expectedUnsealPrice:             expectedUnsealPrice,
+			expectedPaymentIntervalIncrease: expectedPaymentIntervalIncrease,
+			expectedSize:                    piece1Size,
+		},
+
+		"specific sealed piece Cid, second piece Cid matches: quote correct price for sealed, unverified, peer1": {
+			query: types.Query{
+				PayloadCID: &payloadCID,
+				PieceCID:   &expectedPieceCID2,
+			},
+			peerID: peer1,
+			nodeFunc: func(n *lotusmocks.MockFullNode) {
+				mockStorageDealResults(n, piece2, false)
+			},
+			sectorAccessorFunc: func(sa *TestSectorAccessor) {
+				p := piece1.Deals[0]
+				sa.MarkUnsealed(context.TODO(), p.SectorID, p.Offset.Unpadded(), p.Length.Unpadded())
+			},
+			expFunc: func(t *testing.T, pieceStore *tut.TestPieceStore, dagStore *tut.MockDagStoreWrapper) {
+				pieceStore.ExpectPiece(expectedPieceCID1, piece1)
+				pieceStore.ExpectPiece(expectedPieceCID1, piece2)
+				dagStore.AddBlockToPieceIndex(payloadCID, expectedPieceCID1)
+				dagStore.AddBlockToPieceIndex(payloadCID, expectedPieceCID2)
+			},
+			pricingFnc: dPriceFunc,
+
+			expectedPricePerByte:            expectedppbUnVerified,
+			expectedPaymentInterval:         expectedpiPeer1,
+			expectedUnsealPrice:             expectedUnsealPrice,
+			expectedPaymentIntervalIncrease: expectedPaymentIntervalIncrease,
+			expectedSize:                    piece2Size,
+		},
+
+		"specific sealed piece Cid, first piece Cid matches: quote correct price for sealed, verified, peer1": {
+			query: types.Query{
+				PayloadCID: &payloadCID,
+				PieceCID:   &expectedPieceCID1,
+			},
+			peerID: peer1,
+			nodeFunc: func(n *lotusmocks.MockFullNode) {
+				mockStorageDealResults(n, piece1, true)
+			},
+			sectorAccessorFunc: func(sa *TestSectorAccessor) {
+				p := piece2.Deals[0]
+				sa.MarkUnsealed(context.TODO(), p.SectorID, p.Offset.Unpadded(), p.Length.Unpadded())
+			},
+			expFunc: func(t *testing.T, pieceStore *tut.TestPieceStore, dagStore *tut.MockDagStoreWrapper) {
+				pieceStore.ExpectPiece(expectedPieceCID1, piece1)
+				dagStore.AddBlockToPieceIndex(payloadCID, expectedPieceCID1)
+			},
+			pricingFnc: dPriceFunc,
+
+			expectedPricePerByte:            expectedppbVerified,
+			expectedPaymentInterval:         expectedpiPeer1,
+			expectedUnsealPrice:             expectedUnsealPrice,
+			expectedPaymentIntervalIncrease: expectedPaymentIntervalIncrease,
+			expectedSize:                    piece1Size,
+		},
+
+		"specific sealed piece Cid, first piece Cid matches: quote correct price for unsealed, verified, peer1": {
+			query: types.Query{
+				PayloadCID: &payloadCID,
+				PieceCID:   &expectedPieceCID1,
+			},
+			peerID: peer1,
+			nodeFunc: func(n *lotusmocks.MockFullNode) {
+				mockStorageDealResults(n, piece1, true)
+			},
+			sectorAccessorFunc: func(sa *TestSectorAccessor) {
+				p := piece1.Deals[0]
+				sa.MarkUnsealed(context.TODO(), p.SectorID, p.Offset.Unpadded(), p.Length.Unpadded())
+			},
+			expFunc: func(t *testing.T, pieceStore *tut.TestPieceStore, dagStore *tut.MockDagStoreWrapper) {
+				pieceStore.ExpectPiece(expectedPieceCID1, piece1)
+				dagStore.AddBlockToPieceIndex(payloadCID, expectedPieceCID1)
+			},
+			pricingFnc: dPriceFunc,
+
+			expectedPricePerByte:            expectedppbVerified,
+			expectedPaymentInterval:         expectedpiPeer1,
+			expectedUnsealPrice:             expectedUnsealDiscount,
+			expectedPaymentIntervalIncrease: expectedPaymentIntervalIncrease,
+			expectedSize:                    piece1Size,
+		},
+
+		"specific sealed piece Cid, second piece Cid matches: quote correct price for unsealed, verified, peer2": {
+			query: types.Query{
+				PayloadCID: &payloadCID,
+				PieceCID:   &expectedPieceCID2,
+			},
+			peerID: peer2,
+			nodeFunc: func(n *lotusmocks.MockFullNode) {
+				mockStorageDealResults(n, piece2, true)
+			},
+			sectorAccessorFunc: func(sa *TestSectorAccessor) {
+				p := piece2.Deals[0]
+				sa.MarkUnsealed(context.TODO(), p.SectorID, p.Offset.Unpadded(), p.Length.Unpadded())
+			},
+			expFunc: func(t *testing.T, pieceStore *tut.TestPieceStore, dagStore *tut.MockDagStoreWrapper) {
+				pieceStore.ExpectPiece(expectedPieceCID1, piece1)
+				pieceStore.ExpectPiece(expectedPieceCID2, piece2)
+				dagStore.AddBlockToPieceIndex(payloadCID, expectedPieceCID1)
+				dagStore.AddBlockToPieceIndex(payloadCID, expectedPieceCID2)
+			},
+			pricingFnc: dPriceFunc,
+
+			expectedPricePerByte:            expectedppbVerified,
+			expectedPaymentInterval:         expectedpiPeer2,
+			expectedUnsealPrice:             expectedUnsealDiscount,
+			expectedPaymentIntervalIncrease: expectedPaymentIntervalIncrease,
+			expectedSize:                    piece2Size,
+		},
+
+		"pieceCid no-op: quote correct price for sealed, unverified, peer1 based on a pre-existing ask": {
+			query:  types.Query{PayloadCID: &payloadCID},
+			peerID: peer1,
+			nodeFunc: func(n *lotusmocks.MockFullNode) {
+				mockStorageDealResults(n, piece1, false)
+				mockStorageDealResults(n, piece2, false)
+			},
+			expFunc: func(t *testing.T, pieceStore *tut.TestPieceStore, dagStore *tut.MockDagStoreWrapper) {
+				pieceStore.ExpectPiece(expectedPieceCID1, piece1)
+				pieceStore.ExpectPiece(expectedPieceCID2, piece2)
+				dagStore.AddBlockToPieceIndex(payloadCID, expectedPieceCID1)
+				dagStore.AddBlockToPieceIndex(payloadCID, expectedPieceCID2)
+			},
+			setAsk: func(ask *retrievalmarket.Ask) {
+				ask.PricePerByte = expectedppbUnVerified
+				ask.UnsealPrice = expectedUnsealPrice
+			},
+			pricingFnc: func(ctx context.Context, dealPricingParams retrievalmarket.PricingInput) (retrievalmarket.Ask, error) {
+				ask, _ := dPriceFunc(ctx, dealPricingParams)
+				ppb := big.Add(ask.PricePerByte, dealPricingParams.CurrentAsk.PricePerByte)
+				unseal := big.Add(ask.UnsealPrice, dealPricingParams.CurrentAsk.UnsealPrice)
+				ask.PricePerByte = ppb
+				ask.UnsealPrice = unseal
+				return ask, nil
+			},
+
+			expectedPricePerByte:            big.Mul(expectedppbUnVerified, big.NewInt(2)),
+			expectedPaymentInterval:         expectedpiPeer1,
+			expectedUnsealPrice:             big.Mul(expectedUnsealPrice, big.NewInt(2)),
+			expectedPaymentIntervalIncrease: expectedPaymentIntervalIncrease,
+			expectedSize:                    piece1Size,
+		},
+	}
+
+	for name, tc := range tcs {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+
+			fn := lotusmocks.NewMockFullNode(ctrl)
+			fn.EXPECT().StateMinerInfo(gomock.Any(), expectedAddress, ctypes.EmptyTSK).AnyTimes().Return(api.MinerInfo{Worker: expectedMinerWallet}, nil)
+
+			sectorAccessor := NewTestSectorAccessor()
+
+			pieceStore := tut.NewTestPieceStore()
+			dagStore := tut.NewMockDagStoreWrapper(pieceStore, sectorAccessor)
+			tc.nodeFunc(fn)
+			if tc.sectorAccessorFunc != nil {
+				tc.sectorAccessorFunc(sectorAccessor)
+			}
+			tc.expFunc(t, pieceStore, dagStore)
+
+			ds := dss.MutexWrap(datastore.NewMapDatastore())
+
+			askStore, err := askstore.NewAskStore(namespace.Wrap(ds, datastore.NewKey("retrieval-ask")), datastore.NewKey("latest"))
+			require.NoError(t, err)
+			if tc.setAsk != nil {
+				ask := askStore.GetAsk()
+				tc.setAsk(ask)
+				err = askStore.SetAsk(ask)
+				require.NoError(t, err)
+			}
+			p := buildProvider(t, sectorAccessor, fn, pieceStore, dagStore, tc.pricingFnc, askStore)
+			actualResp := p.ExecuteQuery(&tc.query, tc.peerID)
+			pieceStore.VerifyExpectations(t)
+			ctrl.Finish()
+
+			require.Equal(t, types.QueryResponseAvailable, actualResp.Status)
+			require.Empty(t, actualResp.Error)
+			require.Nil(t, actualResp.Protocols.HTTPFilecoinV1)
+			graphsyncResponse := actualResp.Protocols.GraphsyncFilecoinV1
+			require.NotNil(t, graphsyncResponse)
+			require.Equal(t, expectedMinerWallet, graphsyncResponse.PaymentAddress)
+			require.Equal(t, tc.expectedPricePerByte, graphsyncResponse.MinPricePerByte)
+			require.Equal(t, tc.expectedUnsealPrice, graphsyncResponse.UnsealPrice)
+			require.Equal(t, tc.expectedPaymentInterval, graphsyncResponse.MaxPaymentInterval)
+			require.Equal(t, tc.expectedPaymentIntervalIncrease, graphsyncResponse.MaxPaymentIntervalIncrease)
+			require.Equal(t, tc.expectedSize, graphsyncResponse.Size)
+		})
+	}
+}
+
+func TestHandleQueryStream(t *testing.T) {
+
+	payloadCID := tut.GenerateCids(1)[0]
+	expectedPeer := peer.ID("somepeer")
+	paddedSize := uint64(1234)
+	expectedSize := uint64(abi.PaddedPieceSize(paddedSize).Unpadded())
+
+	paddedSize2 := uint64(2234)
+	expectedSize2 := uint64(abi.PaddedPieceSize(paddedSize2).Unpadded())
+
+	expectedPieceCID := tut.GenerateCids(1)[0]
+	expectedPieceCID2 := tut.GenerateCids(1)[0]
+
+	expectedPiece := piecestore.PieceInfo{
+		PieceCID: expectedPieceCID,
+		Deals: []piecestore.DealInfo{
+			{
+				DealID: 0,
+				Length: abi.PaddedPieceSize(paddedSize),
+			},
+		},
+	}
+
+	expectedPiece2 := piecestore.PieceInfo{
+		PieceCID: expectedPieceCID2,
+		Deals: []piecestore.DealInfo{
+			{
+				DealID: 1,
+				Length: abi.PaddedPieceSize(paddedSize2),
+			},
+		},
+	}
+
+	expectedAddress := address.TestAddress2
+	expectedMinerWallet := address.TestAddress
+	expectedPricePerByte := abi.NewTokenAmount(4321)
+	expectedPaymentInterval := uint64(4567)
+	expectedPaymentIntervalIncrease := uint64(100)
+	expectedUnsealPrice := abi.NewTokenAmount(100)
+
+	// differential pricing
+	expectedUnsealDiscount := abi.NewTokenAmount(1)
+
+	receiveQueryOnProvider := func(
+		t *testing.T,
+		fn v1api.FullNode,
+		sa *TestSectorAccessor,
+		query *types.Query,
+		config Config,
+		pieceStore piecestore.PieceStore,
+		dagStore *tut.MockDagStoreWrapper,
+	) *types.QueryResponse {
+		ds := dss.MutexWrap(datastore.NewMapDatastore())
+		askStore, err := askstore.NewAskStore(namespace.Wrap(ds, datastore.NewKey("retrieval-ask")), datastore.NewKey("latest"))
+		require.NoError(t, err)
+
+		priceFunc := func(ctx context.Context, dealPricingParams retrievalmarket.PricingInput) (retrievalmarket.Ask, error) {
+			ask := retrievalmarket.Ask{}
+			ask.PricePerByte = expectedPricePerByte
+			ask.PaymentInterval = expectedPaymentInterval
+			ask.PaymentIntervalIncrease = expectedPaymentIntervalIncrease
+
+			if dealPricingParams.Unsealed {
+				ask.UnsealPrice = expectedUnsealDiscount
+			} else {
+				ask.UnsealPrice = expectedUnsealPrice
+			}
+			return ask, nil
+		}
+
+		c, err := NewProvider(config, expectedAddress, fn, sa, pieceStore, dagStore, askStore, priceFunc)
+		require.NoError(t, err)
+
+		return c.ExecuteQuery(query, expectedPeer)
+	}
+
+	testCases := []struct {
+		name                            string
+		httpRetrievalURL                string
+		query                           types.Query
+		expResp                         types.QueryResponse
+		expFunc                         func(t *testing.T, pieceStore *tut.TestPieceStore, dagStore *tut.MockDagStoreWrapper)
+		sectorAccessorFunc              func(sa *TestSectorAccessor)
+		expectedPricePerByte            abi.TokenAmount
+		expectedPaymentInterval         uint64
+		expectedPaymentIntervalIncrease uint64
+		expectedUnsealPrice             abi.TokenAmount
+	}{
+		{name: "When PieceCID is not provided and PayloadCID is found, no http",
+			expFunc: func(t *testing.T, pieceStore *tut.TestPieceStore, dagStore *tut.MockDagStoreWrapper) {
+				pieceStore.ExpectPiece(expectedPieceCID, expectedPiece)
+				pieceStore.ExpectPiece(expectedPieceCID2, expectedPiece2)
+				dagStore.AddBlockToPieceIndex(payloadCID, expectedPieceCID)
+				dagStore.AddBlockToPieceIndex(payloadCID, expectedPieceCID2)
+			},
+			query: types.Query{PayloadCID: &payloadCID},
+			expResp: types.QueryResponse{
+				Status: types.QueryResponseAvailable,
+				Protocols: types.QueryProtocols{
+					GraphsyncFilecoinV1: &types.GraphsyncFilecoinV1Response{
+						Size: expectedSize,
+					},
+				},
+			},
+			expectedPricePerByte:            expectedPricePerByte,
+			expectedPaymentInterval:         expectedPaymentInterval,
+			expectedPaymentIntervalIncrease: expectedPaymentIntervalIncrease,
+			expectedUnsealPrice:             expectedUnsealPrice,
+		},
+		{name: "When PieceCID is not provided and PayloadCID is found, http",
+			httpRetrievalURL: "https://www.yahoo.com",
+			expFunc: func(t *testing.T, pieceStore *tut.TestPieceStore, dagStore *tut.MockDagStoreWrapper) {
+				pieceStore.ExpectPiece(expectedPieceCID, expectedPiece)
+				pieceStore.ExpectPiece(expectedPieceCID2, expectedPiece2)
+				dagStore.AddBlockToPieceIndex(payloadCID, expectedPieceCID)
+				dagStore.AddBlockToPieceIndex(payloadCID, expectedPieceCID2)
+			},
+			query: types.Query{PayloadCID: &payloadCID},
+			expResp: types.QueryResponse{
+				Status: types.QueryResponseAvailable,
+				Protocols: types.QueryProtocols{
+					GraphsyncFilecoinV1: &types.GraphsyncFilecoinV1Response{
+						Size: expectedSize,
+					},
+					HTTPFilecoinV1: &types.HTTPFilecoinV1Response{
+						URL:  fmt.Sprintf("https://www.yahoo.com/payload/%s.car", payloadCID),
+						Size: expectedSize,
+					},
+				},
+			},
+			expectedPricePerByte:            expectedPricePerByte,
+			expectedPaymentInterval:         expectedPaymentInterval,
+			expectedPaymentIntervalIncrease: expectedPaymentIntervalIncrease,
+			expectedUnsealPrice:             expectedUnsealPrice,
+		},
+
+		{name: "When PieceCID is not provided, prefer a piece for which an unsealed sector already exists and price it accordingly, no http",
+			sectorAccessorFunc: func(sa *TestSectorAccessor) {
+				p := expectedPiece2.Deals[0]
+				sa.MarkUnsealed(context.TODO(), p.SectorID, p.Offset.Unpadded(), p.Length.Unpadded())
+			},
+			expFunc: func(t *testing.T, pieceStore *tut.TestPieceStore, dagStore *tut.MockDagStoreWrapper) {
+				pieceStore.ExpectPiece(expectedPieceCID, expectedPiece)
+				pieceStore.ExpectPiece(expectedPieceCID2, expectedPiece2)
+				dagStore.AddBlockToPieceIndex(payloadCID, expectedPieceCID)
+				dagStore.AddBlockToPieceIndex(payloadCID, expectedPieceCID2)
+			},
+			query: types.Query{PayloadCID: &payloadCID},
+			expResp: types.QueryResponse{
+				Status: types.QueryResponseAvailable,
+				Protocols: types.QueryProtocols{
+					GraphsyncFilecoinV1: &types.GraphsyncFilecoinV1Response{
+						Size: expectedSize2,
+					},
+				},
+			},
+			expectedPricePerByte:            expectedPricePerByte,
+			expectedPaymentInterval:         expectedPaymentInterval,
+			expectedPaymentIntervalIncrease: expectedPaymentIntervalIncrease,
+			expectedUnsealPrice:             expectedUnsealDiscount,
+		},
+
+		{name: "When PieceCID is not provided, prefer a piece for which an unsealed sector already exists and price it accordingly, http",
+			httpRetrievalURL: "https://www.yahoo.com",
+			sectorAccessorFunc: func(sa *TestSectorAccessor) {
+				p := expectedPiece2.Deals[0]
+				sa.MarkUnsealed(context.TODO(), p.SectorID, p.Offset.Unpadded(), p.Length.Unpadded())
+			},
+			expFunc: func(t *testing.T, pieceStore *tut.TestPieceStore, dagStore *tut.MockDagStoreWrapper) {
+				pieceStore.ExpectPiece(expectedPieceCID, expectedPiece)
+				pieceStore.ExpectPiece(expectedPieceCID2, expectedPiece2)
+				dagStore.AddBlockToPieceIndex(payloadCID, expectedPieceCID)
+				dagStore.AddBlockToPieceIndex(payloadCID, expectedPieceCID2)
+			},
+			query: types.Query{PayloadCID: &payloadCID},
+			expResp: types.QueryResponse{
+				Status: types.QueryResponseAvailable,
+				Protocols: types.QueryProtocols{
+					GraphsyncFilecoinV1: &types.GraphsyncFilecoinV1Response{
+						Size: expectedSize2,
+					},
+					HTTPFilecoinV1: &types.HTTPFilecoinV1Response{
+						URL:  fmt.Sprintf("https://www.yahoo.com/payload/%s.car", payloadCID),
+						Size: expectedSize2,
+					},
+				},
+			},
+			expectedPricePerByte:            expectedPricePerByte,
+			expectedPaymentInterval:         expectedPaymentInterval,
+			expectedPaymentIntervalIncrease: expectedPaymentIntervalIncrease,
+			expectedUnsealPrice:             expectedUnsealDiscount,
+		},
+
+		{name: "When PieceCID is provided and both PieceCID and PayloadCID are found, no http",
+			expFunc: func(t *testing.T, pieceStore *tut.TestPieceStore, dagStore *tut.MockDagStoreWrapper) {
+				loadPieceCIDS(t, pieceStore, expectedPieceCID)
+				dagStore.AddBlockToPieceIndex(payloadCID, expectedPieceCID)
+			},
+			query: types.Query{
+				PayloadCID: &payloadCID,
+				PieceCID:   &expectedPieceCID,
+			},
+			expResp: types.QueryResponse{
+				Status: types.QueryResponseAvailable,
+				Protocols: types.QueryProtocols{
+					GraphsyncFilecoinV1: &types.GraphsyncFilecoinV1Response{
+						Size: expectedSize,
+					},
+				},
+			},
+			expectedPricePerByte:            expectedPricePerByte,
+			expectedPaymentInterval:         expectedPaymentInterval,
+			expectedPaymentIntervalIncrease: expectedPaymentIntervalIncrease,
+			expectedUnsealPrice:             expectedUnsealPrice,
+		},
+		{name: "When PieceCID is provided and both PieceCID and PayloadCID are found, http",
+			httpRetrievalURL: "https://www.yahoo.com",
+			expFunc: func(t *testing.T, pieceStore *tut.TestPieceStore, dagStore *tut.MockDagStoreWrapper) {
+				loadPieceCIDS(t, pieceStore, expectedPieceCID)
+				dagStore.AddBlockToPieceIndex(payloadCID, expectedPieceCID)
+			},
+			query: types.Query{
+				PayloadCID: &payloadCID,
+				PieceCID:   &expectedPieceCID,
+			},
+			expResp: types.QueryResponse{
+				Status: types.QueryResponseAvailable,
+				Protocols: types.QueryProtocols{
+					GraphsyncFilecoinV1: &types.GraphsyncFilecoinV1Response{
+						Size: expectedSize,
+					},
+					HTTPFilecoinV1: &types.HTTPFilecoinV1Response{
+						URL:  fmt.Sprintf("https://www.yahoo.com/payload/%s.car", payloadCID),
+						Size: expectedSize,
+					},
+				},
+			},
+			expectedPricePerByte:            expectedPricePerByte,
+			expectedPaymentInterval:         expectedPaymentInterval,
+			expectedPaymentIntervalIncrease: expectedPaymentIntervalIncrease,
+			expectedUnsealPrice:             expectedUnsealPrice,
+		},
+		{name: "When PieceCID is provided and piece is missing",
+			expFunc: func(t *testing.T, ps *tut.TestPieceStore, dagStore *tut.MockDagStoreWrapper) {
+				loadPieceCIDS(t, ps, cid.Undef)
+				ps.ExpectMissingPiece(expectedPieceCID)
+				ps.ExpectMissingPiece(expectedPieceCID2)
+				dagStore.AddBlockToPieceIndex(payloadCID, expectedPieceCID)
+				dagStore.AddBlockToPieceIndex(payloadCID, expectedPieceCID2)
+			},
+			query: types.Query{
+				PayloadCID: &payloadCID,
+				PieceCID:   &expectedPieceCID,
+			},
+			expResp: types.QueryResponse{
+				Status: types.QueryResponseUnavailable,
+				Error:  "piece info for cid not found (deal has not been added to a piece yet)",
+			},
+			expectedPricePerByte:            big.Zero(),
+			expectedPaymentInterval:         0,
+			expectedPaymentIntervalIncrease: 0,
+			expectedUnsealPrice:             big.Zero(),
+		},
+		{name: "When ONLY PieceCID is provided, no http",
+			expFunc: func(t *testing.T, ps *tut.TestPieceStore, dagStore *tut.MockDagStoreWrapper) {},
+			query: types.Query{
+				PieceCID: &expectedPieceCID,
+			},
+			expResp: types.QueryResponse{
+				Status: types.QueryResponseError,
+				Error:  "piece only retrieval not supported",
+			},
+		},
+		{name: "When ONLY PieceCID is provided, unsealed, http",
+			httpRetrievalURL: "https://www.yahoo.com",
+			expFunc: func(t *testing.T, pieceStore *tut.TestPieceStore, dagStore *tut.MockDagStoreWrapper) {
+				pieceStore.ExpectPiece(expectedPieceCID, expectedPiece)
+			},
+			sectorAccessorFunc: func(sa *TestSectorAccessor) {
+				p := expectedPiece.Deals[0]
+				sa.MarkUnsealed(context.TODO(), p.SectorID, p.Offset.Unpadded(), p.Length.Unpadded())
+			},
+			query: types.Query{
+				PieceCID: &expectedPieceCID,
+			},
+			expResp: types.QueryResponse{
+				Status: types.QueryResponseAvailable,
+				Protocols: types.QueryProtocols{
+					HTTPFilecoinV1: &types.HTTPFilecoinV1Response{
+						URL:  fmt.Sprintf("https://www.yahoo.com/piece/%s", expectedPieceCID),
+						Size: expectedSize,
+					},
+				},
+			},
+		},
+		{name: "When ONLY PieceCID is provided, sealed, http",
+			httpRetrievalURL: "https://www.yahoo.com",
+			expFunc: func(t *testing.T, pieceStore *tut.TestPieceStore, dagStore *tut.MockDagStoreWrapper) {
+				pieceStore.ExpectPiece(expectedPieceCID, expectedPiece)
+			},
+			query: types.Query{
+				PieceCID: &expectedPieceCID,
+			},
+			expResp: types.QueryResponse{
+				Status: types.QueryResponseError,
+				Error:  "piece not avialable in unsealed sector",
+			},
+		},
+		{name: "When payload CID not found",
+			expFunc: func(t *testing.T, ps *tut.TestPieceStore, dagStore *tut.MockDagStoreWrapper) {},
+			query: types.Query{
+				PayloadCID: &payloadCID,
+				PieceCID:   &expectedPieceCID,
+			},
+			expResp: types.QueryResponse{
+				Status: types.QueryResponseUnavailable,
+				Error:  "piece info for cid not found (deal has not been added to a piece yet)",
+			},
+		},
+		{name: "error reading piece",
+			expFunc: func(t *testing.T, pieceStore *tut.TestPieceStore, dagStore *tut.MockDagStoreWrapper) {
+				pieceStore.ReturnErrorFromGetPieceInfo(errors.New("something went wrong"))
+				dagStore.AddBlockToPieceIndex(payloadCID, expectedPieceCID)
+			},
+			query: types.Query{PayloadCID: &payloadCID},
+			expResp: types.QueryResponse{
+				Status: types.QueryResponseError,
+				Error:  "failed to fetch piece to retrieve from: could not locate piece: something went wrong",
+			},
+		},
+		{name: "error reading piece, pieceCID only specified",
+			httpRetrievalURL: "https://www.yahoo.com",
+
+			expFunc: func(t *testing.T, pieceStore *tut.TestPieceStore, dagStore *tut.MockDagStoreWrapper) {
+				pieceStore.ReturnErrorFromGetPieceInfo(errors.New("something went wrong"))
+			},
+			query: types.Query{PieceCID: &expectedPieceCID},
+			expResp: types.QueryResponse{
+				Status: types.QueryResponseError,
+				Error:  "failed to fetch piece to retrieve from: something went wrong",
+			},
+		},
+		{name: "When neither PieceCID nor PayloadCID is provided",
+			expFunc: func(t *testing.T, ps *tut.TestPieceStore, dagStore *tut.MockDagStoreWrapper) {},
+			query:   types.Query{},
+			expResp: types.QueryResponse{
+				Status: types.QueryResponseError,
+				Error:  "either piece CID or payload CID must be present",
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			fn := lotusmocks.NewMockFullNode(ctrl)
+			fn.EXPECT().StateMinerInfo(gomock.Any(), expectedAddress, ctypes.EmptyTSK).AnyTimes().Return(api.MinerInfo{Worker: expectedMinerWallet}, nil)
+			fn.EXPECT().StateMarketStorageDeal(gomock.Any(), abi.DealID(0), ctypes.EmptyTSK).AnyTimes().Return(&api.MarketDeal{
+				Proposal: market.DealProposal{
+					PieceSize: abi.PaddedPieceSize(paddedSize),
+					PieceCID:  expectedPieceCID,
+				},
+			}, nil)
+			fn.EXPECT().StateMarketStorageDeal(gomock.Any(), abi.DealID(1), ctypes.EmptyTSK).AnyTimes().Return(&api.MarketDeal{
+				Proposal: market.DealProposal{
+					PieceSize: abi.PaddedPieceSize(paddedSize2),
+					PieceCID:  expectedPieceCID2,
+				},
+			}, nil)
+			sa := NewTestSectorAccessor()
+			pieceStore := tut.NewTestPieceStore()
+			dagStore := tut.NewMockDagStoreWrapper(pieceStore, sa)
+			if tc.sectorAccessorFunc != nil {
+				tc.sectorAccessorFunc(sa)
+			}
+
+			tc.expFunc(t, pieceStore, dagStore)
+			actualResp := receiveQueryOnProvider(t, fn, sa, &tc.query, Config{HTTPRetrievalURL: tc.httpRetrievalURL}, pieceStore, dagStore)
+
+			pieceStore.VerifyExpectations(t)
+			ctrl.Finish()
+
+			if tc.expResp.Protocols.GraphsyncFilecoinV1 != nil {
+				graphsyncResponse := tc.expResp.Protocols.GraphsyncFilecoinV1
+				graphsyncResponse.PaymentAddress = expectedMinerWallet
+				graphsyncResponse.MinPricePerByte = tc.expectedPricePerByte
+				graphsyncResponse.MaxPaymentInterval = tc.expectedPaymentInterval
+				graphsyncResponse.MaxPaymentIntervalIncrease = tc.expectedPaymentIntervalIncrease
+				graphsyncResponse.UnsealPrice = tc.expectedUnsealPrice
+			}
+			assert.Equal(t, &tc.expResp, actualResp)
+		})
+	}
+
+}
+
+type sectorKey struct {
+	sectorID abi.SectorNumber
+	offset   abi.UnpaddedPieceSize
+	length   abi.UnpaddedPieceSize
+}
+
+// TestSectorAccessor is a mock implementation of the SectorAccessor
+type TestSectorAccessor struct {
+	unsealed map[sectorKey]struct{}
+}
+
+var _ retrievalmarket.SectorAccessor = &TestSectorAccessor{}
+
+// NewTestSectorAccessor instantiates a new TestSectorAccessor
+func NewTestSectorAccessor() *TestSectorAccessor {
+	return &TestSectorAccessor{
+		unsealed: make(map[sectorKey]struct{}),
+	}
+}
+
+func (trpn *TestSectorAccessor) IsUnsealed(ctx context.Context, sectorID abi.SectorNumber, offset abi.UnpaddedPieceSize, length abi.UnpaddedPieceSize) (bool, error) {
+	_, ok := trpn.unsealed[sectorKey{sectorID, offset, length}]
+	return ok, nil
+}
+
+func (trpn *TestSectorAccessor) MarkUnsealed(ctx context.Context, sectorID abi.SectorNumber, offset abi.UnpaddedPieceSize, length abi.UnpaddedPieceSize) {
+	trpn.unsealed[sectorKey{sectorID, offset, length}] = struct{}{}
+}
+
+// UnsealSector simulates unsealing a sector by returning a stubbed response
+// or erroring
+func (trpn *TestSectorAccessor) UnsealSector(ctx context.Context, sectorID abi.SectorNumber, offset, length abi.UnpaddedPieceSize) (io.ReadCloser, error) {
+	return nil, errors.New("could not unseal")
+}
+
+func (trpn *TestSectorAccessor) UnsealSectorAt(ctx context.Context, sectorID abi.SectorNumber, pieceOffset abi.UnpaddedPieceSize, length abi.UnpaddedPieceSize) (mount.Reader, error) {
+	return nil, errors.New("could not unseal")
+}
+
+// loadPieceCIDS sets expectations to receive expectedPieceCID and 3 other random PieceCIDs to
+// disinguish the case of a PayloadCID is found but the PieceCID is not
+func loadPieceCIDS(t *testing.T, pieceStore *tut.TestPieceStore, expectedPieceCID cid.Cid) {
+
+	otherPieceCIDs := tut.GenerateCids(3)
+	expectedSize := uint64(1234)
+
+	blockLocs := make([]piecestore.PieceBlockLocation, 4)
+	expectedPieceInfo := piecestore.PieceInfo{
+		PieceCID: expectedPieceCID,
+		Deals: []piecestore.DealInfo{
+			{
+				Length: abi.PaddedPieceSize(expectedSize),
+			},
+		},
+	}
+
+	blockLocs[0] = piecestore.PieceBlockLocation{PieceCID: expectedPieceCID}
+	for i, pieceCID := range otherPieceCIDs {
+		blockLocs[i+1] = piecestore.PieceBlockLocation{PieceCID: pieceCID}
+		pi := expectedPieceInfo
+		pi.PieceCID = pieceCID
+	}
+	if expectedPieceCID != cid.Undef {
+		pieceStore.ExpectPiece(expectedPieceCID, expectedPieceInfo)
+	}
+}

--- a/retrievalmarket/types/queryaskv2.go
+++ b/retrievalmarket/types/queryaskv2.go
@@ -1,0 +1,147 @@
+package types
+
+import (
+	_ "embed"
+	"fmt"
+
+	"github.com/ipfs/go-cid"
+	"github.com/ipld/go-ipld-prime/node/bindnode"
+	bindnoderegistry "github.com/ipld/go-ipld-prime/node/bindnode/registry"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
+)
+
+// Query is a query to a given provider to determine information about a piece
+// they may have available for retrieval
+type Query struct {
+	PayloadCID *cid.Cid // V0
+	PieceCID   *cid.Cid
+}
+
+// QueryResponseStatus indicates whether a queried piece is available
+type QueryResponseStatus uint64
+
+const (
+	// QueryResponseAvailable indicates a provider has a piece and is prepared to
+	// return it
+	QueryResponseAvailable QueryResponseStatus = iota
+
+	// QueryResponseUnavailable indicates a provider either does not have or cannot
+	// serve the queried piece to the client
+	QueryResponseUnavailable
+
+	// QueryResponseError indicates something went wrong generating a query response
+	QueryResponseError
+)
+
+// QueryResponse is a miners response to a given retrieval query
+type QueryResponse struct {
+	Status    QueryResponseStatus
+	Error     string
+	Protocols QueryProtocols
+}
+
+// QueryProtocols indicates protocol specific information about retrieval availability
+type QueryProtocols struct {
+	GraphsyncFilecoinV1 *GraphsyncFilecoinV1Response
+	HTTPFilecoinV1      *HTTPFilecoinV1Response
+}
+
+// GraphsyncFilecoinV1Response are the query response parameters when GraphSync retrieval is supported
+type GraphsyncFilecoinV1Response struct {
+	Size uint64 // Total size of piece in bytes
+	//ExpectedPayloadSize uint64 // V1 - optional, if PayloadCID + selector are specified and miner knows, can offer an expected size
+
+	PaymentAddress             address.Address // address to send funds to -- may be different than miner addr
+	MinPricePerByte            abi.TokenAmount
+	MaxPaymentInterval         uint64
+	MaxPaymentIntervalIncrease uint64
+	Message                    string
+	UnsealPrice                abi.TokenAmount
+}
+
+// HTTPFilecoinV1Response are the query response parameters when HTTP retrieval is supported
+type HTTPFilecoinV1Response struct {
+	URL  string
+	Size uint64
+}
+
+//go:embed queryaskv2.ipldsch
+var embedSchema []byte
+
+// BigIntBindnodeOption converts a big.Int type to and from a Bytes field in a
+// schema
+var BigIntBindnodeOption = bindnode.TypedBytesConverter(&big.Int{}, bigIntFromBytes, bigIntToBytes)
+
+// TokenAmountBindnodeOption converts a filecoin abi.TokenAmount type to and
+// from a Bytes field in a schema
+var TokenAmountBindnodeOption = bindnode.TypedBytesConverter(&abi.TokenAmount{}, tokenAmountFromBytes, tokenAmountToBytes)
+
+// AddressBindnodeOption converts a filecoin Address type to and from a Bytes
+// field in a schema
+var AddressBindnodeOption = bindnode.TypedBytesConverter(&address.Address{}, addressFromBytes, addressToBytes)
+
+var filecoinBindnodeOptions = []bindnode.Option{
+	BigIntBindnodeOption,
+	TokenAmountBindnodeOption,
+	AddressBindnodeOption,
+}
+
+func tokenAmountFromBytes(b []byte) (interface{}, error) {
+	return bigIntFromBytes(b)
+}
+
+func bigIntFromBytes(b []byte) (interface{}, error) {
+	if len(b) == 0 {
+		return big.NewInt(0), nil
+	}
+	return big.FromBytes(b)
+}
+
+func tokenAmountToBytes(iface interface{}) ([]byte, error) {
+	return bigIntToBytes(iface)
+}
+
+func bigIntToBytes(iface interface{}) ([]byte, error) {
+	bi, ok := iface.(*big.Int)
+	if !ok {
+		return nil, fmt.Errorf("expected *big.Int value")
+	}
+	if bi == nil || bi.Int == nil {
+		*bi = big.Zero()
+	}
+	return bi.Bytes()
+}
+
+func addressFromBytes(b []byte) (interface{}, error) {
+	return address.NewFromBytes(b)
+}
+
+func addressToBytes(iface interface{}) ([]byte, error) {
+	addr, ok := iface.(*address.Address)
+	if !ok {
+		return nil, fmt.Errorf("expected *Address value")
+	}
+	return addr.Bytes(), nil
+}
+
+var BindnodeRegistry = bindnoderegistry.NewRegistry()
+
+func init() {
+	for _, r := range []struct {
+		typ     interface{}
+		typName string
+	}{
+		{(*QueryResponse)(nil), "QueryResponse"},
+		{(*QueryProtocols)(nil), "QueryProtocols"},
+		{(*GraphsyncFilecoinV1Response)(nil), "GraphsyncFilecoinV1Response"},
+		{(*HTTPFilecoinV1Response)(nil), "HTTPFilecoinV1Response"},
+		{(*Query)(nil), "Query"},
+	} {
+		if err := BindnodeRegistry.RegisterType(r.typ, string(embedSchema), r.typName, filecoinBindnodeOptions...); err != nil {
+			panic(err.Error())
+		}
+	}
+}

--- a/retrievalmarket/types/queryaskv2.ipldsch
+++ b/retrievalmarket/types/queryaskv2.ipldsch
@@ -1,0 +1,54 @@
+# Query is a query to a given provider to determine information about a piece
+# they may have available for retrieval
+type Query struct {
+  # If kind is Payload, response will error if not included
+	PayloadCID optional Link
+	# If kind is Piece, response will error if not included
+	PieceCID optional Link 
+}
+
+# QueryResponseStatus indicates whether a queried piece is available
+type QueryResponseStatus enum {
+  # QueryResponseAvailable indicates a provider has a piece and is prepared to
+	# return it
+	| QueryResponseAvailable ("0")
+
+	# QueryResponseUnavailable indicates a provider either does not have or cannot
+	# serve the queried piece to the client
+	| QueryResponseUnavailable ("1")
+
+	# QueryResponseError indicates something went wrong generating a query response
+	| QueryResponseError ("2")
+} representation int
+
+type Address bytes
+type TokenAmount bytes
+
+type QueryProtocols struct {
+   GraphsyncFilecoinV1 optional GraphsyncFilecoinV1Response (rename "graphsync/v1")
+   HTTPFilecoinV1 optional HTTPFilecoinV1Response (rename "http/v1")
+}
+
+# QueryResponse is a miners response to a given retrieval query
+type QueryResponse struct {
+	Status        QueryResponseStatus
+  Error         String
+	Protocols     QueryProtocols
+}
+
+# Structure of Graphsync Protocol Data
+type GraphsyncFilecoinV1Response struct {
+	Size Int
+	PaymentAddress             Address # address.Address to send funds to -- may be different than miner addr
+	MinPricePerByte            TokenAmount
+	MaxPaymentInterval         Int
+	MaxPaymentIntervalIncrease Int
+	Message                    String
+	UnsealPrice                TokenAmount
+}
+
+# Structure of HTTP V1 Response
+type HTTPFilecoinV1Response struct {
+      URL String
+      Size Int
+}


### PR DESCRIPTION
# Goals

fix #666 #667  #668 

# Implementation

1. Generate query ask v2 types & ipld schema based on the one documented in #666 
2. Create a libp2p implementation to send and request v2 Query's & QueryResponses -- retrievalmarket/lp2pimpl, based on storagemarket/lp2pimpl
3. Build a retrieval provider which implements query handling. Most of the code here is copied from the go-fil-markets retrieval provider query handling, with additional logic to add http info when neccesary, and to handle piece only queries
4. I also removed the RetrievalProviderNode abstraction since the storagemarket side in boost removes this abstraction
5. Setup a test of the retrieval query system, based on tests in go-fil-markets retrievalmarket impl, plus additional tests for http logic
6. Add config for HTTPRetrievalURL to DealMaking config
7. Add builder logic to construct the retrieval provider for boost
8. Add a cli command to send a query and output a response, specifically for piece only retrievals for now (tailored for Evergreen usage)

# For Discussion

- to do: complete an integration test, manual test the retrieval command