### PR TITLE
Fix failing build for booster-http docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,5 @@
 docker/devnet/data
 react/node_modules
-react/build
 # filecoin-ffi installation
 build/.filecoin-install
 extern/filecoin-ffi/.install-filcrypto


### PR DESCRIPTION
Fix a problem introduced by: https://github.com/filecoin-project/boost/commit/207b5cc10633acbbb6db78b01bef7116d013f2dc

I wanted to speed up boost container build, but it turned out other containers also depend on `react/build`. 