### PR TITLE
Functional test for query ask v2

### DIFF
--- a/cmd/boost/retrieve_piece_cmd.go
+++ b/cmd/boost/retrieve_piece_cmd.go
@@ -81,7 +81,7 @@ var retrievePieceCmd = &cli.Command{
 			PieceCID: &pieceCID,
 		}
 
-		buf, err := types.BindnodeRegistry.TypeToBytes(query, dagcbor.Encode)
+		buf, err := types.BindnodeRegistry.TypeToBytes(&query, dagcbor.Encode)
 		if err != nil {
 			return err
 		}

--- a/itests/dummydeal_offline_test.go
+++ b/itests/dummydeal_offline_test.go
@@ -34,7 +34,8 @@ func TestDummydealOffline(t *testing.T) {
 
 	// make an offline deal
 	offlineDealUuid := uuid.New()
-	res, err := f.MakeDummyDeal(offlineDealUuid, carFilepath, rootCid, "", true)
+	dealRes, err := f.MakeDummyDeal(offlineDealUuid, carFilepath, rootCid, "", true)
+	res := dealRes.Result
 	require.NoError(t, err)
 	require.True(t, res.Accepted)
 	res, err = f.Boost.BoostOfflineDealWithData(context.Background(), offlineDealUuid, carFilepath)

--- a/testutil/car.go
+++ b/testutil/car.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/ipfs/go-blockservice"
 	"github.com/ipfs/go-cid"
-	"github.com/ipfs/go-cidutil"
 	ds "github.com/ipfs/go-datastore"
 	dssync "github.com/ipfs/go-datastore/sync"
 	bstore "github.com/ipfs/go-ipfs-blockstore"
@@ -137,14 +136,11 @@ func WriteUnixfsDAGTo(path string, into ipldformat.DAGService) (cid.Cid, error) 
 
 	bufferedDS := ipldformat.NewBufferedDAG(context.Background(), into)
 	params := ihelper.DagBuilderParams{
-		Maxlinks:  unixfsLinksPerLevel,
-		RawLeaves: true,
-		CidBuilder: cidutil.InlineBuilder{
-			Builder: prefix,
-			Limit:   126,
-		},
-		Dagserv: bufferedDS,
-		NoCopy:  true,
+		Maxlinks:   unixfsLinksPerLevel,
+		RawLeaves:  true,
+		CidBuilder: prefix,
+		Dagserv:    bufferedDS,
+		NoCopy:     true,
 	}
 
 	db, err := params.New(chunk.NewSizeSplitter(rpf, int64(unixfsChunkSize)))


### PR DESCRIPTION
# Goals

Per request, prove the retrieval query v2 protocol actually works with a functional test. 

# Implementation

- Add retrieval client to test frame work
- Add functions to test framework to make and verify retrieval queries
- Modify the DummyDeal function to return the DealParams as well as the result in order to get PieceCID later
- Debug and fix a couple issues in the actual retrieval code! (yay for functional tests)
- Add a couple additional debug logs for good measure in retrieval query code
- Make a change in the CarV2Dense writer (see discussion below for why this was made and implications for DAGStore & retrievals)

# For Discussion

- I fixed some actual problems with the previous 2 PRs in writing this, so we probably need to merge all 3. However, I'm leaving them seperate for now to facilitate easier review. I can squash as needed.

- I discovered a very weird DAGStore issue in the course of writing this PR: If you make a deal with an identity CID at the top, it will successfully store, but it won't be retrievable from that CID. Essentially, the previous WriteCarV2Dense function had a threshold for using identity CIDs while writing. Apparently, these could still store all the way through successfully. However, since I believe DAGStore does not index identity CIDs, how can you figure out what pieces those identity CIDS would be in? EEK. This means I could store a UnixFS file with an identity CID at the top that was not retrievable. At least in the current code. We perhaps need to implement block by block unsealing in the GraphSync retrieval impl.
