### PR TITLE
Allow building docker from Mac M1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,6 +196,7 @@ docsgen-openrpc-boost: docsgen-openrpc-bin
 docker_user?=filecoin
 lotus_version?=1.17.1-rc2
 lotus_src_dir?=
+ffi_from_source?=0
  
 ifeq ($(lotus_src_dir),)
     lotus_src_dir=/tmp/lotus-$(lotus_version)
@@ -205,7 +206,8 @@ else
     lotus_checkout_dir=
 endif
 lotus_test_image=$(docker_user)/lotus-test:$(lotus_version)
-docker_build_cmd=docker build --build-arg LOTUS_TEST_IMAGE=$(lotus_test_image) $(docker_args)
+docker_build_cmd=docker build --build-arg LOTUS_TEST_IMAGE=$(lotus_test_image) \
+	--build-arg FFI_BUILD_FROM_SOURCE=$(ffi_from_source) $(docker_args)
 
 ### lotus test docker image
 info/lotus-test:

--- a/docker/devnet/boost/Dockerfile.source
+++ b/docker/devnet/boost/Dockerfile.source
@@ -27,9 +27,39 @@ RUN apt update && apt install -y \
       mesa-opencl-icd \
       ocl-icd-opencl-dev
 
+### taken from https://github.com/rust-lang/docker-rust/blob/master/1.63.0/buster/Dockerfile
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH \
+    RUST_VERSION=1.63.0
+
+RUN set -eux; \
+    dpkgArch="$(dpkg --print-architecture)"; \
+    case "${dpkgArch##*-}" in \
+        amd64) rustArch='x86_64-unknown-linux-gnu'; rustupSha256='5cc9ffd1026e82e7fb2eec2121ad71f4b0f044e88bca39207b3f6b769aaa799c' ;; \
+        armhf) rustArch='armv7-unknown-linux-gnueabihf'; rustupSha256='48c5ecfd1409da93164af20cf4ac2c6f00688b15eb6ba65047f654060c844d85' ;; \
+        arm64) rustArch='aarch64-unknown-linux-gnu'; rustupSha256='e189948e396d47254103a49c987e7fb0e5dd8e34b200aa4481ecc4b8e41fb929' ;; \
+        i386) rustArch='i686-unknown-linux-gnu'; rustupSha256='0e0be29c560ad958ba52fcf06b3ea04435cb3cd674fbe11ce7d954093b9504fd' ;; \
+        *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
+    esac; \
+    url="https://static.rust-lang.org/rustup/archive/1.25.1/${rustArch}/rustup-init"; \
+    wget "$url"; \
+    echo "${rustupSha256} *rustup-init" | sha256sum -c -; \
+    chmod +x rustup-init; \
+    ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${rustArch}; \
+    rm rustup-init; \
+    chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
+    rustup --version; \
+    cargo --version; \
+    rustc --version;
+### end rust
+
 WORKDIR /go/src/
 
 COPY Makefile /go/src/
+### make configurable filecoin-ffi build
+ARG FFI_BUILD_FROM_SOURCE=0
+ENV FFI_BUILD_FROM_SOURCE=${FFI_BUILD_FROM_SOURCE}
 ##############################################
 # prebuild filecoin-ffi
 COPY extern /go/src/extern

--- a/docker/devnet/booster-http/Dockerfile.source
+++ b/docker/devnet/booster-http/Dockerfile.source
@@ -83,7 +83,7 @@ COPY --from=builder /go/src/boostd /usr/local/bin/
 COPY --from=lotus-dev /usr/local/bin/lotus /usr/local/bin/
 COPY --from=lotus-dev /usr/local/bin/lotus-miner /usr/local/bin/
 ## Fix missing lib libhwloc.so.5
-RUN ls -1 /lib/x86_64-linux-gnu/libhwloc.so.* | head -n 1 | xargs -n1 -I {} ln -s {} /lib/x86_64-linux-gnu/libhwloc.so.5
+RUN ls -1 /lib/*/libhwloc.so.* | head -n 1 | xargs -n1 -I {} ln -s {} /lib/libhwloc.so.5
 
 COPY docker/devnet/booster-http/entrypoint.sh /app/
 

--- a/docker/devnet/booster-http/Dockerfile.source
+++ b/docker/devnet/booster-http/Dockerfile.source
@@ -18,10 +18,41 @@ RUN apt update && apt install -y \
       mesa-opencl-icd \
       ocl-icd-opencl-dev
 
+### taken from https://github.com/rust-lang/docker-rust/blob/master/1.63.0/buster/Dockerfile
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH \
+    RUST_VERSION=1.63.0
+
+RUN set -eux; \
+    dpkgArch="$(dpkg --print-architecture)"; \
+    case "${dpkgArch##*-}" in \
+        amd64) rustArch='x86_64-unknown-linux-gnu'; rustupSha256='5cc9ffd1026e82e7fb2eec2121ad71f4b0f044e88bca39207b3f6b769aaa799c' ;; \
+        armhf) rustArch='armv7-unknown-linux-gnueabihf'; rustupSha256='48c5ecfd1409da93164af20cf4ac2c6f00688b15eb6ba65047f654060c844d85' ;; \
+        arm64) rustArch='aarch64-unknown-linux-gnu'; rustupSha256='e189948e396d47254103a49c987e7fb0e5dd8e34b200aa4481ecc4b8e41fb929' ;; \
+        i386) rustArch='i686-unknown-linux-gnu'; rustupSha256='0e0be29c560ad958ba52fcf06b3ea04435cb3cd674fbe11ce7d954093b9504fd' ;; \
+        *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
+    esac; \
+    url="https://static.rust-lang.org/rustup/archive/1.25.1/${rustArch}/rustup-init"; \
+    wget "$url"; \
+    echo "${rustupSha256} *rustup-init" | sha256sum -c -; \
+    chmod +x rustup-init; \
+    ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${rustArch}; \
+    rm rustup-init; \
+    chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
+    rustup --version; \
+    cargo --version; \
+    rustc --version;
+### end rust
+
 WORKDIR /go/src/
 
 # copy src
 COPY . /go/src/
+
+### make configurable filecoin-ffi build
+ARG FFI_BUILD_FROM_SOURCE=0
+ENV FFI_BUILD_FROM_SOURCE=${FFI_BUILD_FROM_SOURCE}
 
 RUN make booster-http debug
 #########################################################################################


### PR DESCRIPTION
Solves task (building docker on Mac M1) for #742.

It changes dockerfiles to help building **filecoin-ffi** from source:
1. adds rust compiled
2. allows to configure FFI_BUILD_FROM_SOURCE

The complete solution depends on: https://github.com/filecoin-project/lotus/pull/9363
To build images on mac M1:
1. take lotus having https://github.com/filecoin-project/lotus/pull/9363
2. `make docker/all lotus_src_dir=../lotus_with9363 ffi_from_source=1`
