### PR TITLE
Add --enable-tracing flag to booster-http

### DIFF
--- a/docker/devnet/booster-http/entrypoint.sh
+++ b/docker/devnet/booster-http/entrypoint.sh
@@ -10,4 +10,4 @@ echo $MINER_API_INFO
 echo $BOOST_API_INFO
 
 echo Starting booster-http...
-exec booster-http run --api-boost=$BOOST_API_INFO --api-fullnode=$FULLNODE_API_INFO --api-storage=$MINER_API_INFO
+exec booster-http run --api-boost=$BOOST_API_INFO --api-fullnode=$FULLNODE_API_INFO --api-storage=$MINER_API_INFO --enable-tracing=true


### PR DESCRIPTION
Adds a `--enable-tracing` flag to booster-http. The flag is false by default, preventing the instantiation and startup of the tracing exporter. The flag is set to true for the devnet docker setup. Part of #774.