### PR TITLE
Remove single wallet restriction

### DIFF
--- a/cmd/boostd/init.go
+++ b/cmd/boostd/init.go
@@ -540,10 +540,6 @@ func initBoost(ctx context.Context, cctx *cli.Context, marketsRepo lotus_repo.Lo
 		return nil, fmt.Errorf("failed to parse wallet-deal-collateral: %s; err: %w", cctx.String("wallet-deal-collateral"), err)
 	}
 
-	if walletPSD.String() == walletCP.String() {
-		return nil, fmt.Errorf("wallets for PublishStorageDeals and deal collateral must be different")
-	}
-
 	if cctx.Int64("max-staging-deals-bytes") <= 0 {
 		return nil, fmt.Errorf("max size for staging deals area must be > 0 bytes")
 	}


### PR DESCRIPTION
Currently, `init` and `migrate` forces the users to use separate the wallet for collateral and MessagePublish. This PR removes the check to allow use of a single wallet for both.