### PR TITLE
Add deal-removal, index-removal and piece-removal

### DIFF
--- a/extern/boostd-data/client/client.go
+++ b/extern/boostd-data/client/client.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/filecoin-project/boost/cmd/boostd-data/model"
+	"github.com/google/uuid"
 	"github.com/ipfs/go-cid"
 	logger "github.com/ipfs/go-log/v2"
 	"github.com/ipld/go-car/v2/index"
@@ -122,4 +123,34 @@ func (s *Store) GetOffset(pieceCid cid.Cid, hash mh.Multihash) (uint64, error) {
 	}
 
 	return resp, nil
+}
+
+func (s *Store) RemoveDeal(pieceCid cid.Cid, dealId uuid.UUID) error {
+	var resp error
+	err := s.client.Call(&resp, "boostddata_removeDealForPiece", pieceCid, dealId)
+	if err != nil {
+		return err
+	}
+
+	return resp
+}
+
+func (s *Store) RemovePieceMetadata(pieceCid cid.Cid) error {
+	var resp error
+	err := s.client.Call(&resp, "boostddata_removePieceMetadata", pieceCid)
+	if err != nil {
+		return err
+	}
+
+	return resp
+}
+
+func (s *Store) RemoveMultihashes(pieceCid cid.Cid) error {
+	var resp error
+	err := s.client.Call(&resp, "boostddata_removeAllMultihashes", pieceCid)
+	if err != nil {
+		return err
+	}
+
+	return resp
 }

--- a/extern/boostd-data/couchbase/db.go
+++ b/extern/boostd-data/couchbase/db.go
@@ -300,3 +300,76 @@ func has(list []cid.Cid, v cid.Cid) bool {
 	}
 	return false
 }
