### PR TITLE
Add http response code metrics to dashboard

### DIFF
--- a/docker/monitoring/grafana/dashboards/exported_dashboard.json
+++ b/docker/monitoring/grafana/dashboards/exported_dashboard.json
@@ -198,8 +198,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -387,8 +386,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -638,8 +636,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -734,8 +731,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -831,8 +827,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -928,8 +923,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -1024,8 +1018,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -1120,8 +1113,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -1216,8 +1208,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -1445,96 +1436,6 @@
               "mode": "off"
             }
           },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "ms"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 12,
-        "x": 12,
-        "y": 11
-      },
-      "id": 5,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum(rate(booster_http_http_payload_by_cid_request_duration_ms_bucket{}[$__rate_interval])) by (le))",
-          "format": "time_series",
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Payload by CID Request Durations",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
           "displayName": "Requests/s",
           "mappings": [],
           "thresholds": {
@@ -1582,8 +1483,8 @@
       "gridPos": {
         "h": 7,
         "w": 12,
-        "x": 0,
-        "y": 18
+        "x": 12,
+        "y": 11
       },
       "id": 3,
       "options": {
@@ -1664,6 +1565,358 @@
               {
                 "color": "green",
                 "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 18
+      },
+      "id": 36,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(booster_http_http_payload_by_cid_200_response_count{}[$__rate_interval]))",
+          "legendFormat": "200 | Ok",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(booster_http_http_payload_by_cid_400_response_count{}[$__rate_interval]))",
+          "hide": false,
+          "legendFormat": "400 | Bad Request",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(booster_http_http_payload_by_cid_404_response_count{}[$__rate_interval]))",
+          "hide": false,
+          "legendFormat": "404 | Not Found",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(booster_http_http_payload_by_cid_500_response_count{}[$__rate_interval]))",
+          "hide": false,
+          "legendFormat": "500 | Internal Server Error",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "Payload by CID Status Response Counts",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 18
+      },
+      "id": 37,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(booster_http_http_piece_by_cid_200_response_count{}[$__rate_interval]))",
+          "legendFormat": "200 | Ok",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(booster_http_http_piece_by_cid_400_response_count{}[$__rate_interval]))",
+          "hide": false,
+          "legendFormat": "400 | Bad Request",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(booster_http_http_piece_by_cid_404_response_count{}[$__rate_interval]))",
+          "hide": false,
+          "legendFormat": "404 | Not Found",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(booster_http_http_piece_by_cid_500_response_count{}[$__rate_interval]))",
+          "hide": false,
+          "legendFormat": "500 | Internal Server Error",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "Piece by CID Status Response Counts",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 26
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(booster_http_http_payload_by_cid_request_duration_ms_bucket{}[$__rate_interval])) by (le))",
+          "format": "time_series",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Payload by CID Request Durations",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
               }
             ]
           },
@@ -1675,7 +1928,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 18
+        "y": 26
       },
       "id": 6,
       "options": {
@@ -1713,7 +1966,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 25
+        "y": 33
       },
       "id": 28,
       "panels": [
@@ -1779,7 +2032,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 20
+            "y": 18
           },
           "id": 26,
           "links": [],
@@ -1967,7 +2220,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 20
+            "y": 18
           },
           "id": 12,
           "links": [],
@@ -2069,7 +2322,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 28
+            "y": 26
           },
           "hiddenSeries": false,
           "id": 24,
@@ -2217,7 +2470,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 28
+            "y": 26
           },
           "id": 16,
           "links": [],
@@ -2312,7 +2565,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 36
+            "y": 34
           },
           "id": 22,
           "links": [],
@@ -2408,7 +2661,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 36
+            "y": 34
           },
           "id": 20,
           "links": [],
@@ -2504,7 +2757,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 44
+            "y": 42
           },
           "id": 18,
           "links": [],
@@ -2599,7 +2852,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 44
+            "y": 42
           },
           "id": 8,
           "links": [],
@@ -2694,7 +2947,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 52
+            "y": 50
           },
           "id": 14,
           "links": [],
@@ -2789,7 +3042,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 52
+            "y": 50
           },
           "id": 4,
           "links": [],
@@ -2827,6 +3080,7 @@
       "type": "row"
     }
   ],
