### PR TITLE
Failure to retrieve when root payload CID is an identity CID

### DIFF
--- a/car/car_offset_writer_test.go
+++ b/car/car_offset_writer_test.go
@@ -244,6 +244,7 @@ func DAGImport(dserv format.DAGService, fi io.Reader) (format.Node, error) {
 		Maxlinks:  1024,
 		RawLeaves: true,
 
+		// NOTE: InlineBuilder not recommended, we are using this to test identity CIDs
 		CidBuilder: cidutil.InlineBuilder{
 			Builder: prefix,
 			Limit:   32,

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,12 @@ replace github.com/filecoin-project/go-jsonrpc => github.com/nonsense/go-jsonrpc
 
 // replace github.com/filecoin-project/lotus => ../lotus
 
+// replace github.com/filecoin-project/go-fil-markets => ../go-fil-markets
+
+// replace github.com/filecoin-project/dagstore => ../dagstore
+
+// replace github.com/ipld/go-car/v2 => ../../ipld/go-car/v2
+
 require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.0
 	github.com/BurntSushi/toml v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -8,12 +8,6 @@ replace github.com/filecoin-project/go-jsonrpc => github.com/nonsense/go-jsonrpc
 
 // replace github.com/filecoin-project/lotus => ../lotus
 
-// replace github.com/filecoin-project/go-fil-markets => ../go-fil-markets
-
-// replace github.com/filecoin-project/dagstore => ../dagstore
-
-// replace github.com/ipld/go-car/v2 => ../../ipld/go-car/v2
-
 require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.0
 	github.com/BurntSushi/toml v1.1.0

--- a/itests/dummydeal_offline_test.go
+++ b/itests/dummydeal_offline_test.go
@@ -34,7 +34,8 @@ func TestDummydealOffline(t *testing.T) {
 
 	// make an offline deal
 	offlineDealUuid := uuid.New()
-	res, err := f.MakeDummyDeal(offlineDealUuid, carFilepath, rootCid, "", true)
+	dealRes, err := f.MakeDummyDeal(offlineDealUuid, carFilepath, rootCid, "", true)
+	res := dealRes.Result
 	require.NoError(t, err)
 	require.True(t, res.Accepted)
 	res, err = f.Boost.BoostOfflineDealWithData(context.Background(), offlineDealUuid, carFilepath)

--- a/itests/dummydeal_test.go
+++ b/itests/dummydeal_test.go
@@ -56,7 +56,7 @@ func TestDummydealOnline(t *testing.T) {
 	// Make a deal
 	res, err := f.MakeDummyDeal(dealUuid, carFilepath, rootCid, server.URL+"/"+filepath.Base(carFilepath), false)
 	require.NoError(t, err)
-	require.True(t, res.Accepted)
+	require.True(t, res.Result.Accepted)
 	log.Debugw("got response from MarketDummyDeal", "res", spew.Sdump(res))
 
 	time.Sleep(2 * time.Second)
@@ -66,7 +66,7 @@ func TestDummydealOnline(t *testing.T) {
 	failingDealUuid := uuid.New()
 	res2, err2 := f.MakeDummyDeal(failingDealUuid, failingCarFilepath, failingRootCid, server.URL+"/"+filepath.Base(failingCarFilepath), false)
 	require.NoError(t, err2)
-	require.Contains(t, res2.Reason, "no space left", res2.Reason)
+	require.Contains(t, res2.Result.Reason, "no space left", res2.Result.Reason)
 	log.Debugw("got response from MarketDummyDeal for failing deal", "res2", spew.Sdump(res2))
 
 	// Wait for the first deal to be added to a sector and cleaned up so space is made
@@ -74,20 +74,17 @@ func TestDummydealOnline(t *testing.T) {
 	require.NoError(t, err)
 	time.Sleep(100 * time.Millisecond)
 
-	// *********************************************************************
-	// Disable this part of the test for now because there is a bug in lotus
-	// introduced in this PR that causes the test to fail:
-	// https://github.com/filecoin-project/lotus/pull/9174/files#top
-	// *********************************************************************
+	// Make a third deal - it should succeed because the first deal has been cleaned up
+	passingDealUuid := uuid.New()
+	res2, err2 = f.MakeDummyDeal(passingDealUuid, failingCarFilepath, failingRootCid, server.URL+"/"+filepath.Base(failingCarFilepath), false)
+	require.NoError(t, err2)
+	require.True(t, res2.Result.Accepted)
+	log.Debugw("got response from MarketDummyDeal", "res2", spew.Sdump(res2))
 
-	//// Make a third deal - it should succeed because the first deal has been cleaned up
-	//passingDealUuid := uuid.New()
-	//res2, err2 = f.MakeDummyDeal(passingDealUuid, failingCarFilepath, failingRootCid, server.URL+"/"+filepath.Base(failingCarFilepath), false)
-	//require.NoError(t, err2)
-	//require.True(t, res2.Accepted)
-	//log.Debugw("got response from MarketDummyDeal", "res2", spew.Sdump(res2))
-	//
-	//// Wait for the deal to be added to a sector
-	//err = f.WaitForDealAddedToSector(passingDealUuid)
-	//require.NoError(t, err)
+	// Wait for the deal to be added to a sector
+	err = f.WaitForDealAddedToSector(passingDealUuid)
+	require.NoError(t, err)
+
+	outCar := f.RetrieveDirect(ctx, t, rootCid, &res.DealParams.ClientDealProposal.Proposal.PieceCID, true)
+	kit.AssertFilesEqual(t, carFilepath, outCar)
 }

--- a/itests/dummydeal_test.go
+++ b/itests/dummydeal_test.go
@@ -39,6 +39,9 @@ func TestDummydealOnline(t *testing.T) {
 	failingFilepath, err := testutil.CreateRandomFile(tempdir, 5, 2000000)
 	require.NoError(t, err)
 
+	// NOTE: these calls to CreateDenseCARv2 have the identity CID builder enabled so will
+	// produce a root identity CID for this case. So we're testing deal-making and retrieval
+	// where a DAG has an identity CID root
 	rootCid, carFilepath, err := testutil.CreateDenseCARv2(tempdir, randomFilepath)
 	require.NoError(t, err)
 
@@ -85,6 +88,7 @@ func TestDummydealOnline(t *testing.T) {
 	err = f.WaitForDealAddedToSector(passingDealUuid)
 	require.NoError(t, err)
 
-	outCar := f.RetrieveDirect(ctx, t, rootCid, &res.DealParams.ClientDealProposal.Proposal.PieceCID, true)
-	kit.AssertFilesEqual(t, carFilepath, outCar)
+	// rootCid is an identity CID
+	outFile := f.RetrieveDirect(ctx, t, rootCid, &res.DealParams.ClientDealProposal.Proposal.PieceCID, true)
+	kit.AssertFilesEqual(t, randomFilepath, outFile)
 }

--- a/itests/framework/framework.go
+++ b/itests/framework/framework.go
@@ -59,7 +59,7 @@ import (
 	unixfile "github.com/ipfs/go-unixfs/file"
 	"github.com/ipld/go-car"
 	"github.com/libp2p/go-libp2p"
-	"github.com/libp2p/go-libp2p-core/host"
+	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/multiformats/go-multihash"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"

--- a/itests/framework/framework.go
+++ b/itests/framework/framework.go
@@ -59,12 +59,8 @@ import (
 	unixfile "github.com/ipfs/go-unixfs/file"
 	"github.com/ipld/go-car"
 	"github.com/libp2p/go-libp2p"
-<<<<<<< HEAD
-	"github.com/libp2p/go-libp2p/core/host"
-=======
 	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/multiformats/go-multihash"
->>>>>>> 108ee6c (fix: cleanup test & handle identity roots)
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 )

--- a/itests/framework/framework.go
+++ b/itests/framework/framework.go
@@ -48,6 +48,7 @@ import (
 	"github.com/filecoin-project/lotus/storage/paths"
 	"github.com/filecoin-project/lotus/storage/pipeline/sealiface"
 	"github.com/google/uuid"
+	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
 	files "github.com/ipfs/go-ipfs-files"
@@ -58,7 +59,12 @@ import (
 	unixfile "github.com/ipfs/go-unixfs/file"
 	"github.com/ipld/go-car"
 	"github.com/libp2p/go-libp2p"
+<<<<<<< HEAD
 	"github.com/libp2p/go-libp2p/core/host"
+=======
+	"github.com/libp2p/go-libp2p-core/host"
+	"github.com/multiformats/go-multihash"
+>>>>>>> 108ee6c (fix: cleanup test & handle identity roots)
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 )
@@ -684,8 +690,16 @@ func (f *TestFramework) ExtractFileFromCAR(ctx context.Context, t *testing.T, fi
 	ch, err := car.LoadCar(ctx, bserv.Blockstore(), file)
 	require.NoError(t, err)
 
-	b, err := bserv.GetBlock(ctx, ch.Roots[0])
-	require.NoError(t, err)
+	var b blocks.Block
+	if ch.Roots[0].Prefix().MhType == multihash.IDENTITY {
+		mh, err := multihash.Decode(ch.Roots[0].Hash())
+		require.NoError(t, err)
+		b, err = blocks.NewBlockWithCid(mh.Digest, ch.Roots[0])
+		require.NoError(t, err)
+	} else {
+		b, err = bserv.GetBlock(ctx, ch.Roots[0])
+		require.NoError(t, err)
+	}
 
 	nd, err := ipld.Decode(b)
 	require.NoError(t, err)

--- a/testutil/car.go
+++ b/testutil/car.go
@@ -139,6 +139,7 @@ func WriteUnixfsDAGTo(path string, into ipldformat.DAGService) (cid.Cid, error) 
 	params := ihelper.DagBuilderParams{
 		Maxlinks:  unixfsLinksPerLevel,
 		RawLeaves: true,
+		// NOTE: InlineBuilder not recommended, we are using this to test identity CIDs
 		CidBuilder: cidutil.InlineBuilder{
 			Builder: prefix,
 			Limit:   126,

--- a/transport/httptransport/http_transport_test.go
+++ b/transport/httptransport/http_transport_test.go
@@ -509,6 +509,7 @@ func dagImport(dserv format.DAGService, fi io.Reader) (format.Node, error) {
 		Maxlinks:  1024,
 		RawLeaves: true,
 
+		// NOTE: InlineBuilder not recommended, we are using this to test identity CIDs
 		CidBuilder: cidutil.InlineBuilder{
 			Builder: prefix,
 			Limit:   32,


### PR DESCRIPTION
# What

Any CAR file with an identity CID as the root payload CID is unretrievable if written with CarV2.

When a file is imported via UnixFS, the default builders have a condition where any block less than 126 bytes becomes an identity CID. This is true for the [most common CAR generation utils used by Lotus & boostx](https://github.com/filecoin-project/lotus/tree/master/lib/unixfs). So this is likely applicable to real world pieces.

Car files written with CarV1 with identity CIDs may or may not be retrievable but as they are written back out with CarV2 writers they likely won't match commP if trying to do whole payload / piece retrieval over GraphSync.

# How

This PR is actually an issue with a test to demonstrate. This issue affacts the default integration tests, and you can demonstrate simply by adding a retrieval to the boost deal test. This produces an error of:
```
Retrieval query: getPieceInfoFromCid: getting pieces for cid bafyaa4asfyfcmalqudsaeiclsn2n56lmy7rolvh3hcmbb7lailbxpowb4quv6ggvqayqo7pj7mjaagejsbbrelqkeyaxbiheaiqp7e4gsn3ajlb533z2wp377int6fxiluov6il34itoaemeb5w5qeasaamk35b4bihaqaqyqcexuieaqbacbaejhi: getting pieces containing block bafyaa4asfyfcmalqudsaeiclsn2n56lmy7rolvh3hcmbb7lailbxpowb4quv6ggvqayqo7pj7mjaagejsbbrelqkeyaxbiheaiqp7e4gsn3ajlb533z2wp377int6fxiluov6il34itoaemeb5w5qeasaamk35b4bihaqaqyqcexuieaqbacbaejhi: failed to lookup index for mh 0070122e0a260170a0e402204b9374def96cc7e2e5d4fb389810fd6042c377bac1e4295f18d58031077de9fb120018899043122e0a260170a0e40220ff9386937604ac3ddef3ab3f7ffa1b3f16e85d1d5f217be226e011840f6dd810120018adf43c0a0e08021880897a208080402080893a, err: datastore: key not found
```
(probably will produce a different CID if you run it yourself)

You can then fix the test (or at least get it past the above issue) by removing the InlineBuilder in the test car file generator: https://github.com/filecoin-project/boost/blob/main/testutil/car.go#L142

Looking at the error, I believe the issue is that the identity CID is simply not present in the car index generated by the DAGStore, as it's not in the underlying CARv2. So when you ask "what information do you have on this CID?", it responds saying "I don't have any"