### PR TITLE
Transfer limiter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -99,6 +99,7 @@ require (
 	go.uber.org/atomic v1.9.0
 	go.uber.org/fx v1.15.0
 	go.uber.org/multierr v1.8.0
+	golang.org/x/exp v0.0.0-20210715201039-d37aa40e8013
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/tools v0.1.11
 	golang.org/x/xerrors v0.0.0-20220411194840-2f41105eb62f

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -97,7 +97,12 @@ func DefaultBoost() *Boost {
 			},
 
 			MaxTransferDuration: Duration(24 * 3600 * time.Second),
-			RemoteCommp:         false,
+
+			RemoteCommp: false,
+
+			HttpTransferMaxConcurrentDownloads: 20,
+			HttpTransferStallTimeout:           Duration(5 * time.Minute),
+			HttpTransferStallCheckPeriod:       Duration(30 * time.Second),
 		},
 
 		LotusDealmaking: lotus_config.DealmakingConfig{

--- a/node/config/doc_gen.go
+++ b/node/config/doc_gen.go
@@ -246,6 +246,27 @@ see https://docs.filecoin.io/mine/lotus/miner-configuration/#using-filters-for-f
 			Comment: `The public multi-address for retrieving deals with booster-http.
 Note: Must be in multiaddr format, eg /dns/foo.com/tcp/443/https`,
 		},
