### PR TITLE
Configure docker volume for fil-proofs in .env

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ docker compose down --rmi local
 
 rm -rf ./data
 
-rm -rf /var/tmp/filecoin-proof-parameters
+rm -rf ~/.cache/filecoin-proof-parameters
 ```
 
 ## License

--- a/docker/devnet/.env
+++ b/docker/devnet/.env
@@ -5,3 +5,4 @@ BOOST_IMAGE=${DOCKER_USER}/boost-dev:dev
 BOOSTER_HTTP_IMAGE=${DOCKER_USER}/booster-http-dev:dev
 BOOSTER_BITSWAP_IMAGE=${DOCKER_USER}/booster-bitswap-dev:dev
 BOOST_GUI_IMAGE=${DOCKER_USER}/boost-gui:dev
+FIL_PROOFS_PARAMETER_CACHE=${HOME}/.cache/filecoin-proof-parameters

--- a/docker/devnet/docker-compose.yaml
+++ b/docker/devnet/docker-compose.yaml
@@ -24,7 +24,7 @@ services:
     volumes:
       - ./data/lotus:/var/lib/lotus:rw
       - ./data/genesis:/var/lib/genesis:rw
-      - /var/tmp/filecoin-proof-parameters:/var/tmp/filecoin-proof-parameters:rw
+      - ${FIL_PROOFS_PARAMETER_CACHE}:/var/tmp/filecoin-proof-parameters:rw
 
   lotus-miner:
     container_name: lotus-miner
@@ -44,7 +44,7 @@ services:
       - ./data/lotus-miner:/var/lib/lotus-miner:rw
       - ./data/lotus:/var/lib/lotus:ro
       - ./data/genesis:/var/lib/genesis:ro
-      - /var/tmp/filecoin-proof-parameters:/var/tmp/filecoin-proof-parameters:rw
+      - ${FIL_PROOFS_PARAMETER_CACHE}:/var/tmp/filecoin-proof-parameters:rw
 
   boost:
     container_name: boost


### PR DESCRIPTION
Fixes for #880.

Change default host dir mapping for fil-proofs from `/var/tmp/filecoin-proof-parameters` to `~/.cache/filecoin-proof-parameters`.

The dir also was made configurable in `.env`.