### PR TITLE
Booster bitswap MVP executable

### DIFF
--- a/cmd/booster-bitswap/indexbs/indexbs.go
+++ b/cmd/booster-bitswap/indexbs/indexbs.go
@@ -1,0 +1,312 @@
+package indexbs
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/filecoin-project/dagstore"
+	"github.com/filecoin-project/go-fil-markets/piecestore"
+	"github.com/filecoin-project/go-state-types/abi"
+	blocks "github.com/ipfs/go-block-format"
+	logging "github.com/ipfs/go-log/v2"
+	"github.com/ipld/go-car/v2"
+	"github.com/multiformats/go-multihash"
+
+	"github.com/filecoin-project/dagstore/mount"
+	"github.com/hashicorp/go-multierror"
+	lru "github.com/hashicorp/golang-lru"
+	"github.com/ipfs/go-cid"
+	blockstore "github.com/ipfs/go-ipfs-blockstore"
+	carbs "github.com/ipld/go-car/v2/blockstore"
+)
+
+var logbs = logging.Logger("dagstore-all-readblockstore")
+
+var ErrBlockNotFound = errors.New("block not found")
+var ErrNotFound = errors.New("not found")
+
+var _ blockstore.Blockstore = (*IndexBackedBlockstore)(nil)
+
+// ErrNoPieceSelected means that the piece selection function rejected all of the given pieces.
+var ErrNoPieceSelected = errors.New("no piece selected")
+
+// PieceSelectorF helps select a piece to fetch a cid from if the given cid is present in multiple pieces.
+// It should return `ErrNoPieceSelected` if none of the given piece is selected.
+type PieceSelectorF func(c cid.Cid, pieceCids []cid.Cid) (cid.Cid, error)
+
+type accessorWithBlockstore struct {
+	mount mount.Reader
+	bs    dagstore.ReadBlockstore
+}
+
+type IndexBackedBlockstoreAPI interface {
+	PiecesContainingMultihash(mh multihash.Multihash) ([]cid.Cid, error)
+	GetMaxPieceOffset(pieceCid cid.Cid) (uint64, error)
+	GetPieceInfo(pieceCID cid.Cid) (*piecestore.PieceInfo, error)
+	IsUnsealed(ctx context.Context, sectorID abi.SectorNumber, offset abi.UnpaddedPieceSize, length abi.UnpaddedPieceSize) (bool, error)
+	UnsealSectorAt(ctx context.Context, sectorID abi.SectorNumber, pieceOffset abi.UnpaddedPieceSize, length abi.UnpaddedPieceSize) (mount.Reader, error)
+}
+
+// IndexBackedBlockstore is a read only blockstore over all cids across all pieces on a provider.
+type IndexBackedBlockstore struct {
+	api          IndexBackedBlockstoreAPI
+	pieceSelectF PieceSelectorF
+
+	bsStripedLocks  [256]sync.Mutex
+	blockstoreCache *lru.Cache // caches the blockstore for a given piece for piece read affinity i.e. further reads will likely be from the same piece. Maps (piece CID -> blockstore).
+}
+
+func NewIndexBackedBlockstore(api IndexBackedBlockstoreAPI, pieceSelector PieceSelectorF, maxCacheSize int) (blockstore.Blockstore, error) {
+	// instantiate the blockstore cache
+	bslru, err := lru.NewWithEvict(maxCacheSize, func(_ interface{}, val interface{}) {
+		// ensure we close the blockstore for a piece when it's evicted from the cache so dagstore can gc it.
+		abs := val.(*accessorWithBlockstore)
+		abs.mount.Close()
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create lru cache for read only blockstores")
+	}
+
+	return &IndexBackedBlockstore{
+		api:             api,
+		pieceSelectF:    pieceSelector,
+		blockstoreCache: bslru,
+	}, nil
+}
+
+func (ro *IndexBackedBlockstore) Get(ctx context.Context, c cid.Cid) (b blocks.Block, finalErr error) {
+	logbs.Debugw("Get called", "cid", c)
+	defer func() {
+		if finalErr != nil {
+			logbs.Debugw("Get: got error", "cid", c, "error", finalErr)
+		}
+	}()
+
+	mhash := c.Hash()
+
+	// fetch all the pieceCIDs containing the multihash
+	pieceCIDs, err := ro.api.PiecesContainingMultihash(mhash)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch pieces containing the block: %w", err)
+	}
+	if len(pieceCIDs) == 0 {
+		return nil, ErrBlockNotFound
+	}
+
+	// do we have a cached blockstore for a piece containing the required block ? If yes, serve the block from that blockstore
+	for _, pieceCID := range pieceCIDs {
+		lk := &ro.bsStripedLocks[pieceCIDToStriped(pieceCID)]
+		lk.Lock()
+
+		blk, err := ro.readFromBSCacheUnlocked(ctx, c, pieceCID)
+		if err == nil && blk != nil {
+			logbs.Debugw("Get: returning from block store cache", "cid", c)
+
+			lk.Unlock()
+			return blk, nil
+		}
+
+		lk.Unlock()
+	}
+
+	// ---- we don't have a cached blockstore for a piece that can serve the block -> let's build one.
+
+	// select a valid piece that can serve the retrieval
+	pieceCID, err := ro.pieceSelectF(c, pieceCIDs)
+	if err != nil && err == ErrNoPieceSelected {
+		return nil, ErrBlockNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to run piece selection function: %w", err)
+	}
+
+	lk := &ro.bsStripedLocks[pieceCIDToStriped(pieceCID)]
+	lk.Lock()
+	defer lk.Unlock()
+
+	// see if we have blockstore in the cache we can serve the retrieval from as the previous code in this critical section
+	// could have added a blockstore to the cache for the given piece CID.
+	blk, err := ro.readFromBSCacheUnlocked(ctx, c, pieceCID)
+	if err == nil && blk != nil {
+		return blk, nil
+	}
+
+	// load blockstore for the selected piece and try to serve the cid from that blockstore.
+	reader, err := ro.getPieceContent(ctx, pieceCID)
+
+	bs, err := ro.getBlockstore(reader)
+
+	blk, err = bs.Get(ctx, c)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get block: %w", err)
+	}
+
+	// update the block cache and the blockstore cache
+	ro.blockstoreCache.Add(pieceCID, &accessorWithBlockstore{reader, bs})
+
+	logbs.Debugw("Get: returning after creating new blockstore", "cid", c)
+	return blk, nil
+}
+
+func (ro *IndexBackedBlockstore) Has(ctx context.Context, c cid.Cid) (bool, error) {
+	logbs.Debugw("Has called", "cid", c)
+
+	// if there is a piece that can serve the retrieval for the given cid, we have the requested cid
+	// and has should return true.
+	mhash := c.Hash()
+
+	pieceCIDs, err := ro.api.PiecesContainingMultihash(mhash)
+	if err != nil {
+		logbs.Debugw("Has error", "cid", c, "err", err)
+		return false, nil
+	}
+	if len(pieceCIDs) == 0 {
+		logbs.Debugw("Has: returning false no error", "cid", c)
+		return false, nil
+	}
+
+	_, err = ro.pieceSelectF(c, pieceCIDs)
+	if err != nil && err == ErrNoPieceSelected {
+		logbs.Debugw("Has error", "cid", c, "err", err)
+		return false, nil
+	}
+	if err != nil {
+		logbs.Debugw("Has error", "cid", c, "err", err)
+		return false, fmt.Errorf("failed to run piece selection function: %w", err)
+	}
+
+	logbs.Debugw("Has: returning true", "cid", c)
+	return true, nil
+}
+
+func (ro *IndexBackedBlockstore) GetSize(ctx context.Context, c cid.Cid) (int, error) {
+	logbs.Debugw("GetSize called", "cid", c)
+
+	blk, err := ro.Get(ctx, c)
+	if err != nil {
+		logbs.Debugw("GetSize error", "cid", c, "err", err)
+		return 0, fmt.Errorf("failed to get block: %w", err)
+	}
+
+	logbs.Debugw("GetSize success", "cid", c)
+	return len(blk.RawData()), nil
+}
+
+func (ro *IndexBackedBlockstore) readFromBSCacheUnlocked(ctx context.Context, c cid.Cid, pieceCid cid.Cid) (blocks.Block, error) {
+	// We've already ensured that the given piece has the cid/multihash we are looking for.
+	val, ok := ro.blockstoreCache.Get(pieceCid)
+	if !ok {
+		return nil, ErrBlockNotFound
+	}
+
+	rbs := val.(*accessorWithBlockstore).bs
+	blk, err := rbs.Get(ctx, c)
+	if err != nil {
+		// we know that the cid we want to lookup belongs to a piece with given pieceCID and
+		// so if we fail to get the corresponding block from the blockstore for that piece, something has gone wrong
+		// and we should remove the blockstore for that pieceCID from our cache.
+		ro.blockstoreCache.Remove(pieceCid)
+		return nil, err
+	}
+
+	return blk, nil
+}
+
+func pieceCIDToStriped(pieceCid cid.Cid) byte {
+	return pieceCid.String()[len(pieceCid.String())-1]
+}
+
+// --- UNSUPPORTED BLOCKSTORE METHODS -------
+func (ro *IndexBackedBlockstore) DeleteBlock(context.Context, cid.Cid) error {
+	return errors.New("unsupported operation DeleteBlock")
+}
+func (ro *IndexBackedBlockstore) HashOnRead(_ bool) {}
+func (ro *IndexBackedBlockstore) Put(context.Context, blocks.Block) error {
+	return errors.New("unsupported operation Put")
+}
+func (ro *IndexBackedBlockstore) PutMany(context.Context, []blocks.Block) error {
+	return errors.New("unsupported operation PutMany")
+}
+func (ro *IndexBackedBlockstore) AllKeysChan(ctx context.Context) (<-chan cid.Cid, error) {
+	return nil, errors.New("unsupported operation AllKeysChan")
+}
+
+func (ro *IndexBackedBlockstore) getPieceContent(ctx context.Context, pieceCid cid.Cid) (mount.Reader, error) {
+	// Get the deals for the piece
+	pieceInfo, err := ro.api.GetPieceInfo(pieceCid)
+	if err != nil {
+		return nil, fmt.Errorf("getting sector info for piece %s: %w", pieceCid, err)
+	}
+
+	// Get the first unsealed deal
+	di, err := ro.unsealedDeal(ctx, *pieceInfo)
+	if err != nil {
+		return nil, fmt.Errorf("getting unsealed CAR file: %w", err)
+	}
+
+	// Get the raw piece data from the sector
+	pieceReader, err := ro.api.UnsealSectorAt(ctx, di.SectorID, di.Offset.Unpadded(), di.Length.Unpadded())
+	if err != nil {
+		return nil, fmt.Errorf("getting raw data from sector %d: %w", di.SectorID, err)
+	}
+
+	return pieceReader, nil
+}
+
+func (ro *IndexBackedBlockstore) getBlockstore(pieceReader mount.Reader) (dagstore.ReadBlockstore, error) {
+	idx, err := car.ReadOrGenerateIndex(pieceReader, car.ZeroLengthSectionAsEOF(true), car.StoreIdentityCIDs(true))
+	if err != nil {
+		return nil, err
+	}
+	return carbs.NewReadOnly(pieceReader, idx, car.ZeroLengthSectionAsEOF(true))
+}
+
+func (ro *IndexBackedBlockstore) unsealedDeal(ctx context.Context, pieceInfo piecestore.PieceInfo) (*piecestore.DealInfo, error) {
+	// There should always been deals in the PieceInfo, but check just in case
+	if len(pieceInfo.Deals) == 0 {
+		return nil, fmt.Errorf("there are no deals containing piece %s: %w", pieceInfo.PieceCID, ErrNotFound)
+	}
+
+	// The same piece can be in many deals. Find the first unsealed deal.
+	sealedCount := 0
+	var allErr error
+	for _, di := range pieceInfo.Deals {
+		isUnsealed, err := ro.api.IsUnsealed(ctx, di.SectorID, di.Offset.Unpadded(), di.Length.Unpadded())
+		if err != nil {
+			allErr = multierror.Append(allErr, err)
+			continue
+		}
+		if isUnsealed {
+			return &di, nil
+		}
+		sealedCount++
+	}
+
+	// Try to return an error message with as much useful information as possible
+	dealSectors := make([]string, 0, len(pieceInfo.Deals))
+	for _, di := range pieceInfo.Deals {
+		dealSectors = append(dealSectors, fmt.Sprintf("Deal %d: Sector %d", di.DealID, di.SectorID))
+	}
+
+	if allErr == nil {
+		dealSectorsErr := fmt.Errorf("%s: %w", strings.Join(dealSectors, ", "), ErrNotFound)
+		return nil, fmt.Errorf("checked unsealed status of %d deals containing piece %s: none are unsealed: %w",
+			len(pieceInfo.Deals), pieceInfo.PieceCID, dealSectorsErr)
+	}
+
+	if len(pieceInfo.Deals) == 1 {
+		return nil, fmt.Errorf("checking unsealed status of deal %d (sector %d) containing piece %s: %w",
+			pieceInfo.Deals[0].DealID, pieceInfo.Deals[0].SectorID, pieceInfo.PieceCID, allErr)
+	}
+
+	if sealedCount == 0 {
+		return nil, fmt.Errorf("checking unsealed status of %d deals containing piece %s: %s: %w",
+			len(pieceInfo.Deals), pieceInfo.PieceCID, dealSectors, allErr)
+	}
+
+	return nil, fmt.Errorf("checking unsealed status of %d deals containing piece %s - %d are sealed, %d had errors: %s: %w",
+		len(pieceInfo.Deals), pieceInfo.PieceCID, sealedCount, len(pieceInfo.Deals)-sealedCount, dealSectors, allErr)
+}