+		{
+			Name: "HttpTransferMaxConcurrentDownloads",
+			Type: "uint64",
+
+			Comment: `The maximum number of concurrent storage deal HTTP downloads.
+Note that this is a soft maximum; if some downloads stall,
+more downloads are allowed to start.`,
+		},
+		{
+			Name: "HttpTransferStallCheckPeriod",
+			Type: "Duration",
+
+			Comment: `The period between checking if downloads have stalled.`,
+		},
+		{
+			Name: "HttpTransferStallTimeout",
+			Type: "Duration",
+
+			Comment: `The time that can elapse before a download is considered stalled (and
+another concurrent download is allowed to start).`,
+		},
 	},
 	"FeeConfig": []DocField{
 		{

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -167,12 +167,23 @@ type DealmakingConfig struct {
 
 	// The maximum amount of time a transfer can take before it fails
 	MaxTransferDuration Duration
+
 	// Whether to do commp on the Boost node (local) or on the Sealer (remote)
 	RemoteCommp bool
 
 	// The public multi-address for retrieving deals with booster-http.
 	// Note: Must be in multiaddr format, eg /dns/foo.com/tcp/443/https
 	HTTPRetrievalMultiaddr string
+
+	// The maximum number of concurrent storage deal HTTP downloads.
+	// Note that this is a soft maximum; if some downloads stall,
+	// more downloads are allowed to start.
+	HttpTransferMaxConcurrentDownloads uint64
+	// The period between checking if downloads have stalled.
+	HttpTransferStallCheckPeriod Duration
+	// The time that can elapse before a download is considered stalled (and
+	// another concurrent download is allowed to start).
+	HttpTransferStallTimeout Duration
 }
 
 type FeeConfig struct {

--- a/node/modules/storageminer.go
+++ b/node/modules/storageminer.go
@@ -404,6 +404,11 @@ func NewStorageMarketProvider(provAddr address.Address, cfg *config.Boost) func(
 		prvCfg := storagemarket.Config{
 			MaxTransferDuration: time.Duration(cfg.Dealmaking.MaxTransferDuration),
 			RemoteCommp:         cfg.Dealmaking.RemoteCommp,
+			TransferLimiter: storagemarket.TransferLimiterConfig{
+				MaxConcurrent:    cfg.Dealmaking.HttpTransferMaxConcurrentDownloads,
+				StallCheckPeriod: time.Duration(cfg.Dealmaking.HttpTransferStallCheckPeriod),
+				StallTimeout:     time.Duration(cfg.Dealmaking.HttpTransferStallTimeout),
+			},
 		}
 		dl := logs.NewDealLogger(logsDB)
 		tspt := httptransport.New(h, dl)

--- a/storagemarket/provider.go
+++ b/storagemarket/provider.go
@@ -153,8 +153,7 @@ func NewProvider(cfg Config, sqldb *sql.DB, dealsDB *db.DealsDB, fundMgr *fundma
 		updateRetryStateChan: make(chan updateRetryStateReq),
 		storageSpaceChan:     make(chan storageSpaceDealReq),
 
-		Transport: tspt,
-		// TODO: make params configurable
+		Transport:      tspt,
 		xferLimiter:    xferLimiter,
 		fundManager:    fundMgr,
 		storageManager: storageMgr,
@@ -430,7 +429,7 @@ func (p *Provider) Start() error {
 	// Start sampling transfer data rate
 	go p.transfers.start(p.ctx)
 
-	// TODO: wait until all deals have been added to the transfer limiter
+	// Start the transfer limiter
 	go p.xferLimiter.run(p.ctx)
 
 	log.Infow("storage provider: started")

--- a/storagemarket/provider.go
+++ b/storagemarket/provider.go
@@ -54,7 +54,8 @@ type Config struct {
 	// The maximum amount of time a transfer can take before it fails
 	MaxTransferDuration time.Duration
 	// Whether to do commp on the Boost node (local) or the sealing node (remote)
-	RemoteCommp bool
+	RemoteCommp     bool
+	TransferLimiter TransferLimiterConfig
 }
 
 var log = logging.Logger("boost-provider")
@@ -91,6 +92,7 @@ type Provider struct {
 	logsDB    *db.LogsDB
 
 	Transport      transport.Transport
+	xferLimiter    *transferLimiter
 	fundManager    *fundmanager.FundManager
 	storageManager *storagemanager.StorageManager
 	dealPublisher  types.DealPublisher
@@ -122,6 +124,11 @@ func NewProvider(cfg Config, sqldb *sql.DB, dealsDB *db.DealsDB, fundMgr *fundma
 	dagst stores.DAGStoreWrapper, ps piecestore.PieceStore, ip types.IndexProvider, askGetter types.AskGetter,
 	sigVerifier types.SignatureVerifier, dl *logs.DealLogger, tspt transport.Transport) (*Provider, error) {
 
+	xferLimiter, err := newTransferLimiter(cfg.TransferLimiter)
+	if err != nil {
+		return nil, err
+	}
+
 	newDealPS, err := newDealPubsub()
 	if err != nil {
 		return nil, err
@@ -146,7 +153,9 @@ func NewProvider(cfg Config, sqldb *sql.DB, dealsDB *db.DealsDB, fundMgr *fundma
 		updateRetryStateChan: make(chan updateRetryStateReq),
 		storageSpaceChan:     make(chan storageSpaceDealReq),
 
-		Transport:      tspt,
+		Transport: tspt,
+		// TODO: make params configurable
+		xferLimiter:    xferLimiter,
 		fundManager:    fundMgr,
 		storageManager: storageMgr,
 
@@ -420,6 +429,9 @@ func (p *Provider) Start() error {
 
 	// Start sampling transfer data rate
 	go p.transfers.start(p.ctx)
+
+	// TODO: wait until all deals have been added to the transfer limiter
+	go p.xferLimiter.run(p.ctx)
 
 	log.Infow("storage provider: started")
 	return nil

--- a/storagemarket/provider_test.go
+++ b/storagemarket/provider_test.go
@@ -1356,7 +1356,15 @@ func NewHarness(t *testing.T, opts ...harnessOpt) *ProviderHarness {
 	askStore := &mockAskStore{}
 	askStore.SetAsk(pc.price, pc.verifiedPrice, pc.minPieceSize, pc.maxPieceSize)
 
-	prvCfg := Config{MaxTransferDuration: time.Hour, RemoteCommp: !pc.localCommp}
+	prvCfg := Config{
+		MaxTransferDuration: time.Hour,
+		RemoteCommp:         !pc.localCommp,
+		TransferLimiter: TransferLimiterConfig{
+			MaxConcurrent:    10,
+			StallCheckPeriod: time.Millisecond,
+			StallTimeout:     time.Hour,
+		},
+	}
 	prov, err := NewProvider(prvCfg, sqldb, dealsDB, fm, sm, fn, minerStub, minerAddr, minerStub, minerStub, sps, minerStub, df, sqldb,
 		logsDB, dagStore, ps, &NoOpIndexProvider{}, askStore, &mockSignatureVerifier{true, nil}, dl, tspt)
 	require.NoError(t, err)

--- a/storagemarket/provider_test.go
+++ b/storagemarket/provider_test.go
@@ -1619,6 +1619,10 @@ func (ph *ProviderHarness) newDealBuilder(t *testing.T, seed int, opts ...dealPr
 	require.NoError(tbuilder.t, err)
 	name := carv2Fileinfo.Name()
 
+	req := tspttypes.HttpRequest{URL: "http://foo.bar"}
+	xferParams, err := json.Marshal(req)
+	require.NoError(t, err)
+
 	// assemble the final deal params to send to the provider
 	dealParams := &types.DealParams{
 		DealUUID:  uuid.New(),
@@ -1632,8 +1636,9 @@ func (ph *ProviderHarness) newDealBuilder(t *testing.T, seed int, opts ...dealPr
 		},
 		DealDataRoot: rootCid,
 		Transfer: types.Transfer{
-			Type: "http",
-			Size: uint64(carv2Fileinfo.Size()),
+			Type:   "http",
+			Params: xferParams,
+			Size:   uint64(carv2Fileinfo.Size()),
 		},
 	}
 

--- a/storagemarket/transfer_limiter.go
+++ b/storagemarket/transfer_limiter.go
@@ -1,0 +1,225 @@
+package storagemarket
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+
+	smtypes "github.com/filecoin-project/boost/storagemarket/types"
+	"github.com/google/uuid"
+	"github.com/libp2p/go-libp2p-core/peer"
+)
+
+type transfer struct {
+	started   chan struct{}
+	deal      *smtypes.ProviderDealState
+	updatedAt time.Time
+	bytes     uint64
+}
+
+func (t *transfer) isStarted() bool {
+	select {
+	case <-t.started:
+		return true
+	default:
+		return false
+	}
+}
+
+type TransferLimiterConfig struct {
+	// The maximum number of concurrent transfers (soft limit - see comment below)
+	MaxConcurrent uint64
+	// The period between checking if a connection has stalled
+	StallCheckPeriod time.Duration
+	// If no data is sent within the stall timeout the connection is assumed to have stalled
+	StallTimeout time.Duration
+}
+
+//
+// transferLimiter maintains a queue of transfers with a soft upper limit on
+// the number of concurrent transfers.
+//
+// To prevent slow or stalled transfers from blocking up the queue there are
+// a couple of mitigations:
+//
+// The queue is ordered such that we
+// - start transferring data for the oldest deal first
+// - prefer to start transfers with peers that don't have any ongoing transfer
+//
+// For example, if there is
+// - one active transfer with peer A
+// - one pending transfer (peer A)
+// - one pending transfer (peer B)
+// the algorithm will prefer to start a transfer with peer B than peer A.
+//
+// This helps to ensure that slow peers don't block the transfer queue.
+//
+// The limit on the number of concurrent transfers is soft:
+// eg if there is a limit of 5 concurrent transfers and there are
+// - three active transfers
+// - two stalled transfers
+// then two more transfers are permitted to start.
+//
+type transferLimiter struct {
+	cfg TransferLimiterConfig
+
+	lk    sync.RWMutex
+	xfers map[uuid.UUID]*transfer
+}
+
+func newTransferLimiter(cfg TransferLimiterConfig) (*transferLimiter, error) {
+	if cfg.MaxConcurrent == 0 {
+		return nil, fmt.Errorf("maximum active concurrent transfers must be > 0")
+	}
+	if cfg.StallCheckPeriod == 0 {
+		return nil, fmt.Errorf("transfer stall check period must be > 0")
+	}
+	if cfg.StallTimeout == 0 {
+		return nil, fmt.Errorf("transfer stall timeout must be > 0")
+	}
+
+	return &transferLimiter{
+		cfg:   cfg,
+		xfers: make(map[uuid.UUID]*transfer),
+	}, nil
+}
+
+func (tl *transferLimiter) run(ctx context.Context) {
+	// Periodically check for stalled transfers
+	ticker := time.NewTicker(tl.cfg.StallCheckPeriod)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case t := <-ticker.C:
+			tl.check(t)
+
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (tl *transferLimiter) check(now time.Time) {
+	tl.lk.Lock()
+	defer tl.lk.Unlock()
+
+	// Count how many transfers are active (not stalled)
+	var activeCount uint64
+	transferringPeers := make(map[peer.ID]struct{}, len(tl.xfers))
+	unstartedXfers := make([]*transfer, 0, len(tl.xfers))
+	for _, xfer := range tl.xfers {
+		if !xfer.isStarted() {
+			// Build a list of unstarted transfers (needed later)
+			unstartedXfers = append(unstartedXfers, xfer)
+
+			// Skip transfers that haven't started
+			continue
+		}
+
+		// Build the set of peers that have an ongoing transfer (needed later)
+		transferringPeers[xfer.deal.ClientPeerID] = struct{}{}
+
+		// Check each transfer to see if it has stalled
+		if now.Sub(xfer.updatedAt) < tl.cfg.StallTimeout {
+			activeCount++
+		}
+	}
+
+	// Check if there are already enough active transfers
+	if activeCount >= tl.cfg.MaxConcurrent {
+		return
+	}
+
+	// Sort unstarted transfers by creation date (oldest first)
+	sort.Slice(unstartedXfers, func(i, j int) bool {
+		return unstartedXfers[i].deal.CreatedAt.Before(unstartedXfers[j].deal.CreatedAt)
+	})
+
+	// Gets the next transfer that should be started
+	nextTransfer := func() *transfer {
+		var next *transfer
+		// Iterate over transfers from oldest to newest
+		for _, xfer := range unstartedXfers {
+			// Skip transfers that have already been started
+			if xfer.isStarted() {
+				continue
+			}
+
+			// Default to choosing the oldest unstarted transfer
+			if next == nil {
+				next = xfer
+			}
+
+			// If there are no transfers with the peer that sent the storage deal,
+			// start a transfer.
+			// This helps ensure that a slow peer doesn't block up the transfer
+			// queue.
+			if _, ok := transferringPeers[xfer.deal.ClientPeerID]; !ok {
+				return xfer
+			}
+		}
+
+		return next
+	}
+
+	// Start new transfers until we reach the limit
+	for i := activeCount; i < tl.cfg.MaxConcurrent; i++ {
+		next := nextTransfer()
+		if next == nil {
+			return
+		}
+
+		// Update the list of peers with active transfers
+		transferringPeers[next.deal.ClientPeerID] = struct{}{}
+
+		// Signal that the transfer has started
+		next.updatedAt = time.Now()
+		close(next.started)
+	}
+}
+
+// Wait for the next open spot in the transfer queue
+func (tl *transferLimiter) waitInQueue(ctx context.Context, deal *smtypes.ProviderDealState) error {
+	xfer := &transfer{
+		deal:    deal,
+		started: make(chan struct{}),
+	}
+
+	// Add the transfer to the queue
+	tl.lk.Lock()
+	tl.xfers[deal.DealUuid] = xfer
+	tl.lk.Unlock()
+
+	// Wait for the signal that the transfer can start
+	select {
+	case <-xfer.started:
+		return nil
+	case <-ctx.Done():
+		tl.complete(deal.DealUuid)
+		return ctx.Err()
+	}
+}
+
+// Called when a transfer has completed (or errored out)
+func (tl *transferLimiter) complete(dealUuid uuid.UUID) {
+	tl.lk.Lock()
+	defer tl.lk.Unlock()
+
+	delete(tl.xfers, dealUuid)
+}
+
+// Called each time the transfer progresses
+func (tl *transferLimiter) setBytes(dealUuid uuid.UUID, bytes uint64) {
+	// TODO: avoid locking contention with the check function
+	tl.lk.Lock()
+	defer tl.lk.Unlock()
+
+	xfer, ok := tl.xfers[dealUuid]
+	if ok {
+		xfer.updatedAt = time.Now()
+		xfer.bytes = bytes
+	}
+}

--- a/storagemarket/transfer_limiter.go
+++ b/storagemarket/transfer_limiter.go
@@ -227,6 +227,9 @@ func (tl *transferLimiter) startedCount(xfers map[uuid.UUID]*transfer) uint64 {
 
 // Count how many transfers there are in total
 func (tl *transferLimiter) transfersCount() int {
+	tl.lk.RLock()
+	defer tl.lk.RUnlock()
+
 	return len(tl.xfers)
 }
 

--- a/storagemarket/transfer_limiter_test.go
+++ b/storagemarket/transfer_limiter_test.go
@@ -1,0 +1,267 @@
+package storagemarket
+
+import (
+	"context"
+	smtypes "github.com/filecoin-project/boost/storagemarket/types"
+	"github.com/filecoin-project/boost/testutil"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+func generateDeal() *smtypes.ProviderDealState {
+	return &smtypes.ProviderDealState{
+		DealUuid:     uuid.New(),
+		CreatedAt:    time.Now(),
+		ClientPeerID: testutil.GeneratePeer(),
+	}
+}
+
+func TestTransferLimiterBasic(t *testing.T) {
+	// Set up the transfer limiter
+	ctx := context.Background()
+	tl, err := newTransferLimiter(TransferLimiterConfig{
+		MaxConcurrent:    1,
+		StallCheckPeriod: time.Millisecond,
+		StallTimeout:     30 * time.Second,
+	})
+	require.NoError(t, err)
+
+	go tl.run(ctx)
+
+	// Add a deal to the transfer queue
+	deal1 := generateDeal()
+	err = tl.waitInQueue(ctx, deal1)
+	require.NoError(t, err)
+
+	// Remove the deal from the transfer queue
+	tl.complete(deal1.DealUuid)
+}
+
+func TestTransferLimiterQueueSize(t *testing.T) {
+	ctx := context.Background()
+	tl, err := newTransferLimiter(TransferLimiterConfig{
+		MaxConcurrent:    1,
+		StallCheckPeriod: time.Millisecond,
+		StallTimeout:     30 * time.Second,
+	})
+	require.NoError(t, err)
+
+	// Generate two deals and add them to the transfer queue
+	deal1 := generateDeal()
+	deal2 := generateDeal()
+
+	started := make(chan struct{}, 2)
+	go func() {
+		err := tl.waitInQueue(ctx, deal1)
+		require.NoError(t, err)
+		started <- struct{}{}
+	}()
+
+	go func() {
+		err := tl.waitInQueue(ctx, deal2)
+		require.NoError(t, err)
+		started <- struct{}{}
+	}()
+
+	// Wait a little while to make sure the go routines have had a
+	// chance to start
+	time.Sleep(100 * time.Millisecond)
+
+	// Expect the first transfer to start
+	tl.check(time.Now())
+	<-started
+
+	// Expect the second transfer not to start yet, because the transfer queue
+	// has a limit of 1
+	select {
+	case <-started:
+		require.Fail(t, "expected second transfer not to start yet")
+	default:
+	}
+
+	// Complete the first transfer
+	tl.complete(deal1.DealUuid)
+
+	// Expect the second transfer to start now that the first has completed
+	tl.check(time.Now())
+	<-started
+}
+
+func TestTransferLimiterStalledTransfer(t *testing.T) {
+	ctx := context.Background()
+	cfg := TransferLimiterConfig{
+		MaxConcurrent:    1,
+		StallCheckPeriod: time.Millisecond,
+		StallTimeout:     time.Second,
+	}
+	tl, err := newTransferLimiter(cfg)
+	require.NoError(t, err)
+
+	// Generate two deals and add them to the transfer queue
+	deal1 := generateDeal()
+	deal2 := generateDeal()
+
+	started := make(chan struct{}, 2)
+	go func() {
+		err := tl.waitInQueue(ctx, deal1)
+		require.NoError(t, err)
+		started <- struct{}{}
+	}()
+
+	go func() {
+		err := tl.waitInQueue(ctx, deal2)
+		require.NoError(t, err)
+		started <- struct{}{}
+	}()
+
+	// Wait a little while to make sure the go routines have had a
+	// chance to start
+	time.Sleep(100 * time.Millisecond)
+
+	// Expect the first transfer to start
+	tl.check(time.Now())
+	<-started
+
+	// Expect the second transfer not to start yet, because the transfer queue
+	// has a limit of 1
+	select {
+	case <-started:
+		require.Fail(t, "expected second transfer not to start yet")
+	default:
+	}
+
+	// Tell the transfer limiter that some progress has been made in the
+	// transfer for deal 1
+	tl.setBytes(deal1.DealUuid, 1)
+
+	// Simulate a check after half of the stall timeout has elapsed
+	tl.check(time.Now().Add(cfg.StallTimeout / 2))
+
+	// Expect the second transfer not to start yet, because the stall timeout
+	// has not expired
+	select {
+	case <-started:
+		require.Fail(t, "expected second transfer not to start yet")
+	default:
+	}
+
+	// Once the stall duration has elapsed with no updates to the first
+	// transfer, expect the second transfer to be allowed to start
+	tl.check(time.Now().Add(cfg.StallTimeout))
+	<-started
+}
+
+func TestTransferLimiterPriorityOldestFirst(t *testing.T) {
+	ctx := context.Background()
+	cfg := TransferLimiterConfig{
+		MaxConcurrent:    1,
+		StallCheckPeriod: time.Millisecond,
+		StallTimeout:     30 * time.Second,
+	}
+	tl, err := newTransferLimiter(cfg)
+	require.NoError(t, err)
+
+	// Generate deals and add them to the transfer queue in the reverse order
+	// than they were generated
+	dealCount := 100
+	deals := make([]*smtypes.ProviderDealState, 0, dealCount)
+	for i := 0; i < dealCount; i++ {
+		deals = append(deals, generateDeal())
+	}
+	dealsReversed := make(chan *smtypes.ProviderDealState, dealCount)
+	for i := len(deals) - 1; i >= 0; i-- {
+		dealsReversed <- deals[i]
+	}
+
+	started := make(chan *smtypes.ProviderDealState, 3)
+	for i := 0; i < len(deals); i++ {
+		// The order in which the go routines run is non-deterministic,
+		// but by adding deals in newest-to-oldest order, we can assume that
+		// it's extremely unlikely the deals will be started in
+		// oldest-to-newest order
+		go func() {
+			dl := <-dealsReversed
+			err := tl.waitInQueue(ctx, dl)
+			require.NoError(t, err)
+			started <- dl
+		}()
+	}
+
+	// Wait for all the deals to be added to the transfer queue
+	require.Eventually(t, func() bool {
+		return len(dealsReversed) == 0
+	}, time.Second, time.Millisecond)
+
+	// Start processing transfers
+	go tl.run(ctx)
+
+	// Expect the deals to be started in order from oldest to newest
+	for i := 0; i < len(deals); i++ {
+		dl := <-started
+		require.Equal(t, deals[i].DealUuid, dl.DealUuid)
+
+		// Make space in the queue for the next deal to be started
+		tl.complete(dl.DealUuid)
+	}
+}
+
+func TestTransferLimiterPriorityNoPeerFirst(t *testing.T) {
+	ctx := context.Background()
+	cfg := TransferLimiterConfig{
+		MaxConcurrent:    2,
+		StallCheckPeriod: time.Millisecond,
+		StallTimeout:     30 * time.Second,
+	}
+	tl, err := newTransferLimiter(cfg)
+	require.NoError(t, err)
+
+	// Generate three deals, where the first two have the same peer
+	p := testutil.GeneratePeer()
+	deal1 := generateDeal()
+	deal1.ClientPeerID = p
+	deal2 := generateDeal()
+	deal2.ClientPeerID = p
+	deal3 := generateDeal()
+
+	deals := make(chan *smtypes.ProviderDealState, 3)
+	deals <- deal1
+	deals <- deal2
+	deals <- deal3
+
+	started := make(chan *smtypes.ProviderDealState, len(deals))
+	for i := 0; i < 3; i++ {
+		go func() {
+			dl := <-deals
+			err := tl.waitInQueue(ctx, dl)
+			require.NoError(t, err)
+			started <- dl
+		}()
+	}
+
+	// Wait for all the deals to be added to the transfer queue
+	require.Eventually(t, func() bool {
+		return len(deals) == 0
+	}, time.Second, time.Millisecond)
+
+	// The queue size limit is 2.
+	// The oldest to newest order is deal1, deal2, deal3
+	// However we expect deal1 and deal3 to be started first.
+	// This is because deal1 and deal2 have the same peer ID, and
+	// the algorithm should favour deal3 because it has a different
+	// peer ID.
+	tl.check(time.Now())
+	dl := <-started
+	require.True(t, dl.DealUuid == deal1.DealUuid || dl.DealUuid == deal3.DealUuid)
+	dl = <-started
+	require.True(t, dl.DealUuid == deal1.DealUuid || dl.DealUuid == deal3.DealUuid)
+
+	// Complete the first deal transfer to make space for another transfer
+	tl.complete(deal1.DealUuid)
+
+	// Expect deal2 to start last
+	tl.check(time.Now())
+	dl = <-started
+	require.Equal(t, deal2.DealUuid, dl.DealUuid)
+}

--- a/storagemarket/types/types.go
+++ b/storagemarket/types/types.go
@@ -2,12 +2,18 @@ package types
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"io"
+	"net/url"
 
 	"github.com/filecoin-project/boost/sealingpipeline"
+	"github.com/filecoin-project/boost/transport/httptransport/util"
+	"github.com/filecoin-project/boost/transport/types"
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-fil-markets/shared"
 	"github.com/filecoin-project/go-fil-markets/storagemarket"
+	multiaddrutil "github.com/filecoin-project/go-legs/httpsync/multiaddr"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/builtin/v8/market"
 	"github.com/filecoin-project/go-state-types/crypto"
@@ -95,6 +101,42 @@ type Transfer struct {
 	Params []byte
 	// The size of the data transferred in bytes
 	Size uint64
+}
+
+func (t *Transfer) Host() (string, error) {
+	if t.Type != "http" && t.Type != "libp2p" {
+		return "", fmt.Errorf("cannot parse params for unrecognized transfer type '%s'", t.Type)
+	}
+
+	// de-serialize transport opaque token
+	tInfo := &types.HttpRequest{}
+	if err := json.Unmarshal(t.Params, tInfo); err != nil {
+		return "", fmt.Errorf("failed to de-serialize transport params bytes '%s': %w", string(t.Params), err)
+	}
+
+	// Parse http / multiaddr url
+	u, err := util.ParseUrl(tInfo.URL)
+	if err != nil {
+		return "", fmt.Errorf("cannot parse url '%s': %w", tInfo.URL, err)
+	}
+
+	// If the url is in libp2p format
+	if u.Scheme == util.Libp2pScheme {
+		// Get the host from the multiaddr
+		mahttp, err := multiaddrutil.ToURL(u.Multiaddr)
+		if err != nil {
+			return "", err
+		}
+		return mahttp.Host, nil
+	}
+
+	// Otherwise parse as an http url
+	httpUrl, err := url.Parse(u.Url)
+	if err != nil {
+		return "", fmt.Errorf("cannot parse url '%s' from '%s': %w", u.Url, tInfo.URL, err)
+	}
+
+	return httpUrl.Host, nil
 }
 
 type DealResponse struct {

--- a/storagemarket/types/types_test.go
+++ b/storagemarket/types/types_test.go
@@ -1,0 +1,49 @@
+package types
+
+import (
+	"encoding/json"
+	"github.com/filecoin-project/boost/transport/types"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestTransferHost(t *testing.T) {
+	testCases := []struct {
+		name     string
+		xferType string
+		url      string
+		expected string
+	}{{
+		name:     "http",
+		xferType: "http",
+		url:      "http://foo.bar:1234",
+		expected: "foo.bar:1234",
+	}, {
+		name:     "libp2p http",
+		xferType: "libp2p",
+		url:      "libp2p:///ip4/1.2.3.4/tcp/5678/p2p/Qma9T5YraSnpRDZqRR4krcSJabThc8nwZuJV3LercPHufi",
+		expected: "1.2.3.4:5678",
+	}, {
+		name:     "libp2p quic",
+		xferType: "libp2p",
+		url:      "libp2p:///ip4/1.2.3.4/udp/5678/quic/p2p/Qma9T5YraSnpRDZqRR4krcSJabThc8nwZuJV3LercPHufi",
+		expected: "1.2.3.4:5678",
+	}}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := types.HttpRequest{URL: tc.url}
+			res, err := json.Marshal(req)
+			require.NoError(t, err)
+
+			xfer := Transfer{
+				Type:   tc.xferType,
+				Params: res,
+			}
+			h, err := xfer.Host()
+			require.NoError(t, err)
+
+			require.Equal(t, tc.expected, h)
+		})
+	}
+}

--- a/transport/httptransport/util/util.go
+++ b/transport/httptransport/util/util.go
@@ -1,4 +1,4 @@
-package httptransport
+package util
 
 import (
 	"fmt"
@@ -9,19 +9,16 @@ import (
 	"github.com/multiformats/go-multiaddr"
 )
 
-type httpError struct {
-	error
-	code int
+const Libp2pScheme = "libp2p"
+
+type TransportUrl struct {
+	Scheme    string
+	Url       string
+	PeerID    peer.ID
+	Multiaddr multiaddr.Multiaddr
 }
 
-type transportUrl struct {
-	scheme    string
-	url       string
-	peerID    peer.ID
-	multiaddr multiaddr.Multiaddr
-}
-
-func parseUrl(urlStr string) (*transportUrl, error) {
+func ParseUrl(urlStr string) (*TransportUrl, error) {
 	u, err := url.Parse(urlStr)
 	if err != nil {
 		return nil, fmt.Errorf("parsing url '%s': %w", urlStr, err)
@@ -29,15 +26,15 @@ func parseUrl(urlStr string) (*transportUrl, error) {
 	if u.Scheme == "" {
 		return nil, fmt.Errorf("parsing url '%s': could not parse scheme", urlStr)
 	}
-	if u.Scheme == libp2pScheme {
+	if u.Scheme == Libp2pScheme {
 		return parseLibp2pUrl(urlStr)
 	}
-	return &transportUrl{scheme: u.Scheme, url: urlStr}, nil
+	return &TransportUrl{Scheme: u.Scheme, Url: urlStr}, nil
 }
 
-func parseLibp2pUrl(urlStr string) (*transportUrl, error) {
+func parseLibp2pUrl(urlStr string) (*TransportUrl, error) {
 	// Remove libp2p prefix
-	prefix := libp2pScheme + "://"
+	prefix := Libp2pScheme + "://"
 	if !strings.HasPrefix(urlStr, prefix) {
 		return nil, fmt.Errorf("libp2p URL '%s' must start with prefix '%s'", urlStr, prefix)
 	}
@@ -53,10 +50,10 @@ func parseLibp2pUrl(urlStr string) (*transportUrl, error) {
 		return nil, fmt.Errorf("expected only one address in url '%s'", urlStr)
 	}
 
-	return &transportUrl{
-		scheme:    libp2pScheme,
-		url:       libp2pScheme + "://" + addrInfo.ID.String(),
-		peerID:    addrInfo.ID,
-		multiaddr: addrInfo.Addrs[0],
+	return &TransportUrl{
+		Scheme:    Libp2pScheme,
+		Url:       Libp2pScheme + "://" + addrInfo.ID.String(),
+		PeerID:    addrInfo.ID,
+		Multiaddr: addrInfo.Addrs[0],
 	}, nil
 }

--- a/transport/httptransport/util/util_test.go
+++ b/transport/httptransport/util/util_test.go
@@ -1,4 +1,4 @@
-package httptransport
+package util
 
 import (
 	"testing"
@@ -12,21 +12,21 @@ func TestParseUrl(t *testing.T) {
 	tests := []struct {
 		name        string
 		url         string
-		expect      *transportUrl
+		expect      *TransportUrl
 		expectError bool
 	}{{
 		name: "http url",
 		url:  "http://www.test.com/path",
-		expect: &transportUrl{
-			url:    "http://www.test.com/path",
-			scheme: "http",
+		expect: &TransportUrl{
+			Url:    "http://www.test.com/path",
+			Scheme: "http",
 		},
 	}, {
 		name: "https url",
 		url:  "https://www.test.com/path",
-		expect: &transportUrl{
-			url:    "https://www.test.com/path",
-			scheme: "https",
+		expect: &TransportUrl{
+			Url:    "https://www.test.com/path",
+			Scheme: "https",
 		},
 	}, {
 		name:        "bad url",
@@ -35,37 +35,47 @@ func TestParseUrl(t *testing.T) {
 	}, {
 		name: "ip4 libp2p url",
 		url:  "libp2p:///ip4/104.131.131.82/tcp/4001/ipfs/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ",
-		expect: &transportUrl{
-			scheme:    libp2pScheme,
-			url:       libp2pScheme + "://QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ",
-			peerID:    peerMustDecode(t, "QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ"),
-			multiaddr: multiAddrMustParse(t, "/ip4/104.131.131.82/tcp/4001"),
+		expect: &TransportUrl{
+			Scheme:    Libp2pScheme,
+			Url:       Libp2pScheme + "://QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ",
+			PeerID:    peerMustDecode(t, "QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ"),
+			Multiaddr: multiAddrMustParse(t, "/ip4/104.131.131.82/tcp/4001"),
 		},
 	}, {
 		name: "dns libp2p url",
 		url:  "libp2p:///dnsaddr/bootstrap.libp2p.io/ipfs/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb",
-		expect: &transportUrl{
-			scheme:    libp2pScheme,
-			url:       libp2pScheme + "://QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb",
-			peerID:    peerMustDecode(t, "QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb"),
-			multiaddr: multiAddrMustParse(t, "/dnsaddr/bootstrap.libp2p.io"),
+		expect: &TransportUrl{
+			Scheme:    Libp2pScheme,
+			Url:       Libp2pScheme + "://QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb",
+			PeerID:    peerMustDecode(t, "QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb"),
+			Multiaddr: multiAddrMustParse(t, "/dnsaddr/bootstrap.libp2p.io"),
+		},
+	}, {
+		name: "quic libp2p url",
+		url:  "libp2p:///ip4/1.2.3.4/udp/5678/quic/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb",
+		expect: &TransportUrl{
+			Scheme:    Libp2pScheme,
+			Url:       Libp2pScheme + "://QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb",
+			PeerID:    peerMustDecode(t, "QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb"),
+			Multiaddr: multiAddrMustParse(t, "/ip4/1.2.3.4/udp/5678/quic"),
 		},
 	}, {
 		name:        "libp2p url no peer ID",
 		url:         "libp2p:///ip4/104.131.131.82/tcp/4001",
 		expectError: true,
 	}}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := parseUrl(tt.url)
+			got, err := ParseUrl(tt.url)
 			if tt.expectError {
 				require.Error(t, err)
 				return
 			} else {
 				require.NoError(t, err)
 			}
-			if tt.expect.multiaddr != nil {
-				require.Equal(t, tt.expect.multiaddr.String(), got.multiaddr.String())
+			if tt.expect.Multiaddr != nil {
+				require.Equal(t, tt.expect.Multiaddr.String(), got.Multiaddr.String())
 			}
 			require.Equal(t, tt.expect, got)
 		})


### PR DESCRIPTION
Fixes https://github.com/filecoin-project/boost/issues/705

#### Problem summary

Currently boost starts a new download for every storage deal that it receives. If a client sends 1000 deals, boost will open 1000 concurrent connections. Because bandwidth is limited, these downloads will proceed very slowly. Meanwhile the sealing pipeline will sit idle until a transfer finishes.

#### Solution

The Storage Provider should be able to adjust a parameter to limit the number of parallel transfers, so that they can keep their sealing pipeline busy.

For simplicity this PR only uses a single config value: an overall "soft" limit on the number of transfers.
See the explanation at https://github.com/filecoin-project/boost/pull/710/files#diff-dafd8b081e95b0e754470a4a23253b2e4a08ba06390015ac77d0e9a59cbe3a5aR30-R54