### PR TITLE
return ipld ErrNotFound from remote blockstore interface

### DIFF
--- a/cmd/booster-bitswap/remoteblockstore/remoteblockstore_test.go
+++ b/cmd/booster-bitswap/remoteblockstore/remoteblockstore_test.go
@@ -48,6 +48,16 @@ func TestNormalizeError(t *testing.T) {
 		expected:      fmt.Errorf("some err: %w", format.ErrNotFound{Cid: dummyCid}),
 		isNotFoundErr: true,
 	}, {
+		name:          "ipld ErrorNotFound no cid with prefix",
+		err:           fmt.Errorf("some err: %w", format.ErrNotFound{}),
+		expected:      fmt.Errorf("some err: %w", format.ErrNotFound{}),
+		isNotFoundErr: true,
+	}, {
+		name:          "stringified ipld ErrorNotFound no cid with prefix",
+		err:           fmt.Errorf(fmt.Errorf("some err: %w", format.ErrNotFound{}).Error()),
+		expected:      fmt.Errorf("some err: %w", format.ErrNotFound{}),
+		isNotFoundErr: true,
+	}, {
 		name:          "different error",
 		err:           fmt.Errorf("some other err"),
 		expected:      fmt.Errorf("some other err"),

--- a/cmd/booster-bitswap/remoteblockstore/remoteblockstore_test.go
+++ b/cmd/booster-bitswap/remoteblockstore/remoteblockstore_test.go
@@ -1,0 +1,73 @@
+package remoteblockstore
+
+import (
+	"fmt"
+	"github.com/ipfs/go-cid"
+	format "github.com/ipfs/go-ipld-format"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestNormalizeError(t *testing.T) {
+	dummyCid, err := cid.Parse("bafkqaaa")
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name          string
+		err           error
+		expected      error
+		isNotFoundErr bool
+	}{{
+		name:          "ipld ErrNotFound",
+		err:           format.ErrNotFound{Cid: dummyCid},
+		expected:      format.ErrNotFound{Cid: dummyCid},
+		isNotFoundErr: true,
+	}, {
+		name:          "stringified ipld ErrNotFound",
+		err:           fmt.Errorf(format.ErrNotFound{Cid: dummyCid}.Error()),
+		expected:      format.ErrNotFound{Cid: dummyCid},
+		isNotFoundErr: true,
+	}, {
+		name:          "ipld ErrNotFound no cid",
+		err:           format.ErrNotFound{},
+		expected:      format.ErrNotFound{},
+		isNotFoundErr: true,
+	}, {
+		name:          "stringified ipld ErrNotFound no cid",
+		err:           fmt.Errorf(format.ErrNotFound{}.Error()),
+		expected:      format.ErrNotFound{},
+		isNotFoundErr: true,
+	}, {
+		name:          "ipld ErrorNotFound with prefix",
+		err:           fmt.Errorf("some err: %w", format.ErrNotFound{Cid: dummyCid}),
+		expected:      fmt.Errorf("some err: %w", format.ErrNotFound{Cid: dummyCid}),
+		isNotFoundErr: true,
+	}, {
+		name:          "stringified ipld ErrorNotFound with prefix",
+		err:           fmt.Errorf(fmt.Errorf("some err: %w", format.ErrNotFound{Cid: dummyCid}).Error()),
+		expected:      fmt.Errorf("some err: %w", format.ErrNotFound{Cid: dummyCid}),
+		isNotFoundErr: true,
+	}, {
+		name:          "different error",
+		err:           fmt.Errorf("some other err"),
+		expected:      fmt.Errorf("some other err"),
+		isNotFoundErr: false,
+	}, {
+		name:          "stringified ipld ErrorNotFound with bad cid",
+		err:           fmt.Errorf(ipldNotFoundPrefix + "badcid"),
+		expected:      fmt.Errorf(ipldNotFoundPrefix + "badcid"),
+		isNotFoundErr: false,
+	}}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := normalizeError(tc.err)
+			if tc.isNotFoundErr {
+				require.True(t, format.IsNotFound(err))
+			} else {
+				require.False(t, format.IsNotFound(err))
+			}
+			require.Equal(t, tc.expected.Error(), err.Error())
+		})
+	}
+}


### PR DESCRIPTION
Return [ipld ErrNotFound](https://github.com/ipfs/go-ipld-format/blob/master/merkledag.go#L15) from GetSize() if the block is not found, because [Bitswap checks for this error](https://github.com/ipfs/go-bitswap/blob/4e3736a773545bf09d5178a2be24043b76560f87/server/internal/decision/blockstoremanager.go#L97) to decide if a block is present.
Note that the RemoteBlockstore calls across an RPC boundary, so the code needs to do string matching to check if the error message matches the ipld ErrNotFound error.