--- a/cmd/booster-bitswap/main.go
+++ b/cmd/booster-bitswap/main.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"os"
+
+	"github.com/filecoin-project/boost/build"
+	cliutil "github.com/filecoin-project/boost/cli/util"
+	logging "github.com/ipfs/go-log/v2"
+	"github.com/urfave/cli/v2"
+)
+
+var log = logging.Logger("booster")
+
+func main() {
+	app := &cli.App{
+		Name:                 "booster-bitswap",
+		Usage:                "Bitswap endpoint for retrieval from Filecoin",
+		EnableBashCompletion: true,
+		Version:              build.UserVersion(),
+		Flags: []cli.Flag{
+			cliutil.FlagVeryVerbose,
+		},
+		Commands: []*cli.Command{
+			runCmd,
+		},
+	}
+	app.Setup()
+
+	if err := app.Run(os.Args); err != nil {
+		os.Stderr.WriteString("Error: " + err.Error() + "\n")
+	}
+}
+
+func before(cctx *cli.Context) error {
+	_ = logging.SetLogLevel("booster", "INFO")
+
+	if cliutil.IsVeryVerbose {
+		_ = logging.SetLogLevel("booster", "DEBUG")
+	}
+
+	return nil
+}

--- a/cmd/booster-bitswap/run.go
+++ b/cmd/booster-bitswap/run.go
@@ -1,0 +1,267 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	_ "net/http/pprof"
+	"strings"
+
+	"github.com/filecoin-project/boost/api"
+	bclient "github.com/filecoin-project/boost/api/client"
+	cliutil "github.com/filecoin-project/boost/cli/util"
+	"github.com/filecoin-project/dagstore/mount"
+	"github.com/filecoin-project/go-fil-markets/piecestore"
+	"github.com/filecoin-project/go-jsonrpc"
+	"github.com/filecoin-project/go-state-types/abi"
+	lapi "github.com/filecoin-project/lotus/api"
+	"github.com/filecoin-project/lotus/api/client"
+	"github.com/filecoin-project/lotus/api/v0api"
+	"github.com/filecoin-project/lotus/api/v1api"
+	lcli "github.com/filecoin-project/lotus/cli"
+	"github.com/filecoin-project/lotus/markets/dagstore"
+	"github.com/filecoin-project/lotus/markets/sectoraccessor"
+	lotus_modules "github.com/filecoin-project/lotus/node/modules"
+	"github.com/filecoin-project/lotus/node/modules/dtypes"
+	"github.com/filecoin-project/lotus/node/repo"
+	"github.com/filecoin-project/lotus/storage/paths"
+	"github.com/filecoin-project/lotus/storage/sealer"
+	"github.com/ipfs/go-cid"
+	"github.com/multiformats/go-multihash"
+	"github.com/urfave/cli/v2"
+)
+
+var runCmd = &cli.Command{
+	Name:   "run",
+	Usage:  "Start a booster-bitswap process",
+	Before: before,
+	Flags: []cli.Flag{
+		&cli.BoolFlag{
+			Name:  "pprof",
+			Usage: "run pprof web server on localhost:6070",
+		},
+		&cli.UintFlag{
+			Name:  "port",
+			Usage: "the port to listen for bitswap requests on",
+			Value: 8888,
+		},
+		&cli.StringFlag{
+			Name:     "api-boost",
+			Usage:    "the endpoint for the boost API",
+			Required: true,
+		},
+		&cli.StringFlag{
+			Name:     "api-fullnode",
+			Usage:    "the endpoint for the full node API",
+			Required: true,
+		},
+		&cli.StringFlag{
+			Name:     "api-sealer",
+			Usage:    "the endpoint for the sealer API",
+			Required: true,
+		},
+	},
+	Action: func(cctx *cli.Context) error {
+		if cctx.Bool("pprof") {
+			go func() {
+				err := http.ListenAndServe("localhost:6070", nil)
+				if err != nil {
+					log.Error(err)
+				}
+			}()
+		}
+
+		// Connect to the Boost API
+		ctx := lcli.ReqContext(cctx)
+		boostAPIInfo := cctx.String("api-boost")
+		bapi, bcloser, err := getBoostAPI(ctx, boostAPIInfo)
+		if err != nil {
+			return fmt.Errorf("getting boost API: %w", err)
+		}
+		defer bcloser()
+
+		// Connect to the full node API
+		fnAPIInfo := cctx.String("api-fullnode")
+		fullnodeAPI, ncloser, err := getFullNodeAPI(ctx, fnAPIInfo)
+		if err != nil {
+			return fmt.Errorf("getting full node API: %w", err)
+		}
+		defer ncloser()
+
+		// Connect to the sealing API
+		sealingAPIInfo := cctx.String("api-sealer")
+		sauth, err := storageAuthWithURL(sealingAPIInfo)
+		if err != nil {
+			return fmt.Errorf("parsing sealing API endpoint: %w", err)
+		}
+		sealingService, sealerCloser, err := getMinerAPI(ctx, sealingAPIInfo)
+		if err != nil {
+			return fmt.Errorf("getting miner API: %w", err)
+		}
+		defer sealerCloser()
+
+		maddr, err := sealingService.ActorAddress(ctx)
+		if err != nil {
+			return fmt.Errorf("getting miner actor address: %w", err)
+		}
+		log.Infof("Miner address: %s", maddr)
+
+		// Use an in-memory repo because we don't need any functions
+		// of a real repo, we just need to supply something that satisfies
+		// the LocalStorage interface to the store
+		memRepo := repo.NewMemory(nil)
+		lr, err := memRepo.Lock(repo.StorageMiner)
+		if err != nil {
+			return fmt.Errorf("locking mem repo: %w", err)
+		}
+		defer lr.Close()
+
+		// Create the store interface
+		var urls []string
+		lstor, err := paths.NewLocal(ctx, lr, sealingService, urls)
+		if err != nil {
+			return fmt.Errorf("creating new local store: %w", err)
+		}
+		storage := lotus_modules.RemoteStorage(lstor, sealingService, sauth, sealer.Config{
+			// TODO: Not sure if I need this, or any of the other fields in this struct
+			ParallelFetchLimit: 1,
+		})
+		// Create the piece provider and sector accessors
+		pp := sealer.NewPieceProvider(storage, sealingService, sealingService)
+		sa := sectoraccessor.NewSectorAccessor(dtypes.MinerAddress(maddr), sealingService, pp, fullnodeAPI)
+		// Create the server API
+		sapi := serverAPI{ctx: ctx, bapi: bapi, sa: sa}
+		server := NewBitswapServer(cctx.String("base-path"), cctx.Int("port"), sapi)
+
+		// Start the server
+		log.Infof("Starting booster-http node on port %d with base path '%s'",
+			cctx.Int("port"), cctx.String("base-path"))
+		err = server.Start(ctx)
+		if err != nil {
+			return err
+		}
+		// Monitor for shutdown.
+		<-ctx.Done()
+
+		log.Info("Shutting down...")
+
+		err = server.Stop()
+		if err != nil {
+			return err
+		}
+		log.Info("Graceful shutdown successful")
+
+		// Sync all loggers.
+		_ = log.Sync() //nolint:errcheck
+
+		return nil
+	},
+}
+
+func storageAuthWithURL(apiInfo string) (sealer.StorageAuth, error) {
+	s := strings.Split(apiInfo, ":")
+	if len(s) != 2 {
+		return nil, errors.New("unexpected format of `apiInfo`")
+	}
+	headers := http.Header{}
+	headers.Add("Authorization", "Bearer "+s[0])
+	return sealer.StorageAuth(headers), nil
+}
+
+type serverAPI struct {
+	ctx  context.Context
+	bapi api.Boost
+	sa   dagstore.SectorAccessor
+}
+
+var _ BitswapServerAPI = (*serverAPI)(nil)
+
+func (s serverAPI) PiecesContainingMultihash(mh multihash.Multihash) ([]cid.Cid, error) {
+	return s.bapi.BoostDagstorePiecesContainingMultihash(s.ctx, mh)
+}
+
+func (s serverAPI) GetMaxPieceOffset(pieceCid cid.Cid) (uint64, error) {
+	return s.bapi.PiecesGetMaxOffset(s.ctx, pieceCid)
+}
+
+func (s serverAPI) GetPieceInfo(pieceCID cid.Cid) (*piecestore.PieceInfo, error) {
+	return s.bapi.PiecesGetPieceInfo(s.ctx, pieceCID)
+}
+
+func (s serverAPI) IsUnsealed(ctx context.Context, sectorID abi.SectorNumber, offset abi.UnpaddedPieceSize, length abi.UnpaddedPieceSize) (bool, error) {
+	return s.sa.IsUnsealed(ctx, sectorID, offset, length)
+}
+
+func (s serverAPI) UnsealSectorAt(ctx context.Context, sectorID abi.SectorNumber, offset abi.UnpaddedPieceSize, length abi.UnpaddedPieceSize) (mount.Reader, error) {
+	return s.sa.UnsealSectorAt(ctx, sectorID, offset, length)
+}
+
+func getBoostAPI(ctx context.Context, ai string) (api.Boost, jsonrpc.ClientCloser, error) {
+	ai = strings.TrimPrefix(strings.TrimSpace(ai), "BOOST_API_INFO=")
+	info := cliutil.ParseApiInfo(ai)
+	addr, err := info.DialArgs("v0")
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not get DialArgs: %w", err)
+	}
+
+	log.Infof("Using boost API at %s", addr)
+	api, closer, err := bclient.NewBoostRPCV0(ctx, addr, info.AuthHeader())
+	if err != nil {
+		return nil, nil, fmt.Errorf("creating full node service API: %w", err)
+	}
+
+	return api, closer, nil
+}
+
+func getFullNodeAPI(ctx context.Context, ai string) (v1api.FullNode, jsonrpc.ClientCloser, error) {
+	ai = strings.TrimPrefix(strings.TrimSpace(ai), "FULLNODE_API_INFO=")
+	info := cliutil.ParseApiInfo(ai)
+	addr, err := info.DialArgs("v1")
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not get DialArgs: %w", err)
+	}
+
+	log.Infof("Using full node API at %s", addr)
+	api, closer, err := client.NewFullNodeRPCV1(ctx, addr, info.AuthHeader())
+	if err != nil {
+		return nil, nil, fmt.Errorf("creating full node service API: %w", err)
+	}
+
+	v, err := api.Version(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("checking full node service API version: %w", err)
+	}
+
+	if !v.APIVersion.EqMajorMinor(lapi.FullAPIVersion1) {
+		return nil, nil, fmt.Errorf("full node service API version didn't match (expected %s, remote %s)", lapi.FullAPIVersion1, v.APIVersion)
+	}
+
+	return api, closer, nil
+}
+
+func getMinerAPI(ctx context.Context, ai string) (v0api.StorageMiner, jsonrpc.ClientCloser, error) {
+	ai = strings.TrimPrefix(strings.TrimSpace(ai), "MINER_API_INFO=")
+	info := cliutil.ParseApiInfo(ai)
+	addr, err := info.DialArgs("v0")
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not get DialArgs: %w", err)
+	}
+
+	log.Infof("Using sealing API at %s", addr)
+	api, closer, err := client.NewStorageMinerRPCV0(ctx, addr, info.AuthHeader())
+	if err != nil {
+		return nil, nil, fmt.Errorf("creating miner service API: %w", err)
+	}
+
+	v, err := api.Version(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("checking miner service API version: %w", err)
+	}
+
+	if !v.APIVersion.EqMajorMinor(lapi.MinerAPIVersion0) {
+		return nil, nil, fmt.Errorf("miner service API version didn't match (expected %s, remote %s)", lapi.MinerAPIVersion0, v.APIVersion)
+	}
+
+	return api, closer, nil
+}

