### PR TITLE
update readme for prometheus

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ docker compose up -d
 
 ```
 docker network connect devnet tempo
+docker network connect devnet prometheus
 ```
 
 ### Explore Grafana / Tempo and search for traces


### PR DESCRIPTION
Necessary so that Prometheus can scrape targets from the devnet stack.