### PR TITLE
send sealing status in deal status response

### DIFF
--- a/cmd/boost/deal_status_cmd.go
+++ b/cmd/boost/deal_status_cmd.go
@@ -109,10 +109,9 @@ var dealStatusCmd = &cli.Command{
 				out["error"] = resp.Error
 			} else {
 				out = map[string]interface{}{
-					"dealUuid":      resp.DealUUID.String(),
-					"provider":      maddr.String(),
-					"clientWallet":  walletAddr.String(),
-					"statusMessage": statusMessage(resp),
+					"dealUuid":     resp.DealUUID.String(),
+					"provider":     maddr.String(),
+					"clientWallet": walletAddr.String(),
 				}
 				// resp.DealStatus should always be present if there's no error,
 				// but check just in case
@@ -120,6 +119,8 @@ var dealStatusCmd = &cli.Command{
 					out["label"] = lstr
 					out["chainDealId"] = resp.DealStatus.ChainDealID
 					out["status"] = resp.DealStatus.Status
+					out["sealingStatus"] = resp.DealStatus.SealingStatus
+					out["statusMessage"] = statusMessage(resp)
 					out["publishCid"] = nil
 					if resp.DealStatus.PublishCid != nil {
 						out["publishCid"] = resp.DealStatus.PublishCid.String()
@@ -175,12 +176,15 @@ func statusMessage(resp *types.DealStatusResponse) string {
 	case dealcheckpoints.AddedPiece.String():
 		return "Announcing"
 	case dealcheckpoints.IndexedAndAnnounced.String():
+		if resp.DealStatus.SealingStatus != "" {
+			return "Sealing: " + resp.DealStatus.SealingStatus
+		}
 		return "Sealing"
 	case dealcheckpoints.Complete.String():
 		if resp.DealStatus.Error != "" {
 			return "Error: " + resp.DealStatus.Error
 		}
-		return "Complete"
+		return "Expired"
 	}
 	return resp.DealStatus.Status
 }

--- a/node/modules/storageminer.go
+++ b/node/modules/storageminer.go
@@ -328,8 +328,8 @@ func HandleLegacyDeals(mctx helpers.MetricsCtx, lc fx.Lifecycle, host host.Host,
 	return nil
 }
 
-func HandleBoostDeals(lc fx.Lifecycle, h host.Host, prov *storagemarket.Provider, a v1api.FullNode, legacySP lotus_storagemarket.StorageProvider, idxProv *indexprovider.Wrapper, plDB *db.ProposalLogsDB) {
-	lp2pnet := lp2pimpl.NewDealProvider(h, prov, a, plDB)
+func HandleBoostDeals(lc fx.Lifecycle, h host.Host, prov *storagemarket.Provider, a v1api.FullNode, legacySP lotus_storagemarket.StorageProvider, idxProv *indexprovider.Wrapper, plDB *db.ProposalLogsDB, spApi sealingpipeline.API) {
+	lp2pnet := lp2pimpl.NewDealProvider(h, prov, a, plDB, spApi)
 
 	lc.Append(fx.Hook{
 		OnStart: func(ctx context.Context) error {

--- a/storagemarket/types/types.go
+++ b/storagemarket/types/types.go
@@ -57,6 +57,8 @@ type DealStatus struct {
 	Error string
 	// Status is a string corresponding to a deal checkpoint
 	Status string
+	// SealingStatus is the sealing status reported by lotus miner
+	SealingStatus string
 	// Proposal is the deal proposal
 	Proposal market.DealProposal
 	// SignedProposalCid is the cid of the client deal proposal + signature

--- a/storagemarket/types/types_cbor_gen.go
+++ b/storagemarket/types/types_cbor_gen.go
@@ -1199,7 +1199,7 @@ func (t *DealStatus) MarshalCBOR(w io.Writer) error {
 
 	cw := cbg.NewCborWriter(w)
 
-	if _, err := cw.Write([]byte{166}); err != nil {
+	if _, err := cw.Write([]byte{167}); err != nil {
 		return err
 	}
 
@@ -1246,6 +1246,29 @@ func (t *DealStatus) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 	if _, err := io.WriteString(w, string(t.Status)); err != nil {
+		return err
+	}
+
+	// t.SealingStatus (string) (string)
+	if len("SealingStatus") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"SealingStatus\" was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("SealingStatus"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("SealingStatus")); err != nil {
+		return err
+	}
+
+	if len(t.SealingStatus) > cbg.MaxLength {
+		return xerrors.Errorf("Value in field t.SealingStatus was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(t.SealingStatus))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string(t.SealingStatus)); err != nil {
 		return err
 	}
 
@@ -1381,6 +1404,17 @@ func (t *DealStatus) UnmarshalCBOR(r io.Reader) (err error) {
 				}
 
 				t.Status = string(sval)
+			}
+			// t.SealingStatus (string) (string)
+		case "SealingStatus":
+
+			{
+				sval, err := cbg.ReadString(cr)
+				if err != nil {
+					return err
+				}
+
+				t.SealingStatus = string(sval)
 			}
 			// t.Proposal (market.DealProposal) (struct)
 		case "Proposal":


### PR DESCRIPTION
Supersedes https://github.com/filecoin-project/boost/pull/697
Fixes https://github.com/filecoin-project/boost/issues/696

```
$ boost --json deal-status --deal-uuid=f1ffaa64-3249-4173-b008-572b35e1e81e --provider=t01000
{
  "chainDealId": 1,
  "clientWallet": "t3r3hr3xl27unpefvipve2f4hlfvdnq3forgr253z6dqahufvanatdandxm74zikheccvx74ys7by5vzafq2va",
  "dealUuid": "f1ffaa64-3249-4173-b008-572b35e1e81e",
  "label": "bafk2bzacedsnewk7clxwab2wgwyoi7u5tzdhldx7fkxpqdq7unrxz2zoy4d2g",
  "provider": "t01000",
  "publishCid": "bafy2bzacea7cohv4zexvyyv5hwgdauaajcb6w74bn2yxfymy57ywam6xpyneq",
  "sealingStatus": "Proving",
  "status": "IndexedAndAnnounced",
  "statusMessage": "Sealing: Proving"
}
```
