### PR TITLE
add metrics-path

### DIFF
--- a/docker/monitoring/prometheus.yaml
+++ b/docker/monitoring/prometheus.yaml
@@ -16,5 +16,6 @@ scrape_configs:
     static_configs:
       - targets: [ 'booster-http:7777' ]
   - job_name: 'lotus-miner'
+    metrics_path: "/debug/metrics"
     static_configs:
       - targets: [ 'lotus-miner:2345' ]


### PR DESCRIPTION
Unlike `boostd`, and `booster-http`, the metrics path for `lotus-miner` is at `/debug/metrics`:

<img width="1264" alt="Screenshot 2022-09-30 at 13 26 20" src="https://user-images.githubusercontent.com/50459/193259916-24c35744-8c5c-4d76-a2dc-fefc38265ccb.png">
