### PR TITLE
Announce Bitswap records to indexer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/filecoin-project/go-data-transfer v1.15.2
 	github.com/filecoin-project/go-fil-commcid v0.1.0
 	github.com/filecoin-project/go-fil-commp-hashhash v0.1.0
-	github.com/filecoin-project/go-fil-markets v1.24.1-0.20220901222600-b1b44b266c47
+	github.com/filecoin-project/go-fil-markets v1.24.1-0.20220927222333-c1ee492b2c3a
 	github.com/filecoin-project/go-jsonrpc v0.1.7
 	github.com/filecoin-project/go-legs v0.4.9
 	github.com/filecoin-project/go-padreader v0.0.1

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/filecoin-project/go-data-transfer v1.15.2
 	github.com/filecoin-project/go-fil-commcid v0.1.0
 	github.com/filecoin-project/go-fil-commp-hashhash v0.1.0
-	github.com/filecoin-project/go-fil-markets v1.24.1-0.20220927222333-c1ee492b2c3a
+	github.com/filecoin-project/go-fil-markets v1.24.2
 	github.com/filecoin-project/go-jsonrpc v0.1.7
 	github.com/filecoin-project/go-legs v0.4.9
 	github.com/filecoin-project/go-padreader v0.0.1

--- a/go.sum
+++ b/go.sum
@@ -342,8 +342,8 @@ github.com/filecoin-project/go-fil-commcid v0.1.0 h1:3R4ds1A9r6cr8mvZBfMYxTS88Oq
 github.com/filecoin-project/go-fil-commcid v0.1.0/go.mod h1:Eaox7Hvus1JgPrL5+M3+h7aSPHc0cVqpSxA+TxIEpZQ=
 github.com/filecoin-project/go-fil-commp-hashhash v0.1.0 h1:imrrpZWEHRnNqqv0tN7LXep5bFEVOVmQWHJvl2mgsGo=
 github.com/filecoin-project/go-fil-commp-hashhash v0.1.0/go.mod h1:73S8WSEWh9vr0fDJVnKADhfIv/d6dCbAGaAGWbdJEI8=
-github.com/filecoin-project/go-fil-markets v1.24.1-0.20220901222600-b1b44b266c47 h1:AJyJxg87ErVBB5QRrBgnuAp5zMbHNZUgTd9gRF/QiiY=
-github.com/filecoin-project/go-fil-markets v1.24.1-0.20220901222600-b1b44b266c47/go.mod h1:ZOPAjEUia7H60F7p0kEupi0FR7Hy4Zfz90BpR1TMBwI=
+github.com/filecoin-project/go-fil-markets v1.24.1-0.20220927222333-c1ee492b2c3a h1:7HjaU1FSsTO3Av2/HCGuho5895fUakYXlnGdlxCDjtg=
+github.com/filecoin-project/go-fil-markets v1.24.1-0.20220927222333-c1ee492b2c3a/go.mod h1:PasJSEKTxThSKDH0dCl2VbjMLDUeRtLGqbGaDU7NH04=
 github.com/filecoin-project/go-hamt-ipld v0.1.5 h1:uoXrKbCQZ49OHpsTCkrThPNelC4W3LPEk0OrS/ytIBM=
 github.com/filecoin-project/go-hamt-ipld v0.1.5/go.mod h1:6Is+ONR5Cd5R6XZoCse1CWaXZc0Hdb/JeX+EQCQzX24=
 github.com/filecoin-project/go-hamt-ipld/v2 v2.0.0 h1:b3UDemBYN2HNfk3KOXNuxgTTxlWi3xVvbQP0IT38fvM=

--- a/go.sum
+++ b/go.sum
@@ -342,8 +342,8 @@ github.com/filecoin-project/go-fil-commcid v0.1.0 h1:3R4ds1A9r6cr8mvZBfMYxTS88Oq
 github.com/filecoin-project/go-fil-commcid v0.1.0/go.mod h1:Eaox7Hvus1JgPrL5+M3+h7aSPHc0cVqpSxA+TxIEpZQ=
 github.com/filecoin-project/go-fil-commp-hashhash v0.1.0 h1:imrrpZWEHRnNqqv0tN7LXep5bFEVOVmQWHJvl2mgsGo=
 github.com/filecoin-project/go-fil-commp-hashhash v0.1.0/go.mod h1:73S8WSEWh9vr0fDJVnKADhfIv/d6dCbAGaAGWbdJEI8=
