### PR TITLE
run single commp calc at a time

### DIFF
--- a/storagemarket/provider.go
+++ b/storagemarket/provider.go
@@ -96,8 +96,11 @@ type Provider struct {
 	dealPublisher  types.DealPublisher
 	transfers      *dealTransfers
 
-	pieceAdder                  types.PieceAdder
-	commpCalc                   smtypes.CommpCalculator
+	pieceAdder types.PieceAdder
+
+	commpMu   sync.Mutex
+	commpCalc smtypes.CommpCalculator
+
 	maxDealCollateralMultiplier uint64
 	chainDealManager            types.ChainDealManager
 


### PR DESCRIPTION
This PR adds a mutex around commp calculation on localhost (when RemoteCommp is not enabled), so that we don't get OOM errors if multiple deals are downloaded around the same time.