### PR TITLE
fix gostream compatibility

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -72,7 +72,7 @@ require (
 	github.com/libp2p/go-eventbus v0.2.1
 	github.com/libp2p/go-libp2p v0.20.3
 	github.com/libp2p/go-libp2p-core v0.16.1
-	github.com/libp2p/go-libp2p-gostream v0.4.1-0.20220720161416-e1952aede109
+	github.com/libp2p/go-libp2p-gostream v0.4.0
 	github.com/libp2p/go-libp2p-http v0.2.1
 	github.com/libp2p/go-libp2p-kad-dht v0.15.0
 	github.com/libp2p/go-libp2p-peerstore v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -1262,9 +1262,8 @@ github.com/libp2p/go-libp2p-discovery v0.7.0 h1:6Iu3NyningTb/BmUnEhcTwzwbs4zcyww
 github.com/libp2p/go-libp2p-discovery v0.7.0/go.mod h1:zPug0Rxib1aQG9iIdwOpRpBf18cAfZgzicO826UQP4I=
 github.com/libp2p/go-libp2p-gostream v0.3.0/go.mod h1:pLBQu8db7vBMNINGsAwLL/ZCE8wng5V1FThoaE5rNjc=
 github.com/libp2p/go-libp2p-gostream v0.3.1/go.mod h1:1V3b+u4Zhaq407UUY9JLCpboaeufAeVQbnvAt12LRsI=
+github.com/libp2p/go-libp2p-gostream v0.4.0 h1:heduMMEB78yBqeEQv+P7Fn5X926MHC2jDIC7/7yLpYA=
 github.com/libp2p/go-libp2p-gostream v0.4.0/go.mod h1:21DVGBcCQwRfEXZpCnZ2kG24QiEkBpEQvG53gYXE4u0=
-github.com/libp2p/go-libp2p-gostream v0.4.1-0.20220720161416-e1952aede109 h1:zFKEUtx28iDNGEk5kMrjZcM/K2IOx2ddkkWD1BOUXAI=
-github.com/libp2p/go-libp2p-gostream v0.4.1-0.20220720161416-e1952aede109/go.mod h1:21DVGBcCQwRfEXZpCnZ2kG24QiEkBpEQvG53gYXE4u0=
 github.com/libp2p/go-libp2p-host v0.0.1/go.mod h1:qWd+H1yuU0m5CwzAkvbSjqKairayEHdR5MMl7Cwa7Go=
 github.com/libp2p/go-libp2p-host v0.0.3/go.mod h1:Y/qPyA6C8j2coYyos1dfRm0I8+nvd4TGrDGt4tA7JR8=
 github.com/libp2p/go-libp2p-http v0.2.1 h1:h8kuv7ExPe0nDtWAexKQWbjnXqks1hwOdYLs84gMCpo=

--- a/transport/httptransport/libp2p_server.go
+++ b/transport/httptransport/libp2p_server.go
@@ -248,7 +248,7 @@ func (s *Libp2pCarServer) sendCar(r *http.Request, w http.ResponseWriter, val *A
 	}}
 
 	// Get a channel that will be closed when the client closes the connection
-	stream := getConn(r).(gostream.Stream)
+	stream := getConn(r).(network.Stream)
 	closeCh := s.streamMonitor.getCloseChan(stream.ID())
 
 	// Send the content


### PR DESCRIPTION
I was getting this while trying to import boost:
```
# github.com/filecoin-project/boost/transport/httptransport
../../go/pkg/mod/github.com/filecoin-project/boost@v1.2.0/transport/httptransport/libp2p_server.go:251:33: undefined: gostream.Stream
```
It seems that `gostream` now uses `network.Stream` instead of `gostream.Stream`. This makes boost compatible with it again
