### PR TITLE
Add booster-bitswap request and response count metrics to dashboard

### DIFF
--- a/cmd/booster-bitswap/server.go
+++ b/cmd/booster-bitswap/server.go
@@ -3,8 +3,10 @@ package main
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"time"
 
+	"github.com/filecoin-project/boost/metrics"
 	"github.com/filecoin-project/boost/protocolproxy"
 	bsnetwork "github.com/ipfs/go-bitswap/network"
 	"github.com/ipfs/go-bitswap/server"
@@ -73,6 +75,14 @@ func (s *BitswapServer) Start(ctx context.Context, proxy *peer.AddrInfo) error {
 		go s.keepProxyConnectionAlive(s.ctx, *proxy)
 		log.Infow("with proxy", "multiaddrs", proxy.Addrs, "peerId", proxy.ID)
 	}
+
+	// Start the metrics web server
+	http.Handle("/metrics", metrics.Exporter("booster_bitswap")) // metrics server
+	go func() {
+		if err := http.ListenAndServe("0.0.0.0:1234", nil); err != nil {
+			log.Errorf("could not start prometheus metric exporter server: %s", err)
+		}
+	}()
 
 	return nil
 }

--- a/cmd/booster-bitswap/server.go
+++ b/cmd/booster-bitswap/server.go
@@ -3,10 +3,8 @@ package main
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"time"
 
-	"github.com/filecoin-project/boost/metrics"
 	"github.com/filecoin-project/boost/protocolproxy"
 	bsnetwork "github.com/ipfs/go-bitswap/network"
 	"github.com/ipfs/go-bitswap/server"
@@ -75,14 +73,6 @@ func (s *BitswapServer) Start(ctx context.Context, proxy *peer.AddrInfo) error {
 		go s.keepProxyConnectionAlive(s.ctx, *proxy)
 		log.Infow("with proxy", "multiaddrs", proxy.Addrs, "peerId", proxy.ID)
 	}
-
-	// Start the metrics web server
-	http.Handle("/metrics", metrics.Exporter("booster_bitswap")) // metrics server
-	go func() {
-		if err := http.ListenAndServe("0.0.0.0:1234", nil); err != nil {
-			log.Errorf("could not start prometheus metric exporter server: %s", err)
-		}
-	}()
 
 	return nil
 }

--- a/docker/monitoring/prometheus.yaml
+++ b/docker/monitoring/prometheus.yaml
@@ -15,6 +15,9 @@ scrape_configs:
   - job_name: 'booster-http'
     static_configs:
       - targets: [ 'booster-http:7777' ]
+  - job_name: 'booster-bitswap'
+    static_configs:
+      - targets: [ 'booster-bitswap:1234' ]
   - job_name: 'lotus-miner'
     metrics_path: "/debug/metrics"
     static_configs:

--- a/docker/monitoring/prometheus.yaml
+++ b/docker/monitoring/prometheus.yaml
@@ -17,7 +17,7 @@ scrape_configs:
       - targets: [ 'booster-http:7777' ]
   - job_name: 'booster-bitswap'
     static_configs:
