### PR TITLE
Add support for building Boost images from local source

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 docker/devnet/data
+react/node_modules

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,1 @@
-examples
+docker/devnet/data

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ dev.gen
 localnet.json
 lotus-daemon.log
 lotus-miner.log
+docker/devnet/data

--- a/docker/devnet/boost-gui/Dockerfile
+++ b/docker/devnet/boost-gui/Dockerfile
@@ -2,16 +2,14 @@
 #########################################################################################
 FROM node:16.16-alpine3.15 AS builder
 
-RUN apk --no-cache --update add git
-
 ARG BUILD_VERSION=0.1
-WORKDIR /src
-RUN git clone --depth 1 --branch v${BUILD_VERSION} https://github.com/filecoin-project/boost 
+WORKDIR /src/react
 
-WORKDIR /src/boost/react
+COPY react /src/react
+COPY gql /src/gql
 
 #TODO remove force after fixing npm dependencies 
-RUN npm install --force 
+RUN npm ci --force 
 
 RUN npm run build
 #####################################################################################
@@ -32,8 +30,8 @@ LABEL org.opencontainers.image.version=$BUILD_VERSION \
 EXPOSE 8000
 ENV BOOST_URL=http://boost:8080
 
-COPY --from=builder /src/boost/react/build usr/share/nginx/html
-COPY nginx.conf.in /app/nginx.conf.in
-COPY entrypoint.sh /app/entrypoint.sh
+COPY --from=builder /src/react/build usr/share/nginx/html
+COPY docker/devnet/boost-gui/nginx.conf.in /app/nginx.conf.in
+COPY docker/devnet/boost-gui/entrypoint.sh /app/entrypoint.sh
 
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/docker/devnet/boost-gui/Makefile
+++ b/docker/devnet/boost-gui/Makefile
@@ -1,11 +1,13 @@
 #####################################################################################
 service=$(docker_user)/boost-gui
 version=$(boost_version)
+docker_dir=docker/devnet/boost-gui
 ########### DOCKER ##################################################################
 tag=$(service):$(version)
 
 dbuild: 
-	docker build -t $(tag) --build-arg BUILD_VERSION=$(version) .
+	cd ../../../ && \
+		docker build -t $(tag) --build-arg BUILD_VERSION=$(version)  -f $(docker_dir)/Dockerfile .
 
 dpush: dbuild
 	docker push $(tag)

--- a/docker/devnet/boost/Dockerfile
+++ b/docker/devnet/boost/Dockerfile
@@ -1,4 +1,5 @@
 #########################################################################################
+## docker will invoke this file from ../../.. dir in order to access the code
 #########################################################################################
 ARG LOTUS_TEST_IMAGE=filecoin/lotus-test:latest
 FROM ${LOTUS_TEST_IMAGE} as lotus-dev
@@ -19,10 +20,9 @@ RUN apt update && apt install -y \
 
 WORKDIR /go/src/
 
-ARG BUILD_VERSION=0.1
-RUN git clone --depth 1 --branch v${BUILD_VERSION} https://github.com/filecoin-project/boost
+COPY . /go/src/
 
-RUN cd boost && make debug
+RUN make debug
 #########################################################################################
 FROM ubuntu:20.04 as runner
 
@@ -48,9 +48,9 @@ ENV BOOST_PATH /var/lib/boost
 VOLUME /var/lib/boost
 EXPOSE 8080  
 
-COPY --from=builder /go/src/boost/boostd /usr/local/bin/
-COPY --from=builder /go/src/boost/boost /usr/local/bin/
-COPY --from=builder /go/src/boost/boostx /usr/local/bin/
+COPY --from=builder /go/src/boostd /usr/local/bin/
+COPY --from=builder /go/src/boost /usr/local/bin/
+COPY --from=builder /go/src/boostx /usr/local/bin/
 COPY --from=lotus-dev /usr/local/bin/lotus /usr/local/bin/
 COPY --from=lotus-dev /usr/local/bin/lotus-miner /usr/local/bin/
 ## Fix missing lib libhwloc.so.5
@@ -58,7 +58,7 @@ RUN ls -1 /lib/x86_64-linux-gnu/libhwloc.so.* | head -n 1 | xargs -n1 -I {} ln -
 ## Smoke test for the boost and lotus
 RUN lotus -v && boost -v 
 
-COPY entrypoint.sh /app/
-COPY sample/* /app/sample/
+COPY docker/devnet/boost/entrypoint.sh /app/
+COPY docker/devnet/boost/sample/* /app/sample/
 
 ENTRYPOINT ["./entrypoint.sh"]

--- a/docker/devnet/boost/Makefile
+++ b/docker/devnet/boost/Makefile
@@ -1,12 +1,14 @@
 #####################################################################################
 service=$(docker_user)/boost-dev
 version=$(boost_version)
+docker_dir=docker/devnet/boost
 ########### DOCKER ##################################################################
 tag=$(service):$(version)
 
 dbuild: 
-	docker build --build-arg LOTUS_TEST_IMAGE=$(lotus_test_image)  --build-arg BUILD_VERSION=$(version) \
-		-t $(tag) .
+	cd ../../../ && \
+		docker build --build-arg LOTUS_TEST_IMAGE=$(lotus_test_image)  --build-arg BUILD_VERSION=$(version) \
+			-t $(tag) -f $(docker_dir)/Dockerfile .
 
 dpush: dbuild
 	docker push $(tag)


### PR DESCRIPTION
2 tasks for #742

**Implemented**:

- Add support for building Boost images from local source
- Change npm install to npm ci 

Now the build process uses local dir when creating `boost` and `boost-gui` docker images. 