--- a/cmd/booster-bitswap/server.go
+++ b/cmd/booster-bitswap/server.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"errors"
+	"fmt"
+
+	indexbs "github.com/filecoin-project/boost/cmd/booster-bitswap/indexbs"
+	"github.com/filecoin-project/dagstore/mount"
+	"github.com/filecoin-project/go-fil-markets/piecestore"
+	"github.com/filecoin-project/go-state-types/abi"
+	bsnetwork "github.com/ipfs/go-bitswap/network"
+	"github.com/ipfs/go-bitswap/server"
+	"github.com/ipfs/go-cid"
+	nilrouting "github.com/ipfs/go-ipfs-routing/none"
+	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p-core/network"
+	crypto "github.com/libp2p/go-libp2p-crypto"
+	"github.com/libp2p/go-libp2p/p2p/muxer/mplex"
+	"github.com/libp2p/go-libp2p/p2p/muxer/yamux"
+	quic "github.com/libp2p/go-libp2p/p2p/transport/quic"
+	"github.com/libp2p/go-tcp-transport"
+	"github.com/multiformats/go-multihash"
+)
+
+var ErrNotFound = errors.New("not found")
+
+type BitswapServer struct {
+	port int
+	api  BitswapServerAPI
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	server *server.Server
+}
+
+type BitswapServerAPI interface {
+	PiecesContainingMultihash(mh multihash.Multihash) ([]cid.Cid, error)
+	GetMaxPieceOffset(pieceCid cid.Cid) (uint64, error)
+	GetPieceInfo(pieceCID cid.Cid) (*piecestore.PieceInfo, error)
+	IsUnsealed(ctx context.Context, sectorID abi.SectorNumber, offset abi.UnpaddedPieceSize, length abi.UnpaddedPieceSize) (bool, error)
+	UnsealSectorAt(ctx context.Context, sectorID abi.SectorNumber, pieceOffset abi.UnpaddedPieceSize, length abi.UnpaddedPieceSize) (mount.Reader, error)
+}
+
+func NewBitswapServer(path string, port int, api BitswapServerAPI) *BitswapServer {
+	return &BitswapServer{port: port, api: api}
+}
+
+func (s *BitswapServer) Start(ctx context.Context) error {
+	s.ctx, s.cancel = context.WithCancel(ctx)
+	sf := indexbs.PieceSelectorF(func(c cid.Cid, pieceCIDs []cid.Cid) (cid.Cid, error) {
+		for _, pieceCID := range pieceCIDs {
+			pi, err := s.api.GetPieceInfo(pieceCID)
+			if err != nil {
+				return cid.Undef, fmt.Errorf("failed to get piece info: %w", err)
+			}
+			isUnsealed := s.pieceInUnsealedSector(s.ctx, *pi)
+			if isUnsealed {
+				return pieceCID, nil
+			}
+		}
+
+		return cid.Undef, indexbs.ErrNoPieceSelected
+	})
+
+	rbs, err := indexbs.NewIndexBackedBlockstore(s.api, sf, 100)
+	if err != nil {
+		return fmt.Errorf("failed to create index backed blockstore: %w", err)
+	}
+
+	// setup libp2p host
+	privKey, _, err := crypto.GenerateECDSAKeyPair(rand.Reader)
+
+	host, err := libp2p.New(
+		libp2p.ListenAddrStrings(
+			fmt.Sprintf("/ip4/0.0.0.0/tcp/%d", s.port),
+			fmt.Sprintf("/ip4/0.0.0.0/udp/%d/quic", s.port),
+		),
+		libp2p.Transport(tcp.NewTCPTransport),
+		libp2p.Transport(quic.NewTransport),
+		libp2p.Muxer("/mplex/6.7.0", mplex.DefaultTransport),
+		libp2p.Muxer("/yamux/1.0.0", yamux.DefaultTransport),
+		libp2p.Identity(privKey),
+		libp2p.ResourceManager(network.NullResourceManager),
+	)
+	if err != nil {
+		return err
+	}
+
+	// start a bitswap session on the provider
+	nilRouter, err := nilrouting.ConstructNilRouting(ctx, nil, nil, nil)
+	if err != nil {
+		return err
+	}
+	bsopts := []server.Option{server.MaxOutstandingBytesPerPeer(1 << 20)}
+	s.server = server.New(ctx, bsnetwork.NewFromIpfsHost(r.h, nilRouter), rbs, bsopts...)
+
+	fmt.Printf("bitswap server running on SP, addrs: %s, peerID: %s", r.h.Addrs(), r.h.ID())
+	log.Infow("bitswap server running on SP", "multiaddrs", r.h.Addrs(), "peerId", r.h.ID())
+	return nil
+}
+
+func (s *BitswapServer) Stop() error {
+	s.cancel()
+	return s.server.Close()
+}
+
+func (s *BitswapServer) pieceInUnsealedSector(ctx context.Context, pieceInfo piecestore.PieceInfo) bool {
+	for _, di := range pieceInfo.Deals {
+		isUnsealed, err := s.api.IsUnsealed(ctx, di.SectorID, di.Offset.Unpadded(), di.Length.Unpadded())
+		if err != nil {
+			log.Errorf("failed to find out if sector %d is unsealed, err=%s", di.SectorID, err)
+			continue
+		}
+		if isUnsealed {
+			return true
+		}
+	}
+
+	return false
+}

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/filecoin-project/go-data-transfer v1.15.2
 	github.com/filecoin-project/go-fil-commcid v0.1.0
 	github.com/filecoin-project/go-fil-commp-hashhash v0.1.0
