### PR TITLE
Add possibility to build lotus from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,18 +206,14 @@ Note also that the provider address is `t01000` and you will need to supply an a
 
 ### Building Docker images
 
-1. Select Lotus version, for example: `lotus_version=1.17.1-rc2`. It must be the tag name of [the Lotus git repo](https://github.com/filecoin-project/lotus/tags) without `v` prefix.
-
-2. Select Boost version, for example: `boost_version=1.3.0-rc1`.
-
-3. Build images
+1. Build images
 
 ```
 cd docker/devnet
 make build/all
 ```
 
-If you need to build a different version, edit the `.env` file.
+If you need to build containers using a specific version of lotus then provide the version as a parameter, e.g. `make build/all lotus_version=1.17.0`. The version must be a tag name of [Lotus git repo](https://github.com/filecoin-project/lotus/tags) without `v` prefix. Or you can build using a local source of lotus - `make build/all lotus_src_dir=<path of lotus source>`. Also, before starting devnet, you need to update versions in the [.env](docker/devnet/.env) file.
 
 ### Start devnet docker stack
 

--- a/docker/devnet/Makefile
+++ b/docker/devnet/Makefile
@@ -1,15 +1,32 @@
 ##################################################################################
+# building lotus
+#  - from source, provide "lotus_src_dir", e.g.: 
+#      make build/all lotus_src_dir=../../../lotus 
+#  - specific version (default) -> provide "lotus_version", e.g:
+#      make build/all lotus_versionr=1.17.0 
+##################################################################################
 lotus_version?=1.17.1-rc2
+lotus_src_dir=
 boost_version?=1.3.0-rc1
 docker_user?=filecoin
 
+ifeq ($(lotus_src_dir),)
+    lotus_src_dir=/tmp/lotus-$(lotus_version)
+    lotus_checkout_dir=$(lotus_src_dir)
+else
+    lotus_version=dev
+    lotus_checkout_dir=
+endif
 lotus_test_image=$(docker_user)/lotus-test:$(lotus_version)
 ##################################################################################
-lotus-$(lotus_version):
+info/lotus-test:
+	@echo Lotus dir = $(lotus_src_dir)
+	@echo Lotus ver = $(lotus_version)
+.PHONY: info/lotus-test	
+$(lotus_checkout_dir):
 	git clone --depth 1 --branch v$(lotus_version) https://github.com/filecoin-project/lotus $@
-
-prepare/lotus-test: | lotus-$(lotus_version)
-	cd lotus-$(lotus_version) && docker build -f Dockerfile.lotus --target lotus-test -t $(lotus_test_image) .
+prepare/lotus-test: info/lotus-test | $(lotus_checkout_dir)
+	cd $(lotus_src_dir) && docker build -f Dockerfile.lotus --target lotus-test -t $(lotus_test_image) .
 .PHONY: prepare/lotus-test
 ##################################################################################
 build/%: prepare/lotus-test
@@ -28,8 +45,9 @@ push/all: push/lotus push/lotus-miner push/boost push/boost-gui
 clean: clean/lotus-test
 .PHONY: clean
 
+# clean/lotus-test - removes temporary lotus dir at /tmp/lotus-$(lotus_version)
 clean/lotus-test:
-	rm -rf lotus-$(lotus_version)
+	rm -rf $(lotus_checkout_dir)
 .PHONY: clean/lotus-test
 
 .EXPORT_ALL_VARIABLES:


### PR DESCRIPTION
**Implement tasks for #742**:
- Add support for building Lotus / Lotus-miner images from local source
- Use temp directories, when checking out Lotus to build images, rather than local paths.

**Now**:
- to build using lotus source `make build/all lotus_src_dir=../../../lotus`
- to build using specific version -> `make build/all lotus_versionr=1.17.0` 