### PR TITLE
Translate all not found errors to ipld ErrNotFound for bitswap

### DIFF
--- a/cmd/booster-bitswap/remoteblockstore/remoteblockstore_test.go
+++ b/cmd/booster-bitswap/remoteblockstore/remoteblockstore_test.go
@@ -58,6 +58,16 @@ func TestNormalizeError(t *testing.T) {
 		expected:      fmt.Errorf("some err: %w", format.ErrNotFound{}),
 		isNotFoundErr: true,
 	}, {
+		name:          "block not found",
+		err:           fmt.Errorf("block not found"),
+		expected:      format.ErrNotFound{},
+		isNotFoundErr: true,
+	}, {
+		name:          "different capitalization not found",
+		err:           fmt.Errorf("block nOt FoUnd"),
+		expected:      format.ErrNotFound{},
+		isNotFoundErr: true,
+	}, {
 		name:          "different error",
 		err:           fmt.Errorf("some other err"),
 		expected:      fmt.Errorf("some other err"),
@@ -66,6 +76,11 @@ func TestNormalizeError(t *testing.T) {
 		name:          "stringified ipld ErrorNotFound with bad cid",
 		err:           fmt.Errorf(ipldNotFoundPrefix + "badcid"),
 		expected:      fmt.Errorf(ipldNotFoundPrefix + "badcid"),
+		isNotFoundErr: false,
+	}, {
+		name:          "nil error",
+		err:           nil,
+		expected:      nil,
 		isNotFoundErr: false,
 	}}
 
@@ -77,7 +92,11 @@ func TestNormalizeError(t *testing.T) {
 			} else {
 				require.False(t, format.IsNotFound(err))
 			}
-			require.Equal(t, tc.expected.Error(), err.Error())
+			if tc.err == nil {
+				require.Nil(t, err)
+			} else {
+				require.Equal(t, tc.expected.Error(), err.Error())
+			}
 		})
 	}
 }


### PR DESCRIPTION
We are seeing a lot of extraneous "not found" errors in the logs:
```
2022-10-04T16:13:59.899+0300    ERROR   engine  decision/blockstoremanager.go:99        blockstore.GetSize(QmegVFK7NszHq6BG3Lu2kKQ6YkKjyhWwaZ28i2M2mCRPQi) error: block not found
2022-10-04T16:13:59.899+0300    ERROR   engine  decision/blockstoremanager.go:99        blockstore.GetSize(bafkreiccq5bf6vm7pmnvz26hcqmkbtpayg3srhpsenq6dzy2565qjbt6wy) error: block not found
2022-10-04T16:13:59.899+0300    ERROR   engine  decision/blockstoremanager.go:99        blockstore.GetSize(bafybeicoprmqmoztnidjg4u5gqg33cz36heglyoyl6lgeznsvg5z7pdwty) error: block not found
```

This is because
- bitswap expects ipld ErrNotFound if the block is not found
- different parts of the system return different "not found" errors (eg ipld ErrNotFound, blockstore ErrNotFound)
- the error type is not preserved across the RPC boundary

This PR just checks if the error message contains the string "not found", and if so, returns it to bitswap as an ipld ErrNotFound