+  "refresh": false,
   "schemaVersion": 37,
   "style": "dark",
   "tags": [],

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -115,10 +115,18 @@ var (
 	SplitstoreCompactionDead        = stats.Int64("splitstore/dead", "Number of dead blocks in last compaction", stats.UnitDimensionless)
 
 	// http
-	HttpPayloadByCidRequestCount    = stats.Int64("http/payload_by_cid_request_count", "Counter of /payload/<payload-cid> requests", stats.UnitDimensionless)
-	HttpPayloadByCidRequestDuration = stats.Float64("http/payload_by_cid_request_duration_ms", "Time spent retrieving a payload by cid", stats.UnitMilliseconds)
-	HttpPieceByCidRequestCount      = stats.Int64("http/piece_by_cid_request_count", "Counter of /piece/<piece-cid> requests", stats.UnitDimensionless)
-	HttpPieceByCidRequestDuration   = stats.Float64("http/piece_by_cid_request_duration_ms", "Time spent retrieving a piece by cid", stats.UnitMilliseconds)
+	HttpPayloadByCidRequestCount     = stats.Int64("http/payload_by_cid_request_count", "Counter of /payload/<payload-cid> requests", stats.UnitDimensionless)
+	HttpPayloadByCidRequestDuration  = stats.Float64("http/payload_by_cid_request_duration_ms", "Time spent retrieving a payload by cid", stats.UnitMilliseconds)
+	HttpPayloadByCid200ResponseCount = stats.Int64("http/payload_by_cid_200_response_count", "Counter of /payload/<payload-cid> 200 responses", stats.UnitDimensionless)
+	HttpPayloadByCid400ResponseCount = stats.Int64("http/payload_by_cid_400_response_count", "Counter of /payload/<payload-cid> 400 responses", stats.UnitDimensionless)
+	HttpPayloadByCid404ResponseCount = stats.Int64("http/payload_by_cid_404_response_count", "Counter of /payload/<payload-cid> 404 responses", stats.UnitDimensionless)
+	HttpPayloadByCid500ResponseCount = stats.Int64("http/payload_by_cid_500_response_count", "Counter of /payload/<payload-cid> 500 responses", stats.UnitDimensionless)
+	HttpPieceByCidRequestCount       = stats.Int64("http/piece_by_cid_request_count", "Counter of /piece/<piece-cid> requests", stats.UnitDimensionless)
+	HttpPieceByCidRequestDuration    = stats.Float64("http/piece_by_cid_request_duration_ms", "Time spent retrieving a piece by cid", stats.UnitMilliseconds)
+	HttpPieceByCid200ResponseCount   = stats.Int64("http/piece_by_cid_200_response_count", "Counter of /piece/<piece-cid> 200 responses", stats.UnitDimensionless)
+	HttpPieceByCid400ResponseCount   = stats.Int64("http/piece_by_cid_400_response_count", "Counter of /piece/<piece-cid> 400 responses", stats.UnitDimensionless)
+	HttpPieceByCid404ResponseCount   = stats.Int64("http/piece_by_cid_404_response_count", "Counter of /piece/<piece-cid> 404 responses", stats.UnitDimensionless)
+	HttpPieceByCid500ResponseCount   = stats.Int64("http/piece_by_cid_500_response_count", "Counter of /piece/<piece-cid> 500 responses", stats.UnitDimensionless)
 )
 
 var (
@@ -131,6 +139,22 @@ var (
 		Measure:     HttpPayloadByCidRequestDuration,
 		Aggregation: defaultMillisecondsDistribution,
 	}
+	HttpPayloadByCid200ResponseCountView = &view.View{
+		Measure:     HttpPayloadByCid200ResponseCount,
+		Aggregation: view.Count(),
+	}
+	HttpPayloadByCid400ResponseCountView = &view.View{
+		Measure:     HttpPayloadByCid400ResponseCount,
+		Aggregation: view.Count(),
+	}
+	HttpPayloadByCid404ResponseCountView = &view.View{
+		Measure:     HttpPayloadByCid404ResponseCount,
+		Aggregation: view.Count(),
+	}
+	HttpPayloadByCid500ResponseCountView = &view.View{
+		Measure:     HttpPayloadByCid500ResponseCount,
+		Aggregation: view.Count(),
+	}
 	HttpPieceByCidRequestCountView = &view.View{
 		Measure:     HttpPieceByCidRequestCount,
 		Aggregation: view.Count(),
@@ -138,6 +162,22 @@ var (
 	HttpPieceByCidRequestDurationView = &view.View{
 		Measure:     HttpPieceByCidRequestDuration,
 		Aggregation: defaultMillisecondsDistribution,
+	}
+	HttpPieceByCid200ResponseCountView = &view.View{
+		Measure:     HttpPieceByCid200ResponseCount,
+		Aggregation: view.Count(),
+	}
+	HttpPieceByCid400ResponseCountView = &view.View{
+		Measure:     HttpPieceByCid400ResponseCount,
+		Aggregation: view.Count(),
+	}
+	HttpPieceByCid404ResponseCountView = &view.View{
+		Measure:     HttpPieceByCid404ResponseCount,
+		Aggregation: view.Count(),
+	}
+	HttpPieceByCid500ResponseCountView = &view.View{
+		Measure:     HttpPieceByCid500ResponseCount,
+		Aggregation: view.Count(),
 	}
 
 	InfoView = &view.View{
@@ -412,8 +452,16 @@ var DefaultViews = func() []*view.View {
 		APIRequestDurationView,
 		HttpPayloadByCidRequestCountView,
 		HttpPayloadByCidRequestDurationView,
+		HttpPayloadByCid200ResponseCountView,
+		HttpPayloadByCid400ResponseCountView,
+		HttpPayloadByCid404ResponseCountView,
+		HttpPayloadByCid500ResponseCountView,
 		HttpPieceByCidRequestCountView,
 		HttpPieceByCidRequestDurationView,
+		HttpPieceByCid200ResponseCountView,
+		HttpPieceByCid400ResponseCountView,
+		HttpPieceByCid404ResponseCountView,
+		HttpPieceByCid500ResponseCountView,
 	}
 	//views = append(views, blockstore.DefaultViews...)
 	views = append(views, rpcmetrics.DefaultViews...)


### PR DESCRIPTION
Adds metrics for booster-http response codes counts for both Payload by Cid and Piece by Cid to the monitoring Grafana dashboard. Adds counts for 200, 400, 404, and 500 status codes over 30 second intervals.
  - Payload by CID Status Response Counts
  - Piece by CID Status Response Counts

![2022-09-22_00-50-55](https://user-images.githubusercontent.com/3432646/191690568-4bd11330-019a-4b0b-a237-72f773968e02.png)

Updates #824