### PR TITLE
Add block filter via BadBits

### DIFF
--- a/cmd/booster-bitswap/blockfilter/blockfilter.go
+++ b/cmd/booster-bitswap/blockfilter/blockfilter.go
@@ -1,0 +1,190 @@
+package blockfilter
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/benbjohnson/clock"
+	"github.com/ipfs/go-cid"
+	logging "github.com/ipfs/go-log/v2"
+	"github.com/multiformats/go-multibase"
+)
+
+var log = logging.Logger("booster-bitswap")
+
+// BadBitsDenyList is the URL for well known bad bits list
+const BadBitsDenyList string = "https://badbits.dwebops.pub/denylist.json"
+
+// UpdateInterval is the default interval at which the public list is refected and updated
+const UpdateInterval = 5 * time.Minute
+
+// DenyListFetcher is a function that returns a readable stream formatted in the json style of the BadBits list
+type DenyListFetcher func() (io.ReadCloser, error)
+
+const expectedListGrowth = 128
+
+// FetchBadBitsList is the default function used to get the BadBits list
+func FetchBadBitsList() (io.ReadCloser, error) {
+	response, err := http.DefaultClient.Get(BadBitsDenyList)
+	if err != nil {
+		return nil, err
+	}
+	if response.StatusCode < 200 && response.StatusCode > 299 {
+		return nil, errors.New("http status code was not success")
+	}
+	return response.Body, nil
+}
+
+// BlockFilter manages updating a deny list and checking for CID inclusion in that list
+type BlockFilter struct {
+	denyListFetcher  DenyListFetcher
+	filteredHashesLk sync.RWMutex
+	filteredHashes   map[string]struct{}
+	ctx              context.Context
+	cancel           context.CancelFunc
+	clock            clock.Clock
+	onTimerSet       func()
+}
+
+func newBlockFilter(denyListFetcher DenyListFetcher, clock clock.Clock, onTimerSet func()) *BlockFilter {
+	return &BlockFilter{
+		denyListFetcher: denyListFetcher,
+		filteredHashes:  make(map[string]struct{}),
+		clock:           clock,
+		onTimerSet:      onTimerSet,
+	}
+}
+
+// NewBlockFilter returns a block filter
+func NewBlockFilter() *BlockFilter {
+	return newBlockFilter(FetchBadBitsList, clock.New(), nil)
+}
+
+// Start initializes asynchronous updates to the deny list filter
+// It blocks to confirm at least one synchronous update of the denylist
+func (bf *BlockFilter) Start(ctx context.Context) {
+	bf.ctx, bf.cancel = context.WithCancel(ctx)
+	bf.updateDenyList()
+	go bf.run()
+}
+
+// Close shuts down asynchronous updating
+func (bf *BlockFilter) Close() {
+	bf.cancel()
+}
+
+// IsFiltered checks if a given CID is in the deny list, per the rules
+// of hashing cids (convert to base32, add "/" to path, then sha256 hash)
+func (bf *BlockFilter) IsFiltered(c cid.Cid) (bool, error) {
+	// convert CIDv0 to CIDv1
+	if c.Version() == 0 {
+		c = cid.NewCidV1(cid.DagProtobuf, c.Hash())
+	}
+	// get base32 string
+	cidStr, err := c.StringOfBase(multibase.Base32)
+	if err != nil {
+		return false, err
+	}
+	// add "/"
+	cidStr += "/"
+	// sha256 sum the bytes
+	shaBytes := sha256.Sum256([]byte(cidStr))
+	// encode to a hex string
+	shaString := hex.EncodeToString(shaBytes[:])
+
+	// check for set inclusion
+	bf.filteredHashesLk.RLock()
+	_, has := bf.filteredHashes[shaString]
+	bf.filteredHashesLk.RUnlock()
+	return has, nil
+}
+
+// fetch deny list fetches and parses a deny list to get a new set of filtered hashes
+// it uses streaming JSON decoding to avoid an intermediate copy of the entire response
+// lenSuggestion is used to avoid a large number of allocations as the list grows
+func (bf *BlockFilter) fetchDenyList(lenSuggestion int) (map[string]struct{}, error) {
+	// first fetch the reading for the deny list
+	denyListStream, err := bf.denyListFetcher()
+	if err != nil {
+		return nil, fmt.Errorf("unable to fetch deny list: %w", err)
+	}
+	defer denyListStream.Close()
+	type blockedCid struct {
+		Anchor string `json:"anchor"`
+	}
+	// initialize a json decoder
+	jsonDenyList := json.NewDecoder(denyListStream)
+
+	// read open bracket
+	_, err = jsonDenyList.Token()
+	if err != nil {
+		return nil, fmt.Errorf("parsing denylist: %w", err)
+	}
+
+	filteredHashes := make(map[string]struct{}, lenSuggestion)
+	// while the array contains values
+	for jsonDenyList.More() {
+		var b blockedCid
+		// decode an array value (Message)
+		err = jsonDenyList.Decode(&b)
+		if err != nil {
+			return nil, fmt.Errorf("parsing denylist: %w", err)
+		}
+		// save it in the filtered hash set
+		filteredHashes[b.Anchor] = struct{}{}
+	}
+
+	// read closing bracket
+	_, err = jsonDenyList.Token()
+	if err != nil {
+		return nil, fmt.Errorf("parsing denylist: %w", err)
+	}
+
+	return filteredHashes, nil
+}
+
+// updateDenyList replaces the current filtered hashes after successfully
+// fetching and parsing the latest deny list
+func (bf *BlockFilter) updateDenyList() {
+	filteredHashes, err := bf.fetchDenyList(len(bf.filteredHashes) + expectedListGrowth)
+	if err != nil {
+		log.Errorf("updating deny list: %s", err)
+		return
+	}
+	bf.filteredHashesLk.Lock()
+	bf.filteredHashes = filteredHashes
+	bf.filteredHashesLk.Unlock()
+}
+
+// run periodically updates the deny list asynchronously
+func (bf *BlockFilter) run() {
+	updater := bf.clock.Timer(UpdateInterval)
+	// call the callback if set
+	if bf.onTimerSet != nil {
+		bf.onTimerSet()
+	}
+	for {
+		select {
+		case <-bf.ctx.Done():
+			return
+		case <-updater.C:
+			// when timer expires, update deny list
+			bf.updateDenyList()
+
+			// then reset the timer
+			updater.Reset(UpdateInterval)
+			// call the callback if set
+			if bf.onTimerSet != nil {
+				bf.onTimerSet()
+			}
+		}
+	}
+}