+
+// RemoveAllRecords
+func (db *DB) RemoveAllRecords(ctx context.Context, cursor uint64) error {
+	return errors.New("implement me")
+	//buf := make([]byte, size)
+	//binary.PutUvarint(buf, cursor)
+	//
+	//var q query.Query
+	//q.Prefix = fmt.Sprintf("%d/", cursor)
+	//results, err := db.Query(ctx, q)
+	//if err != nil {
+	//	return err
+	//}
+	//
+	//entries, err := results.Rest()
+	//if err != nil {
+	//	return err
+	//}
+	//
+	//batch, err := db.Batch(ctx)
+	//if err != nil {
+	//	return err
+	//}
+	//
+	//var keys []ds.Key
+	//
+	//for _, r := range entries {
+	//	k := ds.NewKey(r.Key)
+	//	keys = append(keys, k)
+	//	if err := batch.Delete(ctx, k); err != nil {
+	//		return fmt.Errorf("failed to batch delete mh=%s, err%w", r.Key[len(q.Prefix)+1:], err)
+	//	}
+	//}
+	//
+	//if err := batch.Commit(ctx); err != nil {
+	//	return fmt.Errorf("failed to commit batch: %w", err)
+	//}
+	//
+	//// Should we only sync the last entry to avoid this loop?
+	//// Would it guarantee the sync for previous keys
+	//for _, v := range keys {
+	//	if err := db.Sync(ctx, v); err != nil {
+	//		return fmt.Errorf("failed to sync delete: %w", err)
+	//	}
+	//}
+	//// TODO: Requires DB compaction for removing the key
+	//return nil
+}
+
+// RemoveAllMetadataForPieceCid(key)
+func (db *DB) RemoveMetadata(ctx context.Context, pieceCid cid.Cid) error {
+	key := datastore.NewKey(fmt.Sprintf("%s%s", sprefixPieceCidToCursor, pieceCid.String()))
+
+	options := gocb.ExistsOptions{
+		Context: ctx,
+	}
+
+	if res, err := db.col.Exists("u:"+key.String(), &options); !res.Exists() {
+		return err
+	}
+
+	rmoptions := gocb.RemoveOptions{
+		Context: ctx,
+	}
+
+	// TODO: Requires DB compaction for removing the key
+	_, err := db.col.Remove("u:"+key.String(), &rmoptions)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/extern/boostd-data/couchbase/service.go
+++ b/extern/boostd-data/couchbase/service.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/filecoin-project/boost/cmd/boostd-data/model"
+	"github.com/google/uuid"
 	"github.com/ipfs/go-cid"
 	ds "github.com/ipfs/go-datastore"
 	logging "github.com/ipfs/go-log/v2"
@@ -230,50 +231,45 @@ func (s *Store) IndexedAt(pieceCid cid.Cid) (time.Time, error) {
 }
 
 // Remove Single deal for pieceCID. If []Deals is empty then Metadata is removed as well
-func (s *Store) RemoveDealForPiece() error {
-	return errors.New("Implement me")
-	//log.Debugw("handle.remove-deal-for-piece", "piece-cid", pieceCid)
-	//
-	//defer func(now time.Time) {
-	//	log.Debugw("handled.remove-deal-for-piece", "took", fmt.Sprintf("%s", time.Since(now)))
-	//}(time.Now())
-	//
-	//s.Lock()
-	//defer s.Unlock()
-	//
-	//ctx := context.Background()
-	//
-	//md, err := s.db.GetPieceCidToMetadata(ctx, pieceCid)
-	//if err != nil {
-	//	return err
-	//}
-	//
-	//for i, v := range md.Deals {
-	//	if v.DealUuid == dealUuid {
-	//		md.Deals[i] = md.Deals[len(md.Deals)-1]
-	//		md.Deals = md.Deals[:len(md.Deals)-1]
-	//		break
-	//	}
-	//}
-	//
-	//// Remove Metadata if removed deal was last one. Don't fail even if error is returned
-	//if len(md.Deals) == 0 {
-	//	if err := s.db.RemoveMetadata(ctx, pieceCid); err != nil {
-	//		log.Errorf("Failed to remove the Metadata after removing the last deal: %w", err)
-	//	}
-	//	// Remove all MultiHash Records as well. Don't fail even if error is returned
-	//	if err := s.db.RemoveAllRecords(ctx, md.Cursor); err != nil {
-	//		log.Errorf("Failed to remove Multihashes after removing the Metadata: %w", err)
-	//	}
-	//	return nil
-	//}
-	//
-	//err = s.db.SetPieceCidToMetadata(ctx, pieceCid, md)
-	//if err != nil {
-	//	return err
-	//}
+func (s *Store) RemoveDealForPiece(pieceCid cid.Cid, dealUuid uuid.UUID) error {
+	log.Debugw("handle.remove-deal-for-piece", "piece-cid", pieceCid)
 
-	//return nil
+	defer func(now time.Time) {
+		log.Debugw("handled.remove-deal-for-piece", "took", fmt.Sprintf("%s", time.Since(now)))
+	}(time.Now())
+
+	s.Lock()
+	defer s.Unlock()
+
+	ctx := context.Background()
+
+	md, err := s.db.GetPieceCidToMetadata(ctx, pieceCid)
+	if err != nil {
+		return err
+	}
+
+	for i, v := range md.Deals {
+		if v.DealUuid == dealUuid {
+			md.Deals[i] = md.Deals[len(md.Deals)-1]
+			md.Deals = md.Deals[:len(md.Deals)-1]
+			break
+		}
+	}
+
+	// Remove Metadata if removed deal was last one. Don't fail even if error is returned
+	if len(md.Deals) == 0 {
+		if err := s.db.RemoveMetadata(ctx, pieceCid); err != nil {
+			log.Errorf("Failed to remove the Metadata after removing the last deal: %w", err)
+		}
+		return nil
+	}
+
+	err = s.db.SetPieceCidToMetadata(ctx, pieceCid, md)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // Remove all Metadata for pieceCID. To be used manually in case of failure
@@ -300,21 +296,25 @@ func (s *Store) RemovePieceMetadata(pieceCid cid.Cid) error {
 // Remove all MultiHashes for pieceCID. To be used manually in case of failure
 // in RemoveDealForPiece
 func (s *Store) RemoveAllMultiHashes(pieceCid cid.Cid) error {
-	return errors.New("Implement me")
-	//log.Debugw("handle.remove-metadata-for-piece", "piece-cid", pieceCid)
-	//
-	//defer func(now time.Time) {
-	//	log.Debugw("handled.remove-metadata-for-piece", "took", fmt.Sprintf("%s", time.Since(now)))
-	//}(time.Now())
-	//
-	//s.Lock()
-	//defer s.Unlock()
-	//
-	//ctx := context.Background()
-	//
-	//if err := s.db.RemoveMetadata(ctx, pieceCid); err != nil {
-	//	return err
-	//}
-	//
-	//return nil
+	log.Debugw("handle.remove-metadata-for-piece", "piece-cid", pieceCid)
+
+	defer func(now time.Time) {
+		log.Debugw("handled.remove-metadata-for-piece", "took", fmt.Sprintf("%s", time.Since(now)))
+	}(time.Now())
+
+	s.Lock()
+	defer s.Unlock()
+
+	ctx := context.Background()
+
+	md, err := s.db.GetPieceCidToMetadata(ctx, pieceCid)
+	if err != nil {
+		return err
+	}
+
+	if err := s.db.removeAllRecords(ctx, md.Cursor); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/extern/boostd-data/couchbase/service.go
+++ b/extern/boostd-data/couchbase/service.go
@@ -228,3 +228,93 @@ func (s *Store) IndexedAt(pieceCid cid.Cid) (time.Time, error) {
 
 	return md.IndexedAt, nil
 }
+
+// Remove Single deal for pieceCID. If []Deals is empty then Metadata is removed as well
+func (s *Store) RemoveDealForPiece() error {
+	return errors.New("Implement me")
+	//log.Debugw("handle.remove-deal-for-piece", "piece-cid", pieceCid)
+	//
+	//defer func(now time.Time) {
+	//	log.Debugw("handled.remove-deal-for-piece", "took", fmt.Sprintf("%s", time.Since(now)))
+	//}(time.Now())
+	//
+	//s.Lock()
+	//defer s.Unlock()
+	//
+	//ctx := context.Background()
+	//
+	//md, err := s.db.GetPieceCidToMetadata(ctx, pieceCid)
+	//if err != nil {
+	//	return err
+	//}
+	//
+	//for i, v := range md.Deals {
+	//	if v.DealUuid == dealUuid {
+	//		md.Deals[i] = md.Deals[len(md.Deals)-1]
+	//		md.Deals = md.Deals[:len(md.Deals)-1]
+	//		break
+	//	}
+	//}
+	//
+	//// Remove Metadata if removed deal was last one. Don't fail even if error is returned
+	//if len(md.Deals) == 0 {
+	//	if err := s.db.RemoveMetadata(ctx, pieceCid); err != nil {
+	//		log.Errorf("Failed to remove the Metadata after removing the last deal: %w", err)
+	//	}
+	//	// Remove all MultiHash Records as well. Don't fail even if error is returned
+	//	if err := s.db.RemoveAllRecords(ctx, md.Cursor); err != nil {
+	//		log.Errorf("Failed to remove Multihashes after removing the Metadata: %w", err)
+	//	}
+	//	return nil
+	//}
+	//
+	//err = s.db.SetPieceCidToMetadata(ctx, pieceCid, md)
+	//if err != nil {
+	//	return err
+	//}
+
+	//return nil
+}
+
+// Remove all Metadata for pieceCID. To be used manually in case of failure
+// in RemoveDealForPiece
+func (s *Store) RemovePieceMetadata(pieceCid cid.Cid) error {
+	log.Debugw("handle.remove-metadata-for-piece", "piece-cid", pieceCid)
+
+	defer func(now time.Time) {
+		log.Debugw("handled.remove-metadata-for-piece", "took", fmt.Sprintf("%s", time.Since(now)))
+	}(time.Now())
+
+	s.Lock()
+	defer s.Unlock()
+
+	ctx := context.Background()
+
+	if err := s.db.RemoveMetadata(ctx, pieceCid); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Remove all MultiHashes for pieceCID. To be used manually in case of failure
+// in RemoveDealForPiece
+func (s *Store) RemoveAllMultiHashes(pieceCid cid.Cid) error {
+	return errors.New("Implement me")
+	//log.Debugw("handle.remove-metadata-for-piece", "piece-cid", pieceCid)
+	//
+	//defer func(now time.Time) {
+	//	log.Debugw("handled.remove-metadata-for-piece", "took", fmt.Sprintf("%s", time.Since(now)))
+	//}(time.Now())
+	//
+	//s.Lock()
+	//defer s.Unlock()
+	//
+	//ctx := context.Background()
+	//
+	//if err := s.db.RemoveMetadata(ctx, pieceCid); err != nil {
+	//	return err
+	//}
+	//
+	//return nil
+}

--- a/extern/boostd-data/ldb/service.go
+++ b/extern/boostd-data/ldb/service.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/filecoin-project/boost/cmd/boostd-data/model"
+	"github.com/google/uuid"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
 	ds "github.com/ipfs/go-datastore"
@@ -289,4 +290,98 @@ func (s *Store) IndexedAt(pieceCid cid.Cid) (time.Time, error) {
 	}
 
 	return md.IndexedAt, nil
+}
+
+// Remove Single deal for pieceCID. If []Deals is empty then Metadata is removed as well
+func (s *Store) RemoveDealForPiece(pieceCid cid.Cid, dealUuid uuid.UUID) error {
+	log.Debugw("handle.remove-deal-for-piece", "piece-cid", pieceCid)
+
+	defer func(now time.Time) {
+		log.Debugw("handled.remove-deal-for-piece", "took", fmt.Sprintf("%s", time.Since(now)))
+	}(time.Now())
+
+	s.Lock()
+	defer s.Unlock()
+
+	ctx := context.Background()
+
+	md, err := s.db.GetPieceCidToMetadata(ctx, pieceCid)
+	if err != nil {
+		return err
+	}
+
+	for i, v := range md.Deals {
+		if v.DealUuid == dealUuid {
+			md.Deals[i] = md.Deals[len(md.Deals)-1]
+			md.Deals = md.Deals[:len(md.Deals)-1]
+			break
+		}
+	}
+
+	// This order is important as md.Cursor is required in case RemoveAllRecords fails
+	// and needs to be run manually
+	if len(md.Deals) == 0 {
+		// Remove all MultiHash Records as well. Don't fail even if error is returned
+		if err := s.db.RemoveAllRecords(ctx, md.Cursor); err != nil {
+			log.Errorf("Failed to remove Multihashes after removing the last deal: %w", err)
+		}
+		// Remove Metadata if removed deal was last one. Don't fail even if error is returned
+		if err := s.db.RemoveMetadata(ctx, pieceCid); err != nil {
+			log.Errorf("Failed to remove the Metadata after removing the last deal: %w", err)
+		}
+		return nil
+	}
+
+	err = s.db.SetPieceCidToMetadata(ctx, pieceCid, md)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Remove all Metadata for pieceCID
+func (s *Store) RemovePieceMetadata(pieceCid cid.Cid) error {
+	log.Debugw("handle.remove-metadata-for-piece", "piece-cid", pieceCid)
+
+	defer func(now time.Time) {
+		log.Debugw("handled.remove-metadata-for-piece", "took", fmt.Sprintf("%s", time.Since(now)))
+	}(time.Now())
+
+	s.Lock()
+	defer s.Unlock()
+
+	ctx := context.Background()
+
+	if err := s.db.RemoveMetadata(ctx, pieceCid); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Remove all MultiHashes for pieceCID. To be used manually in case of failure
+// in RemoveDealForPiece
+func (s *Store) RemoveAllMultiHashes(pieceCid cid.Cid) error {
+	log.Debugw("handle.remove-multihashes-for-piece", "piece-cid", pieceCid)
+
+	defer func(now time.Time) {
+		log.Debugw("handled.remove-multihashes-for-piece", "took", fmt.Sprintf("%s", time.Since(now)))
+	}(time.Now())
+
+	s.Lock()
+	defer s.Unlock()
+
+	ctx := context.Background()
+
+	md, err := s.db.GetPieceCidToMetadata(ctx, pieceCid)
+	if err != nil {
+		return err
+	}
+
+	if err := s.db.RemoveAllRecords(ctx, md.Cursor); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/extern/boostd-data/svc/svc_test.go
+++ b/extern/boostd-data/svc/svc_test.go
@@ -151,6 +151,161 @@ func TestLdbService(t *testing.T) {
 	cleanup()
 }
 
+func TestLdbRemoveService(t *testing.T) {
+	addr, cleanup, err := Setup("ldb")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cl, err := client.NewStore("http://" + addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sampleidx := "fixtures/baga6ea4seaqnfhocd544oidrgsss2ahoaomvxuaqxfmlsizljtzsuivjl5hamka.full.idx"
+
+	pieceCid, err := cid.Parse("baga6ea4seaqnfhocd544oidrgsss2ahoaomvxuaqxfmlsizljtzsuivjl5hamka")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	subject, err := loadIndex(sampleidx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	records, err := getRecords(subject)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	randomuuid := uuid.New()
+
+	err = cl.AddIndex(pieceCid, records)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	di := model.DealInfo{
+		DealUuid:    randomuuid,
+		SectorID:    abi.SectorNumber(1),
+		PieceOffset: 1,
+		PieceLength: 2,
+		CarLength:   3,
+	}
+
+	err = cl.AddDealForPiece(pieceCid, di)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	b, err := hex.DecodeString("1220ff63d7689e2d9567d1a90a7a68425f430137142e1fbc28fe4780b9ee8a5ef842")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mhash, err := multihash.Cast(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	offset, err := cl.GetOffset(pieceCid, mhash)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if offset != 3039040395 {
+		t.Fatal("got wrong offset")
+	}
+
+	pcids, err := cl.PiecesContaining(mhash)
+
+	if len(pcids) != 1 {
+		t.Fatalf("expected len of 1 for pieceCids, got: %d", len(pcids))
+	}
+
+	if !pcids[0].Equals(pieceCid) {
+		t.Fatal("expected for pieceCids to match")
+	}
+
+	dis, err := cl.GetPieceDeals(pieceCid)
+
+	if len(dis) != 1 {
+		t.Fatalf("expected len of 1 for dis, got: %d", len(dis))
+	}
+
+	if dis[0] != di {
+		t.Fatal("expected for dealInfos to match")
+	}
+
+	indexed, err := cl.IsIndexed(pieceCid)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !indexed {
+		t.Fatal("expected pieceCid to be indexed")
+	}
+
+	recs, err := cl.GetRecords(pieceCid)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(recs) == 0 {
+		t.Fatal("expected to get records back from GetIndex")
+	}
+
+	loadedSubject, err := cl.GetIndex(pieceCid)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ok, err := compareIndices(subject, loadedSubject)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		log.Fatal("compare failed")
+	}
+
+	err = cl.RemoveDeal(pieceCid, di.DealUuid)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	loadedSubject, err = cl.GetIndex(pieceCid)
+	if loadedSubject != nil {
+		log.Fatal(err)
+	}
+
+	recs, err = cl.GetRecords(pieceCid)
+	if recs != nil {
+		log.Fatal(err)
+	}
+	//require.ErrorContains(t, err, "key not found")
+	//require.Empty(t, recs)
+
+	indexed, err = cl.IsIndexed(pieceCid)
+	if indexed != false {
+		log.Fatal(err)
+	}
+	//require.ErrorContains(t, err, "key not found")
+	//require.Empty(t, indexed)
+
+	dis, err = cl.GetPieceDeals(pieceCid)
+	if dis != nil {
+		log.Fatal(err)
+	}
+	//require.Contains(t, err, "key not found")
+	//require.Empty(t, dis)
+
+	log.Debug("sleeping for a while.. running tests..")
+
+	cleanup()
+
+}
+
 func setupService(t *testing.T, db string) (string, func()) {
 	addr := "localhost:0"
 	ln, err := net.Listen("tcp", addr)


### PR DESCRIPTION
This PR adds metadata removal in the piecemeta store. These can be used to clean up the piecemeta store after deal/sector expiration.

This PR only adds the functions to the leveldb side. Some implementations are still left in couchbase side(will need a separate PR). 