### PR TITLE
Docker boost speedup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,10 @@
-examples
+docker/devnet/data
+react/node_modules
+# filecoin-ffi installation
+build/.filecoin-install
+extern/filecoin-ffi/.install-filcrypto
+extern/filecoin-ffi/filcrypto.*
+extern/filecoin-ffi/libfilcrypto.a
+# local binaries
+boost*
+devnet

--- a/docker/devnet/Makefile
+++ b/docker/devnet/Makefile
@@ -14,7 +14,9 @@ prepare/lotus-test: | lotus-$(lotus_version)
 ##################################################################################
 build/%: prepare/lotus-test
 	cd $* && make dbuild
-build/boost:
+../../build/.update-modules: 
+	cd ../../ && make build/.update-modules	
+build/boost: ../../build/.update-modules prepare/lotus-test
 	cd boost && make dbuild
 push/%: prepare/lotus-test
 	cd $* && make dpush	

--- a/docker/devnet/boost/Dockerfile.source
+++ b/docker/devnet/boost/Dockerfile.source
@@ -20,10 +20,30 @@ RUN apt update && apt install -y \
 
 WORKDIR /go/src/
 
-# copy src
-COPY . /go/src/
+COPY Makefile /go/src/
+##############################################
+# prebuild filecoin-ffi
+COPY extern /go/src/extern
+COPY build /go/src/build
+COPY .git/modules/extern/filecoin-ffi /go/src/.git/modules/extern/filecoin-ffi
 
-RUN make debug
+RUN make build/.filecoin-install
+##############################################
+# download go dependencies
+COPY go.mod go.sum /go/src/
+RUN go mod download
+##############################################
+##############################################
+#COPY . /go/src
+
+# we need to copy all source except build/ and extern/
+# docker does not allow to do it easy, we can write docker COPY for each dir, 
+# but there are a lot of dirs and may be added new ones
+COPY . /tmp/src
+RUN rm -rf /tmp/src/build /tmp/src/extern /tmp/src/docker /tmp/src/boost*
+RUN cp -r /tmp/src/* /tmp/src/.git /go/src/ 
+##############################################
+RUN --mount=type=cache,target=/root/.cache/go-build make debug
 #########################################################################################
 FROM ubuntu:20.04 as runner
 
@@ -49,13 +69,15 @@ ENV BOOST_PATH /var/lib/boost
 VOLUME /var/lib/boost
 EXPOSE 8080  
 
+## Fix missing lib libhwloc.so.5
+RUN ls -1 /lib/*/libhwloc.so.* | head -n 1 | xargs -n1 -I {} ln -s {} /lib/libhwloc.so.5
+
+COPY --from=lotus-dev /usr/local/bin/lotus /usr/local/bin/
+COPY --from=lotus-dev /usr/local/bin/lotus-miner /usr/local/bin/
+
 COPY --from=builder /go/src/boostd /usr/local/bin/
 COPY --from=builder /go/src/boost /usr/local/bin/
 COPY --from=builder /go/src/boostx /usr/local/bin/
-COPY --from=lotus-dev /usr/local/bin/lotus /usr/local/bin/
-COPY --from=lotus-dev /usr/local/bin/lotus-miner /usr/local/bin/
-## Fix missing lib libhwloc.so.5
-RUN ls -1 /lib/x86_64-linux-gnu/libhwloc.so.* | head -n 1 | xargs -n1 -I {} ln -s {} /lib/x86_64-linux-gnu/libhwloc.so.5
 ## Smoke test for the boost and lotus
 RUN lotus -v && boost -v 
 

--- a/docker/devnet/boost/Dockerfile.source
+++ b/docker/devnet/boost/Dockerfile.source
@@ -33,15 +33,7 @@ RUN make build/.filecoin-install
 COPY go.mod go.sum /go/src/
 RUN go mod download
 ##############################################
-##############################################
-#COPY . /go/src
-
-# we need to copy all source except build/ and extern/
-# docker does not allow to do it easy, we can write docker COPY for each dir, 
-# but there are a lot of dirs and may be added new ones
-COPY . /tmp/src
-RUN rm -rf /tmp/src/build /tmp/src/extern /tmp/src/docker /tmp/src/boost*
-RUN cp -r /tmp/src/* /tmp/src/.git /go/src/ 
+COPY . /go/src
 ##############################################
 RUN --mount=type=cache,target=/root/.cache/go-build make debug
 #########################################################################################

--- a/docker/devnet/boost/Dockerfile.source
+++ b/docker/devnet/boost/Dockerfile.source
@@ -29,13 +29,11 @@ COPY .git/modules/extern/filecoin-ffi /go/src/.git/modules/extern/filecoin-ffi
 
 RUN make build/.filecoin-install
 ##############################################
-# download go dependencies
-COPY go.mod go.sum /go/src/
-RUN go mod download
-##############################################
 COPY . /go/src
 ##############################################
-RUN --mount=type=cache,target=/root/.cache/go-build make debug
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg/mod \
+      make debug
 #########################################################################################
 FROM ubuntu:20.04 as runner
 

--- a/docker/devnet/boost/Makefile
+++ b/docker/devnet/boost/Makefile
@@ -6,8 +6,8 @@ tag=$(service):$(version)
 rootdir=$(realpath .)
 
 dbuild: 
-	docker build --build-arg LOTUS_TEST_IMAGE=$(lotus_test_image) \
-		-t $(tag) -f Dockerfile.source $(rootdir)/../../../
+	DOCKER_BUILDKIT=1 docker build --build-arg LOTUS_TEST_IMAGE=$(lotus_test_image) \
+		-t $(tag) $(docker_args) -f Dockerfile.source $(rootdir)/../../../
 
 dpush: dbuild
 	docker push $(tag)


### PR DESCRIPTION
Resolves #767

This solution adds optimization for building docker image for the boost only, it does not deal with building the lotus.

**Improvements:**
1. caches *filecoin-ffi* build. It was a bit problematic, as a makefile of the *filecoin-ffi* depends on a git. We don't want the cache to be cleared on any git commit... etc. So I made a solution to do `git submodule update` before `docker build` command.  
2. caches go.mod downloads
3. caches `go build` using docker's buildkit feature

My rough estimates of the building time:
```bash
###########################################################
# building source without docker
$ time (cd ../../ && make debug)
...
real	0m28.465s

###########################################################
# building boost image without using cache
time make build/boost docker_args=--no-cache
...
 => [builder  2/12] RUN apt update && apt install -y       build-essential       bzr pkg-config      63.7s
 => [runner  2/12] RUN apt update && apt install -y       curl       hwloc       jq                  22.0s
...
 => [builder  8/12] RUN make build/.filecoin-install                                                  7.6s 
 => [builder  9/12] COPY go.mod go.sum /go/src/                                                       0.1s 
 => [builder 10/12] RUN go mod download                                                              86.7s 
 => [builder 11/12] COPY . /go/src                                                                    0.5s 
 => [builder 12/12] RUN --mount=type=cache,target=/root/.cache/go-build make debug                   82.9s 
...
real	4m5.430s

###########################################################
# building boost image after modifying any go file 
$ time make build/boost
...
 => CACHED [builder  8/12] RUN make build/.filecoin-install                                           0.0s
 => CACHED [builder  9/12] COPY go.mod go.sum /go/src/                                                0.0s
 => CACHED [builder 10/12] RUN go mod download                                                        0.0s
 => [builder 11/12] COPY . /go/src                                                                    0.5s
 => [builder 12/12] RUN --mount=type=cache,target=/root/.cache/go-build make debug                   26.9s
...
real	0m29.331s

```
