### PR TITLE
Add react GUI to boost docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 docker/devnet/data
 react/node_modules
+react/build
 # filecoin-ffi installation
 build/.filecoin-install
 extern/filecoin-ffi/.install-filcrypto

--- a/docker/devnet/boost/Dockerfile.source
+++ b/docker/devnet/boost/Dockerfile.source
@@ -4,6 +4,15 @@
 ARG LOTUS_TEST_IMAGE=filecoin/lotus-test:latest
 FROM ${LOTUS_TEST_IMAGE} as lotus-dev
 #########################################################################################
+FROM node:16.16-alpine3.15 AS react-builder
+
+WORKDIR /src
+COPY react /src/react
+COPY gql /src/gql
+
+RUN npm_config_legacy_peer_deps=yes npm ci --no-audit --prefix react&& \
+      npm run --prefix react build
+#########################################################################################
 FROM golang:1.18-bullseye as builder
 
 RUN apt update && apt install -y \
@@ -31,6 +40,8 @@ RUN make build/.filecoin-install
 ##############################################
 COPY . /go/src
 ##############################################
+COPY --from=react-builder /src/react/build /go/src/react/build
+
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
       make debug


### PR DESCRIPTION
Additional fix for #788:

- it makes sure a react GUI is packed into a boost container. It was not the case on a clean git repo
- uses a separate node image to build the react app and copies binaries to the boost builder

