### PR TITLE
chore: update xcode version to supported

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,7 +121,7 @@ jobs:
   build-macos:
     description: build darwin boost binary
     macos:
-      xcode: "12.5.0"
+      xcode: "12.5.1"
     working_directory: ~/go/src/github.com/filecoin-project/boost
     steps:
       - prepare:


### PR DESCRIPTION
xcode 12.5.0 is no longer supported by circleCI
https://circleci.com/docs/testing-ios