-github.com/filecoin-project/go-fil-markets v1.24.1-0.20220927222333-c1ee492b2c3a h1:7HjaU1FSsTO3Av2/HCGuho5895fUakYXlnGdlxCDjtg=
-github.com/filecoin-project/go-fil-markets v1.24.1-0.20220927222333-c1ee492b2c3a/go.mod h1:PasJSEKTxThSKDH0dCl2VbjMLDUeRtLGqbGaDU7NH04=
+github.com/filecoin-project/go-fil-markets v1.24.2 h1:vIYN2Ro3APgYCBQKCise1WeM0Q4NxOHSfUducOwMqMU=
+github.com/filecoin-project/go-fil-markets v1.24.2/go.mod h1:PasJSEKTxThSKDH0dCl2VbjMLDUeRtLGqbGaDU7NH04=
 github.com/filecoin-project/go-hamt-ipld v0.1.5 h1:uoXrKbCQZ49OHpsTCkrThPNelC4W3LPEk0OrS/ytIBM=
 github.com/filecoin-project/go-hamt-ipld v0.1.5/go.mod h1:6Is+ONR5Cd5R6XZoCse1CWaXZc0Hdb/JeX+EQCQzX24=
 github.com/filecoin-project/go-hamt-ipld/v2 v2.0.0 h1:b3UDemBYN2HNfk3KOXNuxgTTxlWi3xVvbQP0IT38fvM=

