### PR TITLE
When migrating from lotus start from default config

### DIFF
--- a/cmd/boostd/init.go
+++ b/cmd/boostd/init.go
@@ -482,7 +482,7 @@ func migrateMarketsConfig(cctx *cli.Context, mktsRepo lotus_repo.LockedRepo, boo
 		rcfg.Common.Backup = mktsCfg.Common.Backup
 		rcfg.Common.Libp2p = mktsCfg.Common.Libp2p
 		rcfg.Storage = config.StorageConfig{ParallelFetchLimit: mktsCfg.Storage.ParallelFetchLimit}
-		rcfg.Dealmaking = boostDealMakingCfg(mktsCfg)
+		setBoostDealMakingCfg(&rcfg.Dealmaking, mktsCfg)
 		rcfg.LotusDealmaking = mktsCfg.Dealmaking
 		rcfg.LotusFees = config.FeeConfig{
 			MaxPublishDealsFee:     mktsCfg.Fees.MaxPublishDealsFee,
@@ -687,30 +687,28 @@ func addMinerAddressToDatastore(ds datastore.Batching, minerActor address.Addres
 	return ds.Put(context.Background(), minerAddrDSKey, minerActor.Bytes())
 }
 
-func boostDealMakingCfg(mktsCfg *lotus_config.StorageMiner) config.DealmakingConfig {
+func setBoostDealMakingCfg(bdm *config.DealmakingConfig, mktsCfg *lotus_config.StorageMiner) {
 	ldm := mktsCfg.Dealmaking
-	return config.DealmakingConfig{
-		ConsiderOnlineStorageDeals:        ldm.ConsiderOnlineStorageDeals,
-		ConsiderOfflineStorageDeals:       ldm.ConsiderOfflineStorageDeals,
-		ConsiderOnlineRetrievalDeals:      ldm.ConsiderOnlineRetrievalDeals,
-		ConsiderOfflineRetrievalDeals:     ldm.ConsiderOfflineRetrievalDeals,
-		ConsiderVerifiedStorageDeals:      ldm.ConsiderVerifiedStorageDeals,
-		ConsiderUnverifiedStorageDeals:    ldm.ConsiderUnverifiedStorageDeals,
-		PieceCidBlocklist:                 ldm.PieceCidBlocklist,
-		ExpectedSealDuration:              config.Duration(ldm.ExpectedSealDuration),
-		MaxDealStartDelay:                 config.Duration(ldm.MaxDealStartDelay),
-		PublishMsgPeriod:                  config.Duration(ldm.PublishMsgPeriod),
-		PublishMsgMaxDealsPerMsg:          ldm.MaxDealsPerPublishMsg,
-		PublishMsgMaxFee:                  mktsCfg.Fees.MaxPublishDealsFee,
-		MaxProviderCollateralMultiplier:   ldm.MaxProviderCollateralMultiplier,
-		MaxStagingDealsBytes:              ldm.MaxStagingDealsBytes,
-		SimultaneousTransfersForStorage:   ldm.SimultaneousTransfersForStorage,
-		SimultaneousTransfersForRetrieval: ldm.SimultaneousTransfersForRetrieval,
-		StartEpochSealingBuffer:           ldm.StartEpochSealingBuffer,
-		Filter:                            ldm.Filter,
-		RetrievalFilter:                   ldm.RetrievalFilter,
-		RetrievalPricing:                  ldm.RetrievalPricing,
-	}
+	bdm.ConsiderOnlineStorageDeals = ldm.ConsiderOnlineStorageDeals
+	bdm.ConsiderOfflineStorageDeals = ldm.ConsiderOfflineStorageDeals
+	bdm.ConsiderOnlineRetrievalDeals = ldm.ConsiderOnlineRetrievalDeals
+	bdm.ConsiderOfflineRetrievalDeals = ldm.ConsiderOfflineRetrievalDeals
+	bdm.ConsiderVerifiedStorageDeals = ldm.ConsiderVerifiedStorageDeals
+	bdm.ConsiderUnverifiedStorageDeals = ldm.ConsiderUnverifiedStorageDeals
+	bdm.PieceCidBlocklist = ldm.PieceCidBlocklist
+	bdm.ExpectedSealDuration = config.Duration(ldm.ExpectedSealDuration)
+	bdm.MaxDealStartDelay = config.Duration(ldm.MaxDealStartDelay)
+	bdm.PublishMsgPeriod = config.Duration(ldm.PublishMsgPeriod)
+	bdm.PublishMsgMaxDealsPerMsg = ldm.MaxDealsPerPublishMsg
+	bdm.PublishMsgMaxFee = mktsCfg.Fees.MaxPublishDealsFee
+	bdm.MaxProviderCollateralMultiplier = ldm.MaxProviderCollateralMultiplier
+	bdm.MaxStagingDealsBytes = ldm.MaxStagingDealsBytes
+	bdm.SimultaneousTransfersForStorage = ldm.SimultaneousTransfersForStorage
+	bdm.SimultaneousTransfersForRetrieval = ldm.SimultaneousTransfersForRetrieval
+	bdm.StartEpochSealingBuffer = ldm.StartEpochSealingBuffer
+	bdm.Filter = ldm.Filter
+	bdm.RetrievalFilter = ldm.RetrievalFilter
+	bdm.RetrievalPricing = ldm.RetrievalPricing
 }
 
 func getMarketsRepo(repoPath string) (lotus_repo.LockedRepo, error) {


### PR DESCRIPTION
Fixes https://github.com/filecoin-project/boost/issues/700

Tested on my local devnet:
```
[Dealmaking]
  ConsiderOnlineStorageDeals = true
  ConsiderOfflineStorageDeals = true
  ConsiderOnlineRetrievalDeals = true
  ConsiderOfflineRetrievalDeals = true
  ConsiderVerifiedStorageDeals = true
  ConsiderUnverifiedStorageDeals = true
  PieceCidBlocklist = []
  ExpectedSealDuration = "24h0m0s"
  MaxDealStartDelay = "336h0m0s"
  PublishMsgPeriod = "1h0m0s"
  PublishMsgMaxDealsPerMsg = 8
  PublishMsgMaxFee = "0.05 FIL"
  MaxProviderCollateralMultiplier = 2
  MaxStagingDealsBytes = 200000
  SimultaneousTransfersForStorage = 20
  SimultaneousTransfersForRetrieval = 20
  StartEpochSealingBuffer = 480
  DealProposalLogDuration = "24h0m0s"
  Filter = ""
  RetrievalFilter = ""
  MaxTransferDuration = "24h0m0s"
  [Dealmaking.RetrievalPricing]
    Strategy = "default"
    [Dealmaking.RetrievalPricing.Default]
      VerifiedDealsFreeTransfer = true
    [Dealmaking.RetrievalPricing.External]
      Path = ""
```