### PR TITLE
Throttle local commp

### DIFF
--- a/node/config/def.go
+++ b/node/config/def.go
@@ -95,7 +95,8 @@ func DefaultBoost() *Boost {
 
 			MaxTransferDuration: Duration(24 * 3600 * time.Second),
 
-			RemoteCommp: false,
+			RemoteCommp:             false,
+			MaxConcurrentLocalCommp: 1,
 
 			HttpTransferMaxConcurrentDownloads: 20,
 			HttpTransferStallTimeout:           Duration(5 * time.Minute),

--- a/node/config/doc_gen.go
+++ b/node/config/doc_gen.go
@@ -228,6 +228,13 @@ see https://docs.filecoin.io/mine/lotus/miner-configuration/#using-filters-for-f
 			Comment: `Whether to do commp on the Boost node (local) or on the Sealer (remote)`,
 		},
 		{
+			Name: "MaxConcurrentLocalCommp",
+			Type: "uint64",
+
+			Comment: `The maximum number of commp processes to run in parallel on the local
+boost process`,
+		},
+		{
 			Name: "HTTPRetrievalMultiaddr",
 			Type: "string",
 

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -166,6 +166,9 @@ type DealmakingConfig struct {
 
 	// Whether to do commp on the Boost node (local) or on the Sealer (remote)
 	RemoteCommp bool
+	// The maximum number of commp processes to run in parallel on the local
+	// boost process
+	MaxConcurrentLocalCommp uint64
 
 	// The public multi-address for retrieving deals with booster-http.
 	// Note: Must be in multiaddr format, eg /dns/foo.com/tcp/443/https

--- a/node/modules/storageminer.go
+++ b/node/modules/storageminer.go
@@ -402,8 +402,9 @@ func NewStorageMarketProvider(provAddr address.Address, cfg *config.Boost) func(
 		lp lotus_storagemarket.StorageProvider, cdm *storagemarket.ChainDealManager) (*storagemarket.Provider, error) {
 
 		prvCfg := storagemarket.Config{
-			MaxTransferDuration: time.Duration(cfg.Dealmaking.MaxTransferDuration),
-			RemoteCommp:         cfg.Dealmaking.RemoteCommp,
+			MaxTransferDuration:     time.Duration(cfg.Dealmaking.MaxTransferDuration),
+			RemoteCommp:             cfg.Dealmaking.RemoteCommp,
+			MaxConcurrentLocalCommp: cfg.Dealmaking.MaxConcurrentLocalCommp,
 			TransferLimiter: storagemarket.TransferLimiterConfig{
 				MaxConcurrent:    cfg.Dealmaking.HttpTransferMaxConcurrentDownloads,
 				StallCheckPeriod: time.Duration(cfg.Dealmaking.HttpTransferStallCheckPeriod),

--- a/storagemarket/transfer_limiter_test.go
+++ b/storagemarket/transfer_limiter_test.go
@@ -362,8 +362,7 @@ func TestTransferLimiterStalledTransferHardLimited(t *testing.T) {
 	deal3.ClientPeerID = deal1.ClientPeerID
 
 	go func() {
-		err := tl.waitInQueue(ctx, deal3)
-		require.NoError(t, err)
+		tl.waitInQueue(ctx, deal3) //nolint:errcheck
 		started <- struct{}{}
 	}()
 


### PR DESCRIPTION
Supersedes https://github.com/filecoin-project/boost/pull/714

Adds a config option to throttle the number of commp threads that can run in parallel in the boost process:
```
[Dealmaking]
  MaxConcurrentLocalCommp = 1
```