--- a/indexprovider/wrapper.go
+++ b/indexprovider/wrapper.go
@@ -108,7 +108,12 @@ func (w *Wrapper) IndexerAnnounceAllDeals(ctx context.Context) error {
 	var merr error
 
 	for _, d := range deals {
-		if d.Checkpoint >= dealcheckpoints.IndexedAndAnnounced {
+		// filter out deals that will announce automatically at a later
+		// point in their execution, as well as deals that are not processing at all
+		// (i.e. in an error state or expired)
+		// (note technically this is only one check point state IndexedAndAnnounced but is written so
+		// it will work if we ever introduce additional states between IndexedAndAnnounced & Complete)
+		if d.Checkpoint < dealcheckpoints.IndexedAndAnnounced || d.Checkpoint >= dealcheckpoints.Complete {
 			continue
 		}
 

--- a/indexprovider/wrapper.go
+++ b/indexprovider/wrapper.go
@@ -17,6 +17,7 @@ import (
 	"github.com/filecoin-project/lotus/markets/dagstore"
 	"github.com/filecoin-project/lotus/markets/idxprov"
 
+	"github.com/filecoin-project/boost/node/config"
 	"github.com/filecoin-project/boost/storagemarket/types/dealcheckpoints"
 	"github.com/hashicorp/go-multierror"
 	logging "github.com/ipfs/go-log/v2"
@@ -35,36 +36,48 @@ var shardRegMarker = ".boost-shard-registration-complete"
 var defaultDagStoreDir = "dagstore"
 
 type Wrapper struct {
-	cfg         lotus_config.DAGStoreConfig
-	enabled     bool
-	dealsDB     *db.DealsDB
-	legacyProv  lotus_storagemarket.StorageProvider
-	prov        provider.Interface
-	dagStore    *dagstore.Wrapper
-	meshCreator idxprov.MeshCreator
+	cfg            lotus_config.DAGStoreConfig
+	enabled        bool
+	dealsDB        *db.DealsDB
+	legacyProv     lotus_storagemarket.StorageProvider
+	prov           provider.Interface
+	dagStore       *dagstore.Wrapper
+	meshCreator    idxprov.MeshCreator
+	bitswapEnabled bool
 }
 
-func NewWrapper(cfg lotus_config.DAGStoreConfig) func(lc fx.Lifecycle, r repo.LockedRepo, dealsDB *db.DealsDB,
+func NewWrapper(cfg *config.Boost) func(lc fx.Lifecycle, r repo.LockedRepo, dealsDB *db.DealsDB,
 	legacyProv lotus_storagemarket.StorageProvider, prov provider.Interface, dagStore *dagstore.Wrapper,
 	meshCreator idxprov.MeshCreator) *Wrapper {
 
 	return func(lc fx.Lifecycle, r repo.LockedRepo, dealsDB *db.DealsDB,
 		legacyProv lotus_storagemarket.StorageProvider, prov provider.Interface, dagStore *dagstore.Wrapper,
 		meshCreator idxprov.MeshCreator) *Wrapper {
-		if cfg.RootDir == "" {
-			cfg.RootDir = filepath.Join(r.Path(), defaultDagStoreDir)
+		if cfg.DAGStore.RootDir == "" {
+			cfg.DAGStore.RootDir = filepath.Join(r.Path(), defaultDagStoreDir)
 		}
 
 		_, isDisabled := prov.(*DisabledIndexProvider)
-		return &Wrapper{
-			dealsDB:     dealsDB,
-			legacyProv:  legacyProv,
-			prov:        prov,
-			dagStore:    dagStore,
-			meshCreator: meshCreator,
-			cfg:         cfg,
-			enabled:     !isDisabled,
+		w := &Wrapper{
+			dealsDB:        dealsDB,
+			legacyProv:     legacyProv,
+			prov:           prov,
+			dagStore:       dagStore,
+			meshCreator:    meshCreator,
+			cfg:            cfg.DAGStore,
+			bitswapEnabled: cfg.Dealmaking.BitswapPeerID != "",
+			enabled:        !isDisabled,
 		}
+		// announce all deals on startup in case of a config change
+		lc.Append(fx.Hook{
+			OnStart: func(ctx context.Context) error {
+				go func() {
+					_ = w.IndexerAnnounceAllDeals(ctx)
+				}()
+				return nil
+			},
+		})
+		return w
 	}
 }
 
@@ -100,8 +113,11 @@ func (w *Wrapper) IndexerAnnounceAllDeals(ctx context.Context) error {
 		}
 
 		if _, err := w.AnnounceBoostDeal(ctx, d); err != nil {
-			merr = multierror.Append(merr, err)
-			log.Errorw("failed to announce boost deal to Index provider", "dealId", d.DealUuid, "err", err)
+			// don't log already advertised errors as errors - just skip them
+			if !errors.Is(err, provider.ErrAlreadyAdvertised) {
+				merr = multierror.Append(merr, err)
+				log.Errorw("failed to announce boost deal to Index provider", "dealId", d.DealUuid, "err", err)
+			}
 			continue
 		}
 		shards[d.ClientDealProposal.Proposal.PieceCID.String()] = struct{}{}
@@ -162,11 +178,18 @@ func (w *Wrapper) AnnounceBoostDeal(ctx context.Context, pds *types.ProviderDeal
 	}
 
 	// Announce deal to network Indexer
-	fm := metadata.New(&metadata.GraphsyncFilecoinV1{
-		PieceCID:      pds.ClientDealProposal.Proposal.PieceCID,
-		FastRetrieval: true,
-		VerifiedDeal:  pds.ClientDealProposal.Proposal.VerifiedDeal,
-	})
+	protocols := []metadata.Protocol{
+		&metadata.GraphsyncFilecoinV1{
+			PieceCID:      pds.ClientDealProposal.Proposal.PieceCID,
+			FastRetrieval: true,
+			VerifiedDeal:  pds.ClientDealProposal.Proposal.VerifiedDeal,
+		},
+	}
+	if w.bitswapEnabled {
+		protocols = append(protocols, metadata.Bitswap{})
+	}
+
+	fm := metadata.New(protocols...)
 
 	// ensure we have a connection with the full node host so that the index provider gossip sub announcements make their
 	// way to the filecoin bootstrapper network

--- a/node/builder.go
+++ b/node/builder.go
@@ -480,7 +480,7 @@ func ConfigBoost(cfg *config.Boost) Option {
 		// Sealing Pipeline State API
 		Override(new(sealingpipeline.API), From(new(lotus_modules.MinerStorageService))),
 
-		Override(new(*indexprovider.Wrapper), indexprovider.NewWrapper(cfg.DAGStore)),
+		Override(new(*indexprovider.Wrapper), indexprovider.NewWrapper(cfg)),
 
 		Override(new(*storagemarket.ChainDealManager), modules.NewChainDealManager),
 		Override(new(smtypes.CommpCalculator), From(new(lotus_modules.MinerStorageService))),
@@ -540,7 +540,7 @@ func ConfigBoost(cfg *config.Boost) Option {
 		Override(new(*storedask.StoredAsk), lotus_modules.NewStorageAsk),
 
 		Override(new(lotus_storagemarket.StorageProviderNode), lotus_storageadapter.NewProviderNodeAdapter(&legacyFees, &cfg.LotusDealmaking)),
-		Override(new(lotus_storagemarket.StorageProvider), lotus_modules.StorageProvider),
+		Override(new(lotus_storagemarket.StorageProvider), modules.NewLegacyStorageProvider(cfg)),
 		Override(HandleDealsKey, modules.HandleLegacyDeals),
 		Override(HandleBoostDealsKey, modules.HandleBoostDeals),
 		Override(HandleProposalLogCleanerKey, modules.HandleProposalLogCleaner(time.Duration(cfg.Dealmaking.DealProposalLogDuration))),


### PR DESCRIPTION
# Goals

When booster-bitswap is configured, announce Bitswap as a supported protocol to the indexer

# Implementation

- First, see https://github.com/filecoin-project/go-fil-markets/pull/752 - this updates go-fil-markets to support a custom metadata generation function for a given deal. It also removes treating provider.ErrAlreadyAdvertised as an error when announcing all deals
- In this PR, the indexprovider.Wrapper struct is augmented in the following ways:
   - 1. It's configured to run IndexerAnnounceAllDeals once on startup (to catch config updates)
   - 2. We no longer treat provider.ErrAlreadyAdvertised as an error when announcing all deals.
   - 3. The announcement is augmented on Bitswap if config.DealMaking.BitswapPeerID is set.
- A new constructor function for the legacy storage market provider also configures a custom metadata generator that announces legacy deals on bitswap if config.Dealmaking.BitswapPeerID is set