### PR TITLE
scrape_config for lotus-miner on host

### DIFF
--- a/docker/monitoring/docker-compose.yaml
+++ b/docker/monitoring/docker-compose.yaml
@@ -42,6 +42,8 @@ services:
     command: [ "--config.file=/etc/prometheus.yaml" ]
     volumes:
       - ./prometheus.yaml:/etc/prometheus.yaml
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     ports:
       - "9090:9090"
     logging:
@@ -68,3 +70,19 @@ services:
       driver: loki
       options:
         loki-url: 'http://localhost:3100/loki/api/v1/push'
+
+  #####################
+  ## DEBUG CONTAINER ##
+  #####################
+  #ubuntu:
+    #container_name: ubuntu
+    #image: ubuntu:latest
+    #command: [ "sleep", "3600" ]
+    #ports:
+      #- "8098:8098"
+    #extra_hosts:
+      #- "host.docker.internal:host-gateway"
+    #logging:
+      #driver: loki
+      #options:
+        #loki-url: 'http://localhost:3100/loki/api/v1/push'

--- a/docker/monitoring/prometheus.yaml
+++ b/docker/monitoring/prometheus.yaml
@@ -12,3 +12,6 @@ scrape_configs:
   - job_name: 'booster-http'
     static_configs:
       - targets: [ 'booster-http:7777' ]
+  - job_name: 'lotus-miner'
+    static_configs:
+      - targets: [ 'host.docker.internal:8787/debug/metrics' ]


### PR DESCRIPTION
I'd like to be able to use the same monitoring setup that we have for the devnet with a production miner, where `lotus-miner`, `lotus` and `boost` are generally running outside docker.

I am on the fence on this PR, regarding whether it belongs to this repo at all, as production miners can have a variety of deployments and `lotus`, `lotus-miner`, `boost` might be on different hosts, and not necessarily on the same host.

At the same time I'd like to take advantage of all the goodies that @kylehuntsman is adding, such as automatically provisioned dashboards, etc. and have prometheus scrape and tempo collect traces.

---

This PR is enabling `prometheus` to scrape an endpoint that is on the local host, i.e. it is applicable for our production mainnet miner.