--- a/cmd/booster-bitswap/blockfilter/blockfilter.go
+++ b/cmd/booster-bitswap/blockfilter/blockfilter.go
@@ -97,7 +97,7 @@ func (bf *BlockFilter) Start(ctx context.Context) error {
 	// if the file does not exist, synchronously fetch the list
 	if err != nil {
 		if !os.IsNotExist(err) {
-			return err
+			return fmt.Errorf("fetching badbits list: %w", err)
 		}
 		bf.updateDenyList()
 	} else {

--- a/cmd/booster-bitswap/blockfilter/blockfilter_test.go
+++ b/cmd/booster-bitswap/blockfilter/blockfilter_test.go
@@ -1,0 +1,74 @@
+package blockfilter
+
+import (
+	"context"
+	"io"
+	"io/ioutil"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/benbjohnson/clock"
+	"github.com/ipfs/go-cid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBlockFilter(t *testing.T) {
+	blockedCid1, err := cid.Parse("QmWATWQ7fVPP2EFGu71UkfnqhYXDYH566qy47CnJDgvs8u")
+	require.NoError(t, err)
+	blockedCid2, err := cid.Parse("QmTn7prGSqKUd7cqvAjnULrH7zxBEBWrnj9kE7kZSGtDuQ")
+	require.NoError(t, err)
+	timerSetChan := make(chan struct{}, 1)
+	onTimerSet := func() {
+		timerSetChan <- struct{}{}
+	}
+	ff := &fakeFetcher{}
+	clock := clock.NewMock()
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	bf := newBlockFilter(ff.fetchDenyList, clock, onTimerSet)
+	bf.Start(ctx)
+	isFiltered, err := bf.IsFiltered(blockedCid1)
+	require.NoError(t, err)
+	require.True(t, isFiltered)
+	isFiltered, err = bf.IsFiltered(blockedCid2)
+	require.NoError(t, err)
+	require.False(t, isFiltered)
+	select {
+	case <-ctx.Done():
+		t.Fatal("should have updated list but didn't")
+	case <-timerSetChan:
+	}
+	clock.Add(UpdateInterval)
+	select {
+	case <-ctx.Done():
+		t.Fatal("should have updated list but didn't")
+	case <-timerSetChan:
+	}
+	isFiltered, err = bf.IsFiltered(blockedCid1)
+	require.NoError(t, err)
+	require.True(t, isFiltered)
+	isFiltered, err = bf.IsFiltered(blockedCid2)
+	require.NoError(t, err)
+	require.True(t, isFiltered)
+}
+
+type fakeFetcher struct {
+	fetchCount int
+}
+
+func (ff *fakeFetcher) fetchDenyList() (io.ReadCloser, error) {
+	denyList := `[
+		{ "anchor": "09770fe7ec3124653c1d8f6917e3cd72cbd58a3e24a734bc362f656844c4ee7d"}
+	]
+	`
+	if ff.fetchCount > 0 {
+		denyList = `[
+			{ "anchor": "09770fe7ec3124653c1d8f6917e3cd72cbd58a3e24a734bc362f656844c4ee7d"},
+			{ "anchor": "6a98dfc49e852da7eee32d7df49801cb3ae7a432aa73200cd652ba149272481a"}
+		]
+		`
+	}
+	ff.fetchCount++
+	return ioutil.NopCloser(strings.NewReader(denyList)), nil
+}

--- a/cmd/booster-bitswap/remoteblockstore/remoteblockstore.go
+++ b/cmd/booster-bitswap/remoteblockstore/remoteblockstore.go
@@ -25,12 +25,17 @@ type RemoteBlockstoreAPI interface {
 	BlockstoreGetSize(ctx context.Context, c cid.Cid) (int, error)
 }
 
+type BlockFilter interface {
+	IsFiltered(c cid.Cid) (bool, error)
+}
+
 // RemoteBlockstore is a read-only blockstore over all cids across all pieces on a provider.
 type RemoteBlockstore struct {
+	bf  BlockFilter
 	api RemoteBlockstoreAPI
 }
 
-func NewRemoteBlockstore(api RemoteBlockstoreAPI) blockstore.Blockstore {
+func NewRemoteBlockstore(api RemoteBlockstoreAPI, bf BlockFilter) blockstore.Blockstore {
 	return &RemoteBlockstore{
 		api: api,
 	}
@@ -41,6 +46,16 @@ func (ro *RemoteBlockstore) Get(ctx context.Context, c cid.Cid) (b blocks.Block,
 	defer span.End()
 	span.SetAttributes(attribute.String("cid", c.String()))
 
+	log.Debugw("IsFiltered", "cid", c)
+	filtered, err := ro.bf.IsFiltered(c)
+	log.Debugw("IsFiltered response", "cid", c, "filtered", filtered, "err", err)
+	if err != nil {
+		return nil, err
+	}
+	// treat filtered as a not found
+	if filtered {
+		return nil, format.ErrNotFound{Cid: c}
+	}
 	log.Debugw("Get", "cid", c)
 	data, err := ro.api.BlockstoreGet(ctx, c)
 	err = normalizeError(err)
@@ -56,6 +71,16 @@ func (ro *RemoteBlockstore) Has(ctx context.Context, c cid.Cid) (bool, error) {
 	defer span.End()
 	span.SetAttributes(attribute.String("cid", c.String()))
 
+	log.Debugw("IsFiltered", "cid", c)
+	filtered, err := ro.bf.IsFiltered(c)
+	log.Debugw("IsFiltered response", "cid", c, "filtered", filtered, "err", err)
+	if err != nil {
+		return false, err
+	}
+	// treat filtered as a not found
+	if filtered {
+		return false, nil
+	}
 	log.Debugw("Has", "cid", c)
 	has, err := ro.api.BlockstoreHas(ctx, c)
 	log.Debugw("Has response", "cid", c, "has", has, "error", err)
@@ -67,6 +92,16 @@ func (ro *RemoteBlockstore) GetSize(ctx context.Context, c cid.Cid) (int, error)
 	defer span.End()
 	span.SetAttributes(attribute.String("cid", c.String()))
 
+	log.Debugw("IsFiltered", "cid", c)
+	filtered, err := ro.bf.IsFiltered(c)
+	log.Debugw("IsFiltered response", "cid", c, "filtered", filtered, "err", err)
+	if err != nil {
+		return 0, err
+	}
+	// treat filtered as a not found
+	if filtered {
+		return 0, format.ErrNotFound{Cid: c}
+	}
 	log.Debugw("GetSize", "cid", c)
 	size, err := ro.api.BlockstoreGetSize(ctx, c)
 	err = normalizeError(err)

--- a/cmd/booster-bitswap/run.go
+++ b/cmd/booster-bitswap/run.go
@@ -10,6 +10,7 @@ import (
 	"github.com/filecoin-project/boost/api"
 	bclient "github.com/filecoin-project/boost/api/client"
 	cliutil "github.com/filecoin-project/boost/cli/util"
+	"github.com/filecoin-project/boost/cmd/booster-bitswap/blockfilter"
 	"github.com/filecoin-project/boost/cmd/booster-bitswap/remoteblockstore"
 	"github.com/filecoin-project/boost/tracing"
 	"github.com/filecoin-project/go-jsonrpc"
@@ -80,7 +81,9 @@ var runCmd = &cli.Command{
 		}
 		defer bcloser()
 
-		remoteStore := remoteblockstore.NewRemoteBlockstore(bapi)
+		blockFilter := blockfilter.NewBlockFilter()
+		blockFilter.Start(ctx)
+		remoteStore := remoteblockstore.NewRemoteBlockstore(bapi, blockFilter)
 		// Create the server API
 		port := cctx.Int("port")
 		repoDir := cctx.String(FlagRepo.Name)

--- a/cmd/booster-bitswap/run.go
+++ b/cmd/booster-bitswap/run.go
@@ -81,9 +81,7 @@ var runCmd = &cli.Command{
 		}
 		defer bcloser()
 
-		blockFilter := blockfilter.NewBlockFilter()
-		blockFilter.Start(ctx)
-		remoteStore := remoteblockstore.NewRemoteBlockstore(bapi, blockFilter)
+		remoteStore := remoteblockstore.NewRemoteBlockstore(bapi)
 		// Create the server API
 		port := cctx.Int("port")
 		repoDir := cctx.String(FlagRepo.Name)
@@ -92,7 +90,11 @@ var runCmd = &cli.Command{
 			return fmt.Errorf("setting up libp2p host: %w", err)
 		}
 		// Start the server
-		server := NewBitswapServer(remoteStore, host)
+
+		blockFilter := blockfilter.NewBlockFilter()
+		blockFilter.Start(ctx)
+
+		server := NewBitswapServer(remoteStore, host, blockFilter)
 
 		addrs, err := bapi.NetAddrsListen(ctx)
 		if err != nil {

--- a/cmd/booster-bitswap/run.go
+++ b/cmd/booster-bitswap/run.go
@@ -91,9 +91,11 @@ var runCmd = &cli.Command{
 		}
 		// Start the server
 
-		blockFilter := blockfilter.NewBlockFilter()
-		blockFilter.Start(ctx)
-
+		blockFilter := blockfilter.NewBlockFilter(repoDir)
+		err = blockFilter.Start(ctx)
+		if err != nil {
+			return fmt.Errorf("starting block filter: %w", err)
+		}
 		server := NewBitswapServer(remoteStore, host, blockFilter)
 
 		addrs, err := bapi.NetAddrsListen(ctx)


### PR DESCRIPTION
# Goals

Provide a mechanism for filtering out illegal CID requests in bitswap.

# Implementation

- This implements a lightweight block filter module that fetches the bad bits list and checks bitswap requests against what is in the list.
   - The list downloads and updates every five minutes in the background -- currently, it's only 1meg large
   - The in place block check is O(1) against an in memory copy of the list (currently, again, not a serious memory overhead)
- integrates the block filter into the remote blockstore in booster bitswap

# For discusion (that's why it's a draft)

- Currently, this lives inside of booster bitswap -- should it instead live inside of boost and possibly the block API calls?

- I didn't put optimization around passing If-Not-Modified as request header and checking for a 304 Not Modified response -- this may be prudent as the list updates a lot but not every five minutes

- There's no on disk cache -- this was done for simplicity but does mean you need to fetch at startup. Also, this is a blocking call currently -- maybe that's not ideal?

- What is the right way to handle fetching/parsing errors? Right now it's just log.Errorf

- blocked on #786 (currently that branch is the base for this one)