### PR TITLE
tracing behind feature-flag for boostd; configuration in config.toml

### DIFF
--- a/cmd/boostd/run.go
+++ b/cmd/boostd/run.go
@@ -6,7 +6,6 @@ import (
 	"github.com/filecoin-project/boost/api"
 	"github.com/filecoin-project/boost/node"
 	"github.com/filecoin-project/boost/node/modules/dtypes"
-	"github.com/filecoin-project/boost/tracing"
 
 	lapi "github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/api/v0api"
@@ -130,12 +129,6 @@ var runCmd = &cli.Command{
 			return fmt.Errorf("connecting to full node (libp2p): %w", err)
 		}
 
-		// Instantiate the tracer and exporter
-		tracingStopper, err := tracing.New(ctx, "boostd")
-		if err != nil {
-			return fmt.Errorf("failed to instantiate tracer: %w", err)
-		}
-
 		// Instantiate the boost service JSON RPC handler.
 		handler, err := node.BoostHandler(boostApi, true)
 		if err != nil {
@@ -154,7 +147,6 @@ var runCmd = &cli.Command{
 		finishCh := node.MonitorShutdown(shutdownChan,
 			node.ShutdownHandler{Component: "rpc server", StopFunc: rpcStopper},
 			node.ShutdownHandler{Component: "boost", StopFunc: stop},
-			node.ShutdownHandler{Component: "tracing", StopFunc: tracingStopper},
 		)
 
 		<-finishCh

--- a/cmd/booster-http/run.go
+++ b/cmd/booster-http/run.go
@@ -77,6 +77,11 @@ var runCmd = &cli.Command{
 			Usage: "enables tracing of booster-http calls",
 			Value: false,
 		},
+		&cli.StringFlag{
+			Name:  "tracing-endpoint",
+			Usage: "the endpoint for the tracing exporter",
+			Value: "http://tempo:14268/api/traces",
+		},
 	},
 	Action: func(cctx *cli.Context) error {
 		if cctx.Bool("pprof") {
@@ -121,7 +126,7 @@ var runCmd = &cli.Command{
 		enableTracing := cctx.Bool("tracing")
 		var tracingStopper func(context.Context) error
 		if enableTracing {
-			tracingStopper, err = tracing.New(ctx, "booster-http")
+			tracingStopper, err = tracing.New("booster-http", cctx.String("tracing-endpoint"))
 			if err != nil {
 				return fmt.Errorf("failed to instantiate tracer: %w", err)
 			}

--- a/cmd/booster-http/run.go
+++ b/cmd/booster-http/run.go
@@ -73,7 +73,7 @@ var runCmd = &cli.Command{
 			Required: true,
 		},
 		&cli.BoolFlag{
-			Name:  "enable-tracing",
+			Name:  "tracing",
 			Usage: "enables tracing of booster-http calls",
 			Value: false,
 		},
@@ -118,7 +118,7 @@ var runCmd = &cli.Command{
 		defer storageCloser()
 
 		// Instantiate the tracer and exporter
-		enableTracing := cctx.Bool("enable-tracing")
+		enableTracing := cctx.Bool("tracing")
 		var tracingStopper func(context.Context) error
 		if enableTracing {
 			tracingStopper, err = tracing.New(ctx, "booster-http")

--- a/docker/devnet/booster-http/entrypoint.sh
+++ b/docker/devnet/booster-http/entrypoint.sh
@@ -10,4 +10,4 @@ echo $MINER_API_INFO
 echo $BOOST_API_INFO
 
 echo Starting booster-http...
-exec booster-http run --api-boost=$BOOST_API_INFO --api-fullnode=$FULLNODE_API_INFO --api-storage=$MINER_API_INFO --enable-tracing=true
+exec booster-http run --api-boost=$BOOST_API_INFO --api-fullnode=$FULLNODE_API_INFO --api-storage=$MINER_API_INFO --tracing

--- a/docker/devnet/docker-compose.yaml
+++ b/docker/devnet/docker-compose.yaml
@@ -55,6 +55,9 @@ services:
       - LOTUS_API_LISTENADDRESS=/dns/boost/tcp/1288/http
       - LOTUS_PATH=/var/lib/lotus
       - LOTUS_MINER_PATH=/var/lib/lotus-miner
+      - LOTUS_TRACING_ENABLED=true
+      - LOTUS_TRACING_SERVICENAME=boostd
+      - LOTUS_TRACING_ENDPOINT=http://tempo:14268/api/traces
     restart: unless-stopped
     logging: *default-logging
     volumes:

--- a/node/builder.go
+++ b/node/builder.go
@@ -24,6 +24,7 @@ import (
 	"github.com/filecoin-project/boost/storagemarket"
 	"github.com/filecoin-project/boost/storagemarket/dealfilter"
 	smtypes "github.com/filecoin-project/boost/storagemarket/types"
+	"github.com/filecoin-project/boost/tracing"
 	"github.com/filecoin-project/dagstore"
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
@@ -483,6 +484,9 @@ func ConfigBoost(cfg *config.Boost) Option {
 
 		// GraphQL server
 		Override(new(*gql.Server), modules.NewGraphqlServer(cfg)),
+
+		// Tracing
+		Override(new(*tracing.Tracing), modules.NewTracing(cfg)),
 
 		// Address selector
 		Override(new(*ctladdr.AddressSelector), lotus_modules.AddressSelector(&lotus_config.MinerAddressConfig{

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -67,8 +67,9 @@ func DefaultBoost() *Boost {
 		},
 
 		Tracing: TracingConfig{
-			Enabled:  false,
-			Endpoint: "",
+			Enabled:     false,
+			Endpoint:    "",
+			ServiceName: "boostd",
 		},
 
 		Dealmaking: DealmakingConfig{

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -66,6 +66,11 @@ func DefaultBoost() *Boost {
 			Port: 8080,
 		},
 
+		Tracing: TracingConfig{
+			Enabled:  false,
+			Endpoint: "",
+		},
+
 		Dealmaking: DealmakingConfig{
 			ConsiderOnlineStorageDeals:     true,
 			ConsiderOfflineStorageDeals:    true,

--- a/node/config/doc_gen.go
+++ b/node/config/doc_gen.go
@@ -62,6 +62,12 @@ your node if metadata log is disabled`,
 			Comment: ``,
 		},
 		{
+			Name: "Tracing",
+			Type: "TracingConfig",
+
+			Comment: ``,
+		},
+		{
 			Name: "LotusDealmaking",
 			Type: "lotus_config.DealmakingConfig",
 
@@ -390,6 +396,26 @@ see https://docs.filecoin.io/mine/lotus/miner-configuration/#using-filters-for-f
 			Type: "int",
 
 			Comment: `The maximum number of concurrent fetch operations to the storage subsystem`,
+		},
+	},
+	"TracingConfig": []DocField{
+		{
+			Name: "Enabled",
+			Type: "bool",
+
+			Comment: ``,
+		},
+		{
+			Name: "ServiceName",
+			Type: "string",
+
+			Comment: ``,
+		},
+		{
+			Name: "Endpoint",
+			Type: "string",
+
+			Comment: ``,
 		},
 	},
 	"WalletsConfig": []DocField{

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -77,8 +77,9 @@ type GraphqlConfig struct {
 }
 
 type TracingConfig struct {
-	Enabled  bool
-	Endpoint string
+	Enabled     bool
+	ServiceName string
+	Endpoint    string
 }
 
 type LotusDealmakingConfig struct {

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -42,6 +42,7 @@ type Boost struct {
 	Dealmaking         DealmakingConfig
 	Wallets            WalletsConfig
 	Graphql            GraphqlConfig
+	Tracing            TracingConfig
 
 	// Lotus configs
 	LotusDealmaking lotus_config.DealmakingConfig
@@ -73,6 +74,11 @@ type WalletsConfig struct {
 type GraphqlConfig struct {
 	// The port that the graphql server listens on
 	Port uint64
+}
+
+type TracingConfig struct {
+	Enabled  bool
+	Endpoint string
 }
 
 type LotusDealmakingConfig struct {

--- a/node/impl/boost.go
+++ b/node/impl/boost.go
@@ -46,8 +46,6 @@ type BoostAPI struct {
 	api.Net
 
 	Full lapi.FullNode
-	//LocalStore  *stores.Local
-	//RemoteStore *stores.Remote
 
 	Host host.Host
 
@@ -72,9 +70,12 @@ type BoostAPI struct {
 
 	// Sealing Pipeline API
 	Sps sealingpipeline.API
-	// TODO: Figure out how to start graphql server without it needing
-	// to be a dependency of another fx object
+
+	// GraphSQL server
 	GraphqlServer *gql.Server
+
+	// Tracing
+	Tracing *tracing.Tracing
 
 	DS lotus_dtypes.MetadataDS
 

--- a/tracing/exporter.go
+++ b/tracing/exporter.go
@@ -13,8 +13,8 @@ import (
 )
 
 // Registers a Tracer provider globally and returns it's shutdown function
-func New(ctx context.Context, service string) (func(context.Context) error, error) {
-	provider, err := tracerProvider("http://tempo:14268/api/traces", service)
+func New(service, endpoint string) (func(context.Context) error, error) {
+	provider, err := tracerProvider(endpoint, service)
 	if err != nil {
 		return nil, err
 	}

--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -16,3 +16,5 @@ var (
 		trace.WithSchemaURL(semconv.SchemaURL),
 	)
 )
+
+type Tracing struct{}


### PR DESCRIPTION
This PR is adding the `[Tracing]` configuration section in the Boost node config.toml

It also moves the instantiation of the tracing system within the Boost node dependency injection.

It is also renaming the flag on `booster-http` from `--enable-tracing` to just `--tracing`, and adds `--tracing-endpoint`.