### PR TITLE
Add prometheus scrape config for lotus-miner

### DIFF
--- a/docker/devnet/docker-compose.yaml
+++ b/docker/devnet/docker-compose.yaml
@@ -29,8 +29,8 @@ services:
   lotus-miner:
     container_name: lotus-miner
     image: ${LOTUS_MINER_IMAGE}
-    # ports:
-    #   - "2345:2345"
+    ports:
+      - "2345:2345"
     environment:
       - LOTUS_API_LISTENADDRESS=/dns/lotus-miner/tcp/2345/http
       - LOTUS_API_REMOTELISTENADDRESS=lotus-miner:2345

--- a/docker/monitoring/prometheus.yaml
+++ b/docker/monitoring/prometheus.yaml
@@ -15,3 +15,6 @@ scrape_configs:
   - job_name: 'booster-http'
     static_configs:
       - targets: [ 'booster-http:7777' ]
+  - job_name: 'lotus-miner'
+    static_configs:
+      - targets: [ 'lotus-miner:2345' ]


### PR DESCRIPTION
Adds a prometheus scrape configuration for the lotus-miner devnet container so that we can visualize any lotus-miner metrics in the monitoring Grafana dashboard.