### PR TITLE
Add optional signature on query-ask v2

### DIFF
--- a/client/retrieval.go
+++ b/client/retrieval.go
@@ -45,7 +45,7 @@ func NewRetrievalClient() (*RetrievalClient, error) {
 }
 
 // Query sends a retrieval query v2 to another peer
-func (c *RetrievalClient) Query(ctx context.Context, providerID peer.ID, query types.Query) (*types.QueryResponse, error) {
+func (c *RetrievalClient) Query(ctx context.Context, providerID peer.ID, query types.SignedQuery) (*types.QueryResponse, error) {
 	// Send the deal proposal to the provider
 	return c.queryClient.SendQuery(ctx, providerID, query)
 }

--- a/node/modules/storageminer.go
+++ b/node/modules/storageminer.go
@@ -497,6 +497,7 @@ func NewRetrievalMarketProvider(provAddr address.Address, cfg *config.Boost) fun
 			pieceStore,
 			dagStore,
 			askStore,
+			&signatureVerifier{a},
 			retrievalmarket.RetrievalPricingFunc(pricingFnc),
 		)
 	}

--- a/retrievalmarket/lp2pimpl/net.go
+++ b/retrievalmarket/lp2pimpl/net.go
@@ -60,7 +60,7 @@ func NewQueryClient(h host.Host, options ...QueryClientOption) *QueryClient {
 }
 
 // SendQuery sends a retrieval query over a libp2p stream to the peer
-func (c *QueryClient) SendQuery(ctx context.Context, id peer.ID, query types.Query) (*types.QueryResponse, error) {
+func (c *QueryClient) SendQuery(ctx context.Context, id peer.ID, query types.SignedQuery) (*types.QueryResponse, error) {
 	log.Debugw("send query", "pieceCID", query.PieceCID, "payloadCID", query.PayloadCID, "provider-peer", id)
 
 	// Create a libp2p stream to the provider
@@ -125,12 +125,12 @@ func (p *QueryProvider) handleNewQueryStream(s network.Stream) {
 	defer s.SetReadDeadline(time.Time{}) // nolint
 
 	// Read the query from the stream
-	queryi, err := types.BindnodeRegistry.TypeFromReader(s, (*types.Query)(nil), dagcbor.Decode)
+	queryi, err := types.BindnodeRegistry.TypeFromReader(s, (*types.SignedQuery)(nil), dagcbor.Decode)
 	if err != nil {
 		log.Warnw("reading query from stream", "err", err)
 		return
 	}
-	query := queryi.(*types.Query)
+	query := queryi.(*types.SignedQuery)
 
 	// run the query to generate a response
 	queryResponse := p.prov.ExecuteQuery(query, s.Conn().RemotePeer())

--- a/retrievalmarket/types/queryaskv2.ipldsch
+++ b/retrievalmarket/types/queryaskv2.ipldsch
@@ -7,6 +7,13 @@ type Query struct {
 	PieceCID optional Link 
 }
 
+# SignedQuery adds an optional address and signature to a Query 
+type SignedQuery struct {
+	Query Query
+	ClientAddress optional Address
+	ClientSignature optional Signature
+}
+
 # QueryResponseStatus indicates whether a queried piece is available
 type QueryResponseStatus enum {
   # QueryResponseAvailable indicates a provider has a piece and is prepared to
@@ -23,6 +30,7 @@ type QueryResponseStatus enum {
 
 type Address bytes
 type TokenAmount bytes
+type Signature bytes
 
 type QueryProtocols struct {
    GraphsyncFilecoinV1 optional GraphsyncFilecoinV1Response (rename "graphsync/v1")


### PR DESCRIPTION
# Goals

@s0nik42 suggest a number of very smart improvements to the retrieval and storage protocols in #666. We probably need to think these through, but since we are in the middle of redoing the QueryAsk protocol for retrievals anyway, I made this follow on PR to #671 that adds support for optional signature verification.

# Implementation

- Make a signed query ask wrapper
- Verify the signature only if an optional client address is present
- Update tests
- Update libp2p protocol to send signed query asks
- Update CLI command to sign ask with wallet sig
