### PR TITLE
change network name for devnet

### DIFF
--- a/docker/devnet/docker-compose.yaml
+++ b/docker/devnet/docker-compose.yaml
@@ -7,6 +7,10 @@ x-logging:
     max-file: '3'
   driver: json-file
 
+networks:
+  default:
+    name: devnet
+
 services:
   lotus:
     container_name: lotus


### PR DESCRIPTION
This PR is changing the default network name of the devnet from `devnet_default` to `devnet`. The idea is that we'll have to connect other containers to it, i.e. `prometheus` and/or `tempo` and maybe others from the `monitoring` stack.

cc @airenas 