-      - targets: [ 'booster-bitswap:1234' ]
+      - targets: [ 'booster-bitswap:9696' ]
   - job_name: 'lotus-miner'
     metrics_path: "/debug/metrics"
     static_configs:

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -128,6 +128,17 @@ var (
 	HttpPieceByCid400ResponseCount   = stats.Int64("http/piece_by_cid_400_response_count", "Counter of /piece/<piece-cid> 400 responses", stats.UnitDimensionless)
 	HttpPieceByCid404ResponseCount   = stats.Int64("http/piece_by_cid_404_response_count", "Counter of /piece/<piece-cid> 404 responses", stats.UnitDimensionless)
 	HttpPieceByCid500ResponseCount   = stats.Int64("http/piece_by_cid_500_response_count", "Counter of /piece/<piece-cid> 500 responses", stats.UnitDimensionless)
+
+	// bitswap
+	BitswapRblsGetRequestCount             = stats.Int64("bitswap/rbls_get_request_count", "Counter of RemoteBlockstore Get requests", stats.UnitDimensionless)
+	BitswapRblsGetSuccessResponseCount     = stats.Int64("bitswap/rbls_get_success_response_count", "Counter of successful RemoteBlockstore Get responses", stats.UnitDimensionless)
+	BitswapRblsGetFailResponseCount        = stats.Int64("bitswap/rbls_get_fail_response_count", "Counter of failed RemoteBlockstore Get responses", stats.UnitDimensionless)
+	BitswapRblsGetSizeRequestCount         = stats.Int64("bitswap/rbls_getsize_request_count", "Counter of RemoteBlockstore GetSize requests", stats.UnitDimensionless)
+	BitswapRblsGetSizeSuccessResponseCount = stats.Int64("bitswap/rbls_getsize_success_response_count", "Counter of successful RemoteBlockstore GetSize responses", stats.UnitDimensionless)
+	BitswapRblsGetSizeFailResponseCount    = stats.Int64("bitswap/rbls_getsize_fail_response_count", "Counter of failed RemoteBlockstore GetSize responses", stats.UnitDimensionless)
+	BitswapRblsHasRequestCount             = stats.Int64("bitswap/rbls_has_request_count", "Counter of RemoteBlockstore Has requests", stats.UnitDimensionless)
+	BitswapRblsHasSuccessResponseCount     = stats.Int64("bitswap/rbls_has_success_response_count", "Counter of successful RemoteBlockstore Has responses", stats.UnitDimensionless)
+	BitswapRblsHasFailResponseCount        = stats.Int64("bitswap/rbls_has_fail_response_count", "Counter of failed RemoteBlockstore Has responses", stats.UnitDimensionless)
 )
 
 var (
@@ -178,6 +189,44 @@ var (
 	}
 	HttpPieceByCid500ResponseCountView = &view.View{
 		Measure:     HttpPieceByCid500ResponseCount,
+		Aggregation: view.Count(),
+	}
+
+	// bitswap
+	BitswapRblsGetRequestCountView = &view.View{
+		Measure:     BitswapRblsGetRequestCount,
+		Aggregation: view.Count(),
+	}
+	BitswapRblsGetSuccessResponseCountView = &view.View{
+		Measure:     BitswapRblsGetSuccessResponseCount,
+		Aggregation: view.Count(),
+	}
+	BitswapRblsGetFailResponseCountView = &view.View{
+		Measure:     BitswapRblsGetFailResponseCount,
+		Aggregation: view.Count(),
+	}
+	BitswapRblsGetSizeRequestCountView = &view.View{
+		Measure:     BitswapRblsGetSizeRequestCount,
+		Aggregation: view.Count(),
+	}
+	BitswapRblsGetSizeSuccessResponseCountView = &view.View{
+		Measure:     BitswapRblsGetSizeSuccessResponseCount,
+		Aggregation: view.Count(),
+	}
+	BitswapRblsGetSizeFailResponseCountView = &view.View{
+		Measure:     BitswapRblsGetSizeFailResponseCount,
+		Aggregation: view.Count(),
+	}
+	BitswapRblsHasRequestCountView = &view.View{
+		Measure:     BitswapRblsHasRequestCount,
+		Aggregation: view.Count(),
+	}
+	BitswapRblsHasSuccessResponseCountView = &view.View{
+		Measure:     BitswapRblsHasSuccessResponseCount,
+		Aggregation: view.Count(),
+	}
+	BitswapRblsHasFailResponseCountView = &view.View{
+		Measure:     BitswapRblsHasFailResponseCount,
 		Aggregation: view.Count(),
 	}
 
@@ -463,6 +512,15 @@ var DefaultViews = func() []*view.View {
 		HttpPieceByCid400ResponseCountView,
 		HttpPieceByCid404ResponseCountView,
 		HttpPieceByCid500ResponseCountView,
+		BitswapRblsGetRequestCountView,
+		BitswapRblsGetSuccessResponseCountView,
+		BitswapRblsGetFailResponseCountView,
+		BitswapRblsGetSizeRequestCountView,
+		BitswapRblsGetSizeSuccessResponseCountView,
+		BitswapRblsGetSizeFailResponseCountView,
+		BitswapRblsHasRequestCountView,
+		BitswapRblsHasSuccessResponseCountView,
+		BitswapRblsHasFailResponseCountView,
 		lotusmetrics.DagStorePRBytesDiscardedView,
 		lotusmetrics.DagStorePRBytesRequestedView,
 		lotusmetrics.DagStorePRDiscardCountView,


### PR DESCRIPTION
Setups the metrics infrastructure and adds metrics for booster-bitswap request and response counts for the `RemoteBlockstore` `Get`, `Has`, and `GetSize` functions to the monitoring Grafana dashboard. Adds counts for requests, and both success and fail responses. All counts show results over a 30 second interval.

#### Code Changes
- Adds metrics webserver on booster-bitswap server `Start` to `0.0.0.0:1234`
- Adds prometheus scrape job to scrape booster-bitswap `/metrics` endpoint
- Records request counts, success, and fail response counts for `RemoteBlockstore` `Get`, `Has`, and `GetSize`

#### Dashboard Changes
- Adds request counts for `RemoteBlockstore` `Get`, `Has`, and `GetSize`
- Adds response counts for `RemoteBlockstore` `Get`, `Has`, and `GetSize`
- Adds an overall Bitswap Success / Failure rate that encompasses all `Get`, `Has`, and `GetSize` function requests and responses
- Adds individual Success / Failure rate for each `RemoteBlockstore` `Get`, `Has`, and `GetSize` function

![2022-09-27_01-38-30](https://user-images.githubusercontent.com/3432646/192477137-911fcf3d-1429-474f-9f02-27d4498bbb7e.png)