-	github.com/filecoin-project/go-fil-markets v1.23.2
+	github.com/filecoin-project/go-fil-markets v1.23.3-0.20220817063153-cdd032886583
 	github.com/filecoin-project/go-jsonrpc v0.1.5
 	github.com/filecoin-project/go-padreader v0.0.1
 	github.com/filecoin-project/go-paramfetch v0.0.4
@@ -44,8 +44,9 @@ require (
 	github.com/graph-gophers/graphql-go v1.2.0
 	github.com/graph-gophers/graphql-transport-ws v0.0.2
 	github.com/hashicorp/go-multierror v1.1.1
+	github.com/ipfs/go-bitswap v0.9.0 // indirect
 	github.com/ipfs/go-block-format v0.0.3
-	github.com/ipfs/go-blockservice v0.3.0
+	github.com/ipfs/go-blockservice v0.4.0
 	github.com/ipfs/go-cid v0.2.0
 	github.com/ipfs/go-cidutil v0.1.0
 	github.com/ipfs/go-datastore v0.5.1
@@ -54,8 +55,8 @@ require (
 	github.com/ipfs/go-ipfs-blocksutil v0.0.1
 	github.com/ipfs/go-ipfs-chunker v0.0.5
 	github.com/ipfs/go-ipfs-ds-help v1.1.0
-	github.com/ipfs/go-ipfs-exchange-interface v0.1.0
-	github.com/ipfs/go-ipfs-exchange-offline v0.2.0
+	github.com/ipfs/go-ipfs-exchange-interface v0.2.0
+	github.com/ipfs/go-ipfs-exchange-offline v0.3.0
 	github.com/ipfs/go-ipfs-files v0.1.1
 	github.com/ipfs/go-ipld-format v0.4.0
 	github.com/ipfs/go-log/v2 v2.5.1
@@ -70,27 +71,27 @@ require (
 	github.com/jpillora/backoff v1.0.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/libp2p/go-eventbus v0.2.1
-	github.com/libp2p/go-libp2p v0.20.3
-	github.com/libp2p/go-libp2p-core v0.16.1
+	github.com/libp2p/go-libp2p v0.21.0
+	github.com/libp2p/go-libp2p-core v0.19.1
 	github.com/libp2p/go-libp2p-gostream v0.4.1-0.20220720161416-e1952aede109
 	github.com/libp2p/go-libp2p-http v0.2.1
 	github.com/libp2p/go-libp2p-kad-dht v0.15.0
-	github.com/libp2p/go-libp2p-peerstore v0.7.0
+	github.com/libp2p/go-libp2p-peerstore v0.7.1
 	github.com/libp2p/go-libp2p-pubsub v0.7.1
 	github.com/libp2p/go-libp2p-record v0.1.3
-	github.com/libp2p/go-libp2p-resource-manager v0.3.0
+	github.com/libp2p/go-libp2p-resource-manager v0.5.1
 	github.com/mattn/go-sqlite3 v1.14.10
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/multiformats/go-multiaddr v0.5.0
-	github.com/multiformats/go-multibase v0.0.3
-	github.com/multiformats/go-multihash v0.1.0
+	github.com/multiformats/go-multiaddr v0.6.0
+	github.com/multiformats/go-multibase v0.1.1
+	github.com/multiformats/go-multihash v0.2.0
 	github.com/multiformats/go-varint v0.0.6
 	github.com/open-rpc/meta-schema v0.0.0-20201029221707-1b72ef2ea333
 	github.com/pressly/goose/v3 v3.5.3
 	github.com/prometheus/client_golang v1.12.1
 	github.com/raulk/clock v1.1.0
-	github.com/raulk/go-watchdog v1.2.0
-	github.com/stretchr/testify v1.7.1
+	github.com/raulk/go-watchdog v1.3.0
+	github.com/stretchr/testify v1.8.0
 	github.com/urfave/cli/v2 v2.8.1
 	github.com/whyrusleeping/base32 v0.0.0-20170828182744-c30ac30633cc
 	github.com/whyrusleeping/cbor-gen v0.0.0-20220323183124-98fa8256a799
@@ -100,6 +101,6 @@ require (
 	go.uber.org/multierr v1.8.0
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/tools v0.1.11
-	golang.org/x/xerrors v0.0.0-20220411194840-2f41105eb62f
+	golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f
 	gopkg.in/cheggaaa/pb.v1 v1.0.28
 )

--- a/go.sum
+++ b/go.sum
@@ -388,6 +388,8 @@ github.com/filecoin-project/go-fil-commp-hashhash v0.1.0/go.mod h1:73S8WSEWh9vr0
 github.com/filecoin-project/go-fil-markets v1.23.1/go.mod h1:V+1vFO34RZmpdECdikKGiyWhSNJK81Q89Kn0egA9iAk=
 github.com/filecoin-project/go-fil-markets v1.23.2 h1:9+5CCliLVoTbq3qffT2xZMuGjyl2HyR0RJ7x29ywRi8=
 github.com/filecoin-project/go-fil-markets v1.23.2/go.mod h1:V+1vFO34RZmpdECdikKGiyWhSNJK81Q89Kn0egA9iAk=
+github.com/filecoin-project/go-fil-markets v1.23.3-0.20220817063153-cdd032886583 h1:DaHJ8oLE2TSsea/fnXGOTnPd3qbRhCCbuyaiaFdAKf8=
+github.com/filecoin-project/go-fil-markets v1.23.3-0.20220817063153-cdd032886583/go.mod h1:ZOPAjEUia7H60F7p0kEupi0FR7Hy4Zfz90BpR1TMBwI=
 github.com/filecoin-project/go-hamt-ipld v0.1.5 h1:uoXrKbCQZ49OHpsTCkrThPNelC4W3LPEk0OrS/ytIBM=
 github.com/filecoin-project/go-hamt-ipld v0.1.5/go.mod h1:6Is+ONR5Cd5R6XZoCse1CWaXZc0Hdb/JeX+EQCQzX24=
 github.com/filecoin-project/go-hamt-ipld/v2 v2.0.0 h1:b3UDemBYN2HNfk3KOXNuxgTTxlWi3xVvbQP0IT38fvM=
@@ -516,8 +518,13 @@ github.com/go-logr/logr v0.4.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTg
 github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.1 h1:DX7uPQ4WgAWfoh+NGGlbJQswnYIVvz0SRlLS3rPZQDA=
 github.com/go-logr/logr v1.2.1/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+github.com/go-logr/logr v1.2.3 h1:2DntVwHkVopvECVRSlL5PSo9eG+cAkDCuckLubN+rq0=
+github.com/go-logr/logr v1.2.3/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/stdr v1.2.0 h1:j4LrlVXgrbIWO83mmQUnK0Hi+YnbD+vzrE1z/EphbFE=
 github.com/go-logr/stdr v1.2.0/go.mod h1:YkVgnZu1ZjjL7xTxrfm/LLZBfkhTqSR1ydtm6jTKKwI=
+github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
+github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/go-ole/go-ole v1.2.5 h1:t4MGB5xEDZvXI+0rMjjsfBsD7yAgp/s9ZDkL1JndXwY=
 github.com/go-ole/go-ole v1.2.5/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
 github.com/go-openapi/jsonpointer v0.19.2/go.mod h1:3akKfEdA7DF1sugOqz1dVQHBcuDBPKZGEoHC/NkiQRg=
@@ -774,6 +781,9 @@ github.com/ipfs/go-bitswap v0.3.4/go.mod h1:4T7fvNv/LmOys+21tnLzGKncMeeXUYUd1nUi
 github.com/ipfs/go-bitswap v0.5.1/go.mod h1:P+ckC87ri1xFLvk74NlXdP0Kj9RmWAh4+H78sC6Qopo=
 github.com/ipfs/go-bitswap v0.6.0 h1:f2rc6GZtoSFhEIzQmddgGiel9xntj02Dg0ZNf2hSC+w=
 github.com/ipfs/go-bitswap v0.6.0/go.mod h1:Hj3ZXdOC5wBJvENtdqsixmzzRukqd8EHLxZLZc3mzRA=
+github.com/ipfs/go-bitswap v0.8.0/go.mod h1:/h8sBij8UVEaNWl8ABzpLRA5Y1cttdNUnpeGo2AA/LQ=
+github.com/ipfs/go-bitswap v0.9.0 h1:/dZi/XhUN/aIk78pI4kaZrilUglJ+7/SCmOHWIpiy8E=
+github.com/ipfs/go-bitswap v0.9.0/go.mod h1:zkfBcGWp4dQTQd0D0akpudhpOVUAJT9GbH9tDmR8/s4=
 github.com/ipfs/go-block-format v0.0.1/go.mod h1:DK/YYcsSUIVAFNwo/KZCdIIbpN0ROH/baNLgayt4pFc=
 github.com/ipfs/go-block-format v0.0.2/go.mod h1:AWR46JfpcObNfg3ok2JHDUfdiHRgWhJgCQF+KIgOPJY=
 github.com/ipfs/go-block-format v0.0.3 h1:r8t66QstRp/pd/or4dpnbVfXT5Gt7lOqRvC+/dDTpMc=
@@ -785,6 +795,8 @@ github.com/ipfs/go-blockservice v0.1.7/go.mod h1:GmS+BAt4hrwBKkzE11AFDQUrnvqjwFa
 github.com/ipfs/go-blockservice v0.2.1/go.mod h1:k6SiwmgyYgs4M/qt+ww6amPeUH9EISLRBnvUurKJhi8=
 github.com/ipfs/go-blockservice v0.3.0 h1:cDgcZ+0P0Ih3sl8+qjFr2sVaMdysg/YZpLj5WJ8kiiw=
 github.com/ipfs/go-blockservice v0.3.0/go.mod h1:P5ppi8IHDC7O+pA0AlGTF09jruB2h+oP3wVVaZl8sfk=
+github.com/ipfs/go-blockservice v0.4.0 h1:7MUijAW5SqdsqEW/EhnNFRJXVF8mGU5aGhZ3CQaCWbY=
+github.com/ipfs/go-blockservice v0.4.0/go.mod h1:kRjO3wlGW9mS1aKuiCeGhx9K1DagQ10ACpVO59qgAx4=
 github.com/ipfs/go-cid v0.0.1/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.2/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.3/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
@@ -880,10 +892,14 @@ github.com/ipfs/go-ipfs-ds-help v1.1.0/go.mod h1:YR5+6EaebOhfcqVCyqemItCLthrpVNo
 github.com/ipfs/go-ipfs-exchange-interface v0.0.1/go.mod h1:c8MwfHjtQjPoDyiy9cFquVtVHkO9b9Ob3FG91qJnWCM=
 github.com/ipfs/go-ipfs-exchange-interface v0.1.0 h1:TiMekCrOGQuWYtZO3mf4YJXDIdNgnKWZ9IE3fGlnWfo=
 github.com/ipfs/go-ipfs-exchange-interface v0.1.0/go.mod h1:ych7WPlyHqFvCi/uQI48zLZuAWVP5iTQPXEfVaw5WEI=
+github.com/ipfs/go-ipfs-exchange-interface v0.2.0 h1:8lMSJmKogZYNo2jjhUs0izT+dck05pqUw4mWNW9Pw6Y=
+github.com/ipfs/go-ipfs-exchange-interface v0.2.0/go.mod h1:z6+RhJuDQbqKguVyslSOuVDhqF9JtTrO3eptSAiW2/Y=
 github.com/ipfs/go-ipfs-exchange-offline v0.0.1/go.mod h1:WhHSFCVYX36H/anEKQboAzpUws3x7UeEGkzQc3iNkM0=
 github.com/ipfs/go-ipfs-exchange-offline v0.1.1/go.mod h1:vTiBRIbzSwDD0OWm+i3xeT0mO7jG2cbJYatp3HPk5XY=
 github.com/ipfs/go-ipfs-exchange-offline v0.2.0 h1:2PF4o4A7W656rC0RxuhUace997FTcDTcIQ6NoEtyjAI=
 github.com/ipfs/go-ipfs-exchange-offline v0.2.0/go.mod h1:HjwBeW0dvZvfOMwDP0TSKXIHf2s+ksdP4E3MLDRtLKY=
+github.com/ipfs/go-ipfs-exchange-offline v0.3.0 h1:c/Dg8GDPzixGd0MC8Jh6mjOwU57uYokgWRFidfvEkuA=
+github.com/ipfs/go-ipfs-exchange-offline v0.3.0/go.mod h1:MOdJ9DChbb5u37M1IcbrRB02e++Z7521fMxqCNRrz9s=
 github.com/ipfs/go-ipfs-files v0.0.3/go.mod h1:INEFm0LL2LWXBhNJ2PMIIb2w45hpXgPjNoE7yA8Y1d4=
 github.com/ipfs/go-ipfs-files v0.0.4/go.mod h1:INEFm0LL2LWXBhNJ2PMIIb2w45hpXgPjNoE7yA8Y1d4=
 github.com/ipfs/go-ipfs-files v0.0.8/go.mod h1:wiN/jSG8FKyk7N0WyctKSvq3ljIa2NNTiZB55kpTdOs=
@@ -1176,6 +1192,7 @@ github.com/libp2p/go-libp2p v0.20.0/go.mod h1:g0C5Fu+aXXbCXkusCzLycuBowEih3ElmDq
 github.com/libp2p/go-libp2p v0.20.1/go.mod h1:XgJHsOhEBVBXp/2Sj9bm/yEyD94uunAaP6oaegdcKks=
 github.com/libp2p/go-libp2p v0.20.3 h1:tjjDNfp7FqdI/7v1rXtB/BtELaPlAThL2uzlj18kcrw=
 github.com/libp2p/go-libp2p v0.20.3/go.mod h1:I+vndVanE/p/SjFbnA+BEmmfAUEpWxrdXZeyQ1Dus5c=
+github.com/libp2p/go-libp2p v0.21.0/go.mod h1:zvcA6/C4mr5/XQarRICh+L1SN9dAHHlSWDq4x5VYxg4=
 github.com/libp2p/go-libp2p-asn-util v0.0.0-20200825225859-85005c6cf052/go.mod h1:nRMRTab+kZuk0LnKZpxhOVH/ndsdr2Nr//Zltc/vwgo=
 github.com/libp2p/go-libp2p-asn-util v0.1.0/go.mod h1:wu+AnM9Ii2KgO5jMmS1rz9dvzTdj8BXqsPR9HR0XB7I=
 github.com/libp2p/go-libp2p-asn-util v0.2.0 h1:rg3+Os8jbnO5DxkC7K/Utdi+DkY3q/d1/1q+8WeNAsw=
@@ -1250,6 +1267,7 @@ github.com/libp2p/go-libp2p-core v0.14.0/go.mod h1:tLasfcVdTXnixsLB0QYaT1syJOhsb
 github.com/libp2p/go-libp2p-core v0.15.1/go.mod h1:agSaboYM4hzB1cWekgVReqV5M4g5M+2eNNejV+1EEhs=
 github.com/libp2p/go-libp2p-core v0.16.1 h1:bWoiEBqVkpJ13hbv/f69tHODp86t6mvc4fBN4DkK73M=
 github.com/libp2p/go-libp2p-core v0.16.1/go.mod h1:O3i/7y+LqUb0N+qhzXjBjjpchgptWAVMG1Voegk7b4c=
+github.com/libp2p/go-libp2p-core v0.19.1/go.mod h1:2uLhmmqDiFY+dw+70KkBLeKvvsJHGWUINRDdeV1ip7k=
 github.com/libp2p/go-libp2p-crypto v0.0.1/go.mod h1:yJkNyDmO341d5wwXxDUGO0LykUVT72ImHNUqh5D/dBE=
 github.com/libp2p/go-libp2p-crypto v0.0.2/go.mod h1:eETI5OUfBnvARGOHrJz2eWNyTUxEGZnBxMcbUjfIj4I=
 github.com/libp2p/go-libp2p-crypto v0.1.0/go.mod h1:sPUokVISZiy+nNuTTH/TY+leRSxnFj/2GLjtOTW90hI=
@@ -1329,6 +1347,7 @@ github.com/libp2p/go-libp2p-peerstore v0.4.0/go.mod h1:rDJUFyzEWPpXpEwywkcTYYzDH
 github.com/libp2p/go-libp2p-peerstore v0.6.0/go.mod h1:DGEmKdXrcYpK9Jha3sS7MhqYdInxJy84bIPtSu65bKc=
 github.com/libp2p/go-libp2p-peerstore v0.7.0 h1:2iIUwok3vtmnWJTZeTeLgnBO6GbkXcwSRwgZHEKrQZs=
 github.com/libp2p/go-libp2p-peerstore v0.7.0/go.mod h1:cdUWTHro83vpg6unCpGUr8qJoX3e93Vy8o97u5ppIM0=
+github.com/libp2p/go-libp2p-peerstore v0.7.1/go.mod h1:cdUWTHro83vpg6unCpGUr8qJoX3e93Vy8o97u5ppIM0=
 github.com/libp2p/go-libp2p-pnet v0.2.0/go.mod h1:Qqvq6JH/oMZGwqs3N1Fqhv8NVhrdYcO0BW4wssv21LA=
 github.com/libp2p/go-libp2p-protocol v0.0.1/go.mod h1:Af9n4PiruirSDjHycM1QuiMi/1VZNHYcK8cLgFJLZ4s=
 github.com/libp2p/go-libp2p-protocol v0.1.0/go.mod h1:KQPHpAabB57XQxGrXCNvbL6UEXfQqUgC/1adR2Xtflk=
@@ -1357,6 +1376,8 @@ github.com/libp2p/go-libp2p-resource-manager v0.1.5/go.mod h1:wJPNjeE4XQlxeidwqV
 github.com/libp2p/go-libp2p-resource-manager v0.2.1/go.mod h1:K+eCkiapf+ey/LADO4TaMpMTP9/Qde/uLlrnRqV4PLQ=
 github.com/libp2p/go-libp2p-resource-manager v0.3.0 h1:2+cYxUNi33tcydsVLt6K5Fv2E3OTiVeafltecAj15E0=
 github.com/libp2p/go-libp2p-resource-manager v0.3.0/go.mod h1:K+eCkiapf+ey/LADO4TaMpMTP9/Qde/uLlrnRqV4PLQ=
+github.com/libp2p/go-libp2p-resource-manager v0.5.1 h1:jm0mdqn7yfh7wbUzlj948BYZX0KZ3RW7OqerkGQ5rYY=
+github.com/libp2p/go-libp2p-resource-manager v0.5.1/go.mod h1:CggtV6EZb+Y0dGh41q5ezO4udcVKyhcEFpydHD8EMe0=
 github.com/libp2p/go-libp2p-routing v0.0.1/go.mod h1:N51q3yTr4Zdr7V8Jt2JIktVU+3xBBylx1MZeVA6t1Ys=
 github.com/libp2p/go-libp2p-routing v0.1.0/go.mod h1:zfLhI1RI8RLEzmEaaPwzonRvXeeSHddONWkcTcB54nE=
 github.com/libp2p/go-libp2p-routing-helpers v0.2.3 h1:xY61alxJ6PurSi+MXbywZpelvuU4U4p/gPTxjqCqTzY=
@@ -1698,6 +1719,7 @@ github.com/multiformats/go-multiaddr v0.4.0/go.mod h1:YcpyLH8ZPudLxQlemYBPhSm0/o
 github.com/multiformats/go-multiaddr v0.4.1/go.mod h1:3afI9HfVW8csiF8UZqtpYRiDyew8pRX7qLIGHu9FLuM=
 github.com/multiformats/go-multiaddr v0.5.0 h1:i/JuOoVg4szYQ4YEzDGtb2h0o8M7CG/Yq6cGlcjWZpM=
 github.com/multiformats/go-multiaddr v0.5.0/go.mod h1:3KAxNkUqLTJ20AAwN4XVX4kZar+bR+gh4zgbfr3SNug=
+github.com/multiformats/go-multiaddr v0.6.0/go.mod h1:F4IpaKZuPP360tOMn2Tpyu0At8w23aRyVqeK0DbFeGM=
 github.com/multiformats/go-multiaddr-dns v0.0.1/go.mod h1:9kWcqw/Pj6FwxAwW38n/9403szc57zJPs45fmnznu3Q=
 github.com/multiformats/go-multiaddr-dns v0.0.2/go.mod h1:9kWcqw/Pj6FwxAwW38n/9403szc57zJPs45fmnznu3Q=
 github.com/multiformats/go-multiaddr-dns v0.0.3/go.mod h1:9kWcqw/Pj6FwxAwW38n/9403szc57zJPs45fmnznu3Q=
@@ -1720,6 +1742,7 @@ github.com/multiformats/go-multiaddr-net v0.2.0/go.mod h1:gGdH3UXny6U3cKKYCvpXI5
 github.com/multiformats/go-multibase v0.0.1/go.mod h1:bja2MqRZ3ggyXtZSEDKpl0uO/gviWFaSteVbWT51qgs=
 github.com/multiformats/go-multibase v0.0.3 h1:l/B6bJDQjvQ5G52jw4QGSYeOTZoAwIO77RblWplfIqk=
 github.com/multiformats/go-multibase v0.0.3/go.mod h1:5+1R4eQrT3PkYZ24C3W2Ue2tPwIdYQD509ZjSb5y9Oc=
+github.com/multiformats/go-multibase v0.1.1/go.mod h1:ZEjHE+IsUrgp5mhlEAYjMtZwK1k4haNkcaPg9aoe1a8=
 github.com/multiformats/go-multicodec v0.2.0/go.mod h1:/y4YVwkfMyry5kFbMTbLJKErhycTIftytRV+llXdyS4=
 github.com/multiformats/go-multicodec v0.3.0/go.mod h1:qGGaQmioCDh+TeFOnxrbU0DaIPw8yFgAZgFG0V7p1qQ=
 github.com/multiformats/go-multicodec v0.3.1-0.20210902112759-1539a079fd61/go.mod h1:1Hj/eHRaVWSXiSNNfcEPcwZleTmdNP81xlxDLnWU9GQ=
@@ -1738,6 +1761,7 @@ github.com/multiformats/go-multihash v0.0.15/go.mod h1:D6aZrWNLFTV/ynMpKsNtB40mJ
 github.com/multiformats/go-multihash v0.0.16/go.mod h1:zhfEIgVnB/rPMfxgFw15ZmGoNaKyNUIE4IWHG/kC+Ag=
 github.com/multiformats/go-multihash v0.1.0 h1:CgAgwqk3//SVEw3T+6DqI4mWMyRuDwZtOWcJT0q9+EA=
 github.com/multiformats/go-multihash v0.1.0/go.mod h1:RJlXsxt6vHGaia+S8We0ErjhojtKzPP2AH4+kYM7k84=
+github.com/multiformats/go-multihash v0.2.0/go.mod h1:WxoMcYG85AZVQUyRyo9s4wULvW5qrI9vb2Lt6evduFc=
 github.com/multiformats/go-multistream v0.0.1/go.mod h1:fJTiDfXJVmItycydCnNx4+wSzZ5NwG2FEVAI30fiovg=
 github.com/multiformats/go-multistream v0.0.4/go.mod h1:fJTiDfXJVmItycydCnNx4+wSzZ5NwG2FEVAI30fiovg=
 github.com/multiformats/go-multistream v0.1.0/go.mod h1:fJTiDfXJVmItycydCnNx4+wSzZ5NwG2FEVAI30fiovg=
@@ -1928,6 +1952,8 @@ github.com/raulk/clock v1.1.0 h1:dpb29+UKMbLqiU/jqIJptgLR1nn23HLgMY0sTCDza5Y=
 github.com/raulk/clock v1.1.0/go.mod h1:3MpVxdZ/ODBQDxbN+kzshf5OSZwPjtMDx6BBXBmOeY0=
 github.com/raulk/go-watchdog v1.2.0 h1:konN75pw2BMmZ+AfuAm5rtFsWcJpKF3m02rKituuXNo=
 github.com/raulk/go-watchdog v1.2.0/go.mod h1:lzSbAl5sh4rtI8tYHU01BWIDzgzqaQLj6RcA1i4mlqI=
+github.com/raulk/go-watchdog v1.3.0 h1:oUmdlHxdkXRJlwfG0O9omj8ukerm8MEQavSiDTEtBsk=
+github.com/raulk/go-watchdog v1.3.0/go.mod h1:fIvOnLbF0b0ZwkB9YU4mOW9Did//4vPZtDqv66NfsMU=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0 h1:OdAsTTz6OkFY5QxjkYwrChwuRruF69c169dPK26NUlk=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
@@ -2037,6 +2063,7 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/goleveldb v1.0.0 h1:fBdIW9lB4Iz0n9khmH8w27SJ3QEJ7+IgjPEwGSZiFdE=
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
@@ -2190,6 +2217,8 @@ go.opentelemetry.io/otel v0.20.0/go.mod h1:Y3ugLH2oa81t5QO+Lty+zXf8zC9L26ax4Nzox
 go.opentelemetry.io/otel v1.2.0/go.mod h1:aT17Fk0Z1Nor9e0uisf98LrntPGMnk4frBO9+dkf69I=
 go.opentelemetry.io/otel v1.3.0 h1:APxLf0eiBwLl+SOXiJJCVYzA1OOJNyAoV8C5RNRyy7Y=
 go.opentelemetry.io/otel v1.3.0/go.mod h1:PWIKzi6JCp7sM0k9yZ43VX+T345uNbAkDKwHVjb2PTs=
+go.opentelemetry.io/otel v1.7.0 h1:Z2lA3Tdch0iDcrhJXDIlC94XE+bxok1F9B+4Lz/lGsM=
+go.opentelemetry.io/otel v1.7.0/go.mod h1:5BdUoMIz5WEs0vt0CUEMtSSaTSHBBVwrhnz7+nrD5xk=
 go.opentelemetry.io/otel/bridge/opencensus v0.25.0/go.mod h1:dkZDdaNwLlIutxK2Kc2m3jwW2M1ISaNf8/rOYVwuVHs=
 go.opentelemetry.io/otel/exporters/jaeger v1.2.0/go.mod h1:KJLFbEMKTNPIfOxcg/WikIozEoKcPgJRz3Ce1vLlM8E=
 go.opentelemetry.io/otel/internal/metric v0.25.0/go.mod h1:Nhuw26QSX7d6n4duoqAFi5KOQR4AuzyMcl5eXOgwxtc=
@@ -2205,6 +2234,8 @@ go.opentelemetry.io/otel/trace v0.20.0/go.mod h1:6GjCW8zgDjwGHGa6GkyeB8+/5vjT16g
 go.opentelemetry.io/otel/trace v1.2.0/go.mod h1:N5FLswTubnxKxOJHM7XZC074qpeEdLy3CgAVsdMucK0=
 go.opentelemetry.io/otel/trace v1.3.0 h1:doy8Hzb1RJ+I3yFhtDmwNc7tIyw1tNMOIsyPzp1NOGY=
 go.opentelemetry.io/otel/trace v1.3.0/go.mod h1:c/VDhno8888bvQYmbYLqe41/Ldmr/KKunbvWM4/fEjk=
+go.opentelemetry.io/otel/trace v1.7.0 h1:O37Iogk1lEkMRXewVtZ1BBTVn5JEp8GrJvP92bJqC6o=
+go.opentelemetry.io/otel/trace v1.7.0/go.mod h1:fzLSB9nqR2eXzxPXb2JW9IKE+ScyXA48yyE4TNvoHqU=
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
@@ -2661,6 +2692,7 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20220411194840-2f41105eb62f h1:GGU+dLjvlC3qDwqYgL6UgRmHXhOOgns0bZu2Ty5mm6U=
 golang.org/x/xerrors v0.0.0-20220411194840-2f41105eb62f/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
 gonum.org/v1/gonum v0.0.0-20180816165407-929014505bf4/go.mod h1:Y+Yx5eoAFn32cQvJDxZx5Dpnq+c3wtXuadVZAcxbbBo=
 gonum.org/v1/gonum v0.8.2/go.mod h1:oe/vMfY3deqTw+1EZJhuvEW2iwGF1bW9wwu7XCu0+v0=
 gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0/go.mod h1:wa6Ws7BG/ESfp6dHfk7C6KdzKA7wR7u/rKwOGE66zvw=


### PR DESCRIPTION
# Goals

This is basically a "mashup" of booster-http, https://github.com/filecoin-project/boost/pull/377, and https://github.com/filecoin-project/dagstore/pull/116 to kick the tires and see how to wire everything up for an independent boost executable.

# Implementation

- Copy booster-http files
- Replace HTTPServer with bitswap server
- Migrate over the indexed blockstore from DAGStore PR and modify it to only use the available APIs
- Migrate over the piece selection function from  https://github.com/filecoin-project/boost/pull/377, modify to not use go-fil-markets

# TODO

- [ ] Tests, comments

# For discussion

Key issues identified:
- dagstore.AcquireShard is not available on the API (and I assume it won't be) so that means unless a CarV2 was stored, we're going to be indexing every time we pull a shard. Perhaps this moves up the priority of #573 or associated efforts to make indexes more easily accessible
- I couldn't figure out pricing without moving over a lot of go-fil-markets machinery around asks. We probably need to consider the API for figuring out of if a deal is free.