### PR TITLE
Couchbase record sharding

### DIFF
--- a/extern/boostd-data/couchbase/db.go
+++ b/extern/boostd-data/couchbase/db.go
@@ -19,6 +19,10 @@ import (
 
 const bucketName = "piecestore"
 
+// The maximum length for a couchbase key is 250 bytes, but we don't need a
+// key that long, 128 bytes is more than enough
+const maxCouchKeyLen = 128
+
 // maxCasRetries is the number of times to retry an update operation when
 // there is a cas mismatch
 const maxCasRetries = 10
@@ -79,11 +83,13 @@ type DBSettings struct {
 }
 
 const connectTimeout = 5 * time.Second
+const kvTimeout = 30 * time.Second
 
 func newDB(ctx context.Context, settings DBSettings) (*DB, error) {
 	cluster, err := gocb.Connect(settings.ConnectString, gocb.ClusterOptions{
 		TimeoutsConfig: gocb.TimeoutsConfig{
 			ConnectTimeout: connectTimeout,
+			KVTimeout:      kvTimeout,
 		},
 		Authenticator: gocb.PasswordAuthenticator{
 			Username: settings.Auth.Username,
@@ -106,6 +112,10 @@ func newDB(ctx context.Context, settings DBSettings) (*DB, error) {
 				Name:       bucketName,
 				RAMQuotaMB: settings.Bucket.RAMQuotaMB,
 				BucketType: gocb.CouchbaseBucketType,
+				// The default eviction policy requires couchbase to keep all
+				// keys (and metadata) in memory. So use an eviction policy
+				// that allows keys to be stored on disk (but not in memory).
+				EvictionPolicy: gocb.EvictionPolicyTypeFull,
 			},
 		}, &gocb.CreateBucketOptions{Context: ctx})
 		if err != nil {
@@ -148,8 +158,6 @@ func (db *DB) GetPieceCidsByMultihash(ctx context.Context, mh multihash.Multihas
 		return nil, fmt.Errorf("getting piece cids by multihash %s: %w", mh, err)
 	}
 
-	//cas := getResult.Cas()
-
 	var cidStrs []string
 	err = getResult.Content(&cidStrs)
 	if err != nil {
@@ -184,27 +192,29 @@ func (db *DB) SetMultihashesToPieceCid(ctx context.Context, mhs []multihash.Mult
 		eg.Go(func() error {
 			defer func() { <-throttle }()
 
-			cbKey := toCouchKey(sprefixMhtoPieceCids + mh.String())
+			return db.withCasRetry("multihash -> pieces", func() error {
+				cbKey := toCouchKey(sprefixMhtoPieceCids + mh.String())
 
-			// Create the array
-			upsertDocResult, err := db.col.Upsert(cbKey, []int{}, &gocb.UpsertOptions{Context: ctx})
-			if err != nil {
-				return fmt.Errorf("adding multihash %s to piece %s: upsert doc: %w", mh, pieceCid, err)
-			}
+				// Create the array
+				upsertDocResult, err := db.col.Upsert(cbKey, []int{}, &gocb.UpsertOptions{Context: ctx})
+				if err != nil {
+					return fmt.Errorf("adding multihash %s to piece %s: upsert doc: %w", mh, pieceCid, err)
+				}
 
-			// Add the piece cid to the set of piece cids
-			mops := []gocb.MutateInSpec{
-				gocb.ArrayAddUniqueSpec("", pieceCid.String(), &gocb.ArrayAddUniqueSpecOptions{}),
-			}
-			_, err = db.col.MutateIn(cbKey, mops, &gocb.MutateInOptions{
-				Context: ctx,
-				Cas:     upsertDocResult.Cas(),
+				// Add the piece cid to the set of piece cids
+				mops := []gocb.MutateInSpec{
+					gocb.ArrayAddUniqueSpec("", pieceCid.String(), &gocb.ArrayAddUniqueSpecOptions{}),
+				}
+				_, err = db.col.MutateIn(cbKey, mops, &gocb.MutateInOptions{
+					Context: ctx,
+					Cas:     upsertDocResult.Cas(),
+				})
+				if err != nil {
+					return fmt.Errorf("adding multihash %s to piece %s: mutate doc: %w", mh, pieceCid, err)
+				}
+
+				return nil
 			})
-			if err != nil {
-				return fmt.Errorf("adding multihash %s to piece %s: mutate doc: %w", mh, pieceCid, err)
-			}
-
-			return nil
 		})
 	}
 
@@ -212,7 +222,7 @@ func (db *DB) SetMultihashesToPieceCid(ctx context.Context, mhs []multihash.Mult
 }
 
 // SetPieceCidToMetadata
-func (db *DB) SetPieceCidToMetadata(ctx context.Context, pieceCid cid.Cid, md model.Metadata) error {
+func (db *DB) SetPieceCidToMetadata(ctx context.Context, pieceCid cid.Cid, md CouchbaseMetadata) error {
 	ctx, span := tracing.Tracer.Start(ctx, "db.set_piece_cid_to_metadata")
 	defer span.End()
 
@@ -238,7 +248,7 @@ func (db *DB) MarkIndexErrored(ctx context.Context, pieceCid cid.Cid, idxErr err
 			return fmt.Errorf("getting piece cid to metadata for piece %s: %w", pieceCid, err)
 		}
 
-		var metadata model.Metadata
+		var metadata CouchbaseMetadata
 		err = getResult.Content(&metadata)
 		if err != nil {
 			return fmt.Errorf("getting piece cid to metadata content for piece %s: %w", pieceCid, err)
@@ -278,7 +288,7 @@ func (db *DB) AddDealForPiece(ctx context.Context, pieceCid cid.Cid, dealInfo mo
 			return fmt.Errorf("getting piece cid to metadata for piece %s: %w", pieceCid, err)
 		}
 
-		var md model.Metadata
+		var md CouchbaseMetadata
 		err = getResult.Content(&md)
 		if err != nil {
 			return fmt.Errorf("getting piece cid to metadata content for piece %s: %w", pieceCid, err)
@@ -310,7 +320,7 @@ func (db *DB) AddDealForPiece(ctx context.Context, pieceCid cid.Cid, dealInfo mo
 }
 
 // GetPieceCidToMetadata
-func (db *DB) GetPieceCidToMetadata(ctx context.Context, pieceCid cid.Cid) (model.Metadata, error) {
+func (db *DB) GetPieceCidToMetadata(ctx context.Context, pieceCid cid.Cid) (CouchbaseMetadata, error) {
 	ctx, span := tracing.Tracer.Start(ctx, "db.get_piece_cid_to_metadata")
 	defer span.End()
 
@@ -318,118 +328,45 @@ func (db *DB) GetPieceCidToMetadata(ctx context.Context, pieceCid cid.Cid) (mode
 	k := toCouchKey(sprefixPieceCidToMetadata + pieceCid.String())
 	getResult, err := db.col.Get(k, &gocb.GetOptions{Context: ctx})
 	if err != nil {
-		return model.Metadata{}, fmt.Errorf("getting piece cid to metadata for piece %s: %w", pieceCid, err)
+		return CouchbaseMetadata{}, fmt.Errorf("getting piece cid to metadata for piece %s: %w", pieceCid, err)
 	}
 
-	var metadata model.Metadata
+	var metadata CouchbaseMetadata
 	err = getResult.Content(&metadata)
 	if err != nil {
-		return model.Metadata{}, fmt.Errorf("getting piece cid to metadata content for piece %s: %w", pieceCid, err)
+		return CouchbaseMetadata{}, fmt.Errorf("getting piece cid to metadata content for piece %s: %w", pieceCid, err)
 	}
 
 	return metadata, nil
 }
 
-// AllRecords
-func (db *DB) AllRecords(ctx context.Context, pieceCid cid.Cid) ([]model.Record, error) {
-	ctx, span := tracing.Tracer.Start(ctx, "db.all_records")
-	defer span.End()
-
-	cbKey := toCouchKey(sprefixPieceCidToOffsets + pieceCid.String())
-	cbMap := db.col.Map(cbKey)
-	recMap, err := cbMap.Iterator()
-	if err != nil {
-		return nil, fmt.Errorf("getting all records for piece %s: %w", pieceCid, err)
-	}
-
-	recs := make([]model.Record, 0, len(recMap))
-	for mhStr, offsetSizeIfce := range recMap {
-		mh, err := multihash.FromHexString(mhStr)
-		if err != nil {
-			return nil, fmt.Errorf("parsing piece cid %s multihash value '%s': %w", pieceCid, mhStr, err)
-		}
-		val, ok := offsetSizeIfce.(map[string]interface{})
-		if !ok {
-			return nil, fmt.Errorf("unexpected type for piece cid %s offset/size value: %T", pieceCid, offsetSizeIfce)
-		}
-
-		offsetIfce, ok := val["o"]
-		if !ok {
-			return nil, fmt.Errorf("parsing piece %s offset value '%s': missing Offset map key", pieceCid, val)
-		}
-		offsetStr, ok := offsetIfce.(string)
-		if !ok {
-			return nil, fmt.Errorf("unexpected type for piece cid %s offset value: %T", pieceCid, offsetIfce)
-		}
-		offset, err := strconv.ParseUint(offsetStr, 10, 64)
-		if err != nil {
-			return nil, fmt.Errorf("parsing piece %s offset value '%s' as uint64: %w", pieceCid, val, err)
-		}
-
-		sizeIfce, ok := val["s"]
-		if !ok {
-			return nil, fmt.Errorf("parsing piece %s offset value '%s': missing Size map key", pieceCid, val)
-		}
-		sizeStr, ok := sizeIfce.(string)
-		if !ok {
-			return nil, fmt.Errorf("unexpected type for piece cid %s size value: %T", pieceCid, offsetIfce)
-		}
-		size, err := strconv.ParseUint(sizeStr, 10, 64)
-		if err != nil {
-			return nil, fmt.Errorf("parsing piece %s size value '%s' as uint64: %w", pieceCid, val, err)
-		}
-
-		recs = append(recs, model.Record{Cid: cid.NewCidV1(cid.Raw, mh), OffsetSize: model.OffsetSize{
-			Offset: offset,
-			Size:   size,
-		}})
-	}
-
-	return recs, nil
-}
-
-type offsetSize struct {
-	// Need to use strings instead of uint64 because uint64 may not fit into
-	// Javascript number
-	Offset string `json:"o"`
-	Size   string `json:"s"`
-}
-
-// AddIndexRecords
-func (db *DB) AddIndexRecords(ctx context.Context, pieceCid cid.Cid, recs []model.Record) error {
-	ctx, span := tracing.Tracer.Start(ctx, "db.add_index_records")
-	defer span.End()
-
-	mhToOffsetSize := make(map[string]offsetSize)
-	for _, rec := range recs {
-		mhToOffsetSize[rec.Cid.Hash().String()] = offsetSize{
-			Offset: fmt.Sprintf("%d", rec.Offset),
-			Size:   fmt.Sprintf("%d", rec.Size),
-		}
-	}
-
-	cbKey := toCouchKey(sprefixPieceCidToOffsets + pieceCid.String())
-	_, err := db.col.Upsert(cbKey, mhToOffsetSize, &gocb.UpsertOptions{Context: ctx})
-	if err != nil {
-		return fmt.Errorf("adding offset / sizes for piece %s: %w", pieceCid, err)
-	}
-
-	return nil
-}
-
-// GetOffsetSize
-func (db *DB) GetOffsetSize(ctx context.Context, pieceCid cid.Cid, m multihash.Multihash) (*model.OffsetSize, error) {
+// GetOffsetSize gets the offset and size of the multihash in the given piece.
+// Note that recordCount is needed in order to determine which shard the multihash is in.
+func (db *DB) GetOffsetSize(ctx context.Context, pieceCid cid.Cid, hash multihash.Multihash, recordCount int) (*model.OffsetSize, error) {
 	ctx, span := tracing.Tracer.Start(ctx, "db.get_offset_size")
 	defer span.End()
 
-	cbKey := toCouchKey(sprefixPieceCidToOffsets + pieceCid.String())
+	// Get the prefix for the shard that the multihash is in
+	shardPrefixBitCount, _ := getShardPrefixBitCount(recordCount)
+	mask := get2ByteMask(shardPrefixBitCount)
+	shardPrefix := hashToShardPrefix(hash, mask)
+
+	// Get the map of multihash -> offset/size.
+	// Note: This doesn't actually fetch the map, it just gets a reference to it.
+	cbKey := toCouchKey(sprefixPieceCidToOffsets + pieceCid.String() + shardPrefix)
 	cbMap := db.col.Map(cbKey)
+
+	// Get the offset/size from the map.
+	// Note: This doesn't actually fetch the map, it tells couchbase to find
+	// the key in the map on the server side, and return the value.
 	var val offsetSize
-	err := cbMap.At(m.String(), &val)
+	err := cbMap.At(hash.String(), &val)
 	if err != nil {
-		return nil, fmt.Errorf("getting offset/size for piece %s multihash %s: %w", pieceCid, m, err)
+		return nil, fmt.Errorf("getting offset/size for piece %s multihash %s: %w", pieceCid, hash, err)
 	}
 
+	// Parse the offset and size (they have to be stored as strings as they
+	// may be too large for a javascript number)
 	offset, err := strconv.ParseUint(val.Offset, 10, 64)
 	if err != nil {
 		return nil, fmt.Errorf("parsing piece %s offset value '%s' as uint64: %w", pieceCid, val, err)
@@ -440,6 +377,172 @@ func (db *DB) GetOffsetSize(ctx context.Context, pieceCid cid.Cid, m multihash.M
 	}
 
 	return &model.OffsetSize{Offset: offset, Size: size}, nil
+}
+
+// AllRecords gets all the mulithash -> offset/size mappings in a given piece.
+// Note that recordCount is needed in order to determine the shard structure.
+func (db *DB) AllRecords(ctx context.Context, pieceCid cid.Cid, recordCount int) ([]model.Record, error) {
+	ctx, span := tracing.Tracer.Start(ctx, "db.all_records")
+	defer span.End()
+
+	recs := make([]model.Record, 0, recordCount)
+
+	// Get the number of shards
+	_, totalShards := getShardPrefixBitCount(recordCount)
+	for i := 0; i < totalShards; i++ {
+		// Get the map of multihash -> offset/size for the shard
+		shardPrefix := getShardPrefix(i)
+		cbKey := toCouchKey(sprefixPieceCidToOffsets + pieceCid.String() + shardPrefix)
+		cbMap := db.col.Map(cbKey)
+		recMap, err := cbMap.Iterator()
+		if err != nil {
+			if isNotFoundErr(err) {
+				// If there are no records in a particular shard just skip the shard
+				continue
+			}
+			return nil, fmt.Errorf("getting all records for piece %s: %w", pieceCid, err)
+		}
+
+		// Get each value in the map
+		for mhStr, offsetSizeIfce := range recMap {
+			mh, err := multihash.FromHexString(mhStr)
+			if err != nil {
+				return nil, fmt.Errorf("parsing piece cid %s multihash value '%s': %w", pieceCid, mhStr, err)
+			}
+			val, ok := offsetSizeIfce.(map[string]interface{})
+			if !ok {
+				return nil, fmt.Errorf("unexpected type for piece cid %s offset/size value: %T", pieceCid, offsetSizeIfce)
+			}
+
+			offsetIfce, ok := val["o"]
+			if !ok {
+				return nil, fmt.Errorf("parsing piece %s offset value '%s': missing Offset map key", pieceCid, val)
+			}
+			offsetStr, ok := offsetIfce.(string)
+			if !ok {
+				return nil, fmt.Errorf("unexpected type for piece cid %s offset value: %T", pieceCid, offsetIfce)
+			}
+			offset, err := strconv.ParseUint(offsetStr, 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("parsing piece %s offset value '%s' as uint64: %w", pieceCid, val, err)
+			}
+
+			sizeIfce, ok := val["s"]
+			if !ok {
+				return nil, fmt.Errorf("parsing piece %s offset value '%s': missing Size map key", pieceCid, val)
+			}
+			sizeStr, ok := sizeIfce.(string)
+			if !ok {
+				return nil, fmt.Errorf("unexpected type for piece cid %s size value: %T", pieceCid, offsetIfce)
+			}
+			size, err := strconv.ParseUint(sizeStr, 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("parsing piece %s size value '%s' as uint64: %w", pieceCid, val, err)
+			}
+
+			recs = append(recs, model.Record{Cid: cid.NewCidV1(cid.Raw, mh), OffsetSize: model.OffsetSize{
+				Offset: offset,
+				Size:   size,
+			}})
+		}
+	}
+
+	return recs, nil
+}
+
+type offsetSize struct {
+	// Need to use strings instead of uint64 because uint64 may not fit into
+	// a Javascript number
+	Offset string `json:"o"`
+	Size   string `json:"s"`
+}
+
+// Couchbase has an upper limit on the size of a value: 20mb
+// A JSON-encoded map with 128k keys results in a value of about 8mb in size
+// so this is well under the 20mb limit.
+var maxRecsPerShard = 128 * 1024
+
+// Limit the number of shards to 2048. This means there is an upper limit of
+// ~270 million blocks per piece, which should be more than enough:
+// 64 Gib piece / (2048 * 128 * 1024) = 238 bytes per block
+const maxShardsPerPiece = 2048
+
+var maxRecsPerPiece = maxShardsPerPiece * maxRecsPerShard
+
+func getShardPrefixBitCount(recordCount int) (int, int) {
+	// The number of shards required to store all the keys
+	requiredShards := (recordCount / maxRecsPerShard) + 1
+	// The number of shards that will be created must be a power of 2,
+	// so get the first power of two that's >= requiredShards
+	shardPrefixBits := 0
+	totalShards := 1
+	for totalShards < requiredShards {
+		shardPrefixBits += 1
+		totalShards *= 2
+	}
+
+	return shardPrefixBits, totalShards
+}
+
+func getShardPrefix(shardIndex int) string {
+	shardPrefix := []byte{0, 0}
+	shardPrefix[1] = byte(shardIndex)
+	shardPrefix[0] = byte(shardIndex >> 8)
+	return string(shardPrefix)
+}
+
+// AddIndexRecords
+func (db *DB) AddIndexRecords(ctx context.Context, pieceCid cid.Cid, recs []model.Record) error {
+	ctx, span := tracing.Tracer.Start(ctx, "db.add_index_records")
+	defer span.End()
+
+	if len(recs) > maxRecsPerPiece {
+		return fmt.Errorf("index for piece %s too large: %d records (size limit is %d)", pieceCid, len(recs), maxRecsPerPiece)
+	}
+
+	// Get the number of bits in the shard prefix, and the total number of shards
+	shardPrefixBitCount, totalShards := getShardPrefixBitCount(len(recs))
+
+	// Initialize the multihash -> offset/size map for each shard
+	type mhToOffsetSizeMap map[string]offsetSize
+	shardMaps := make(map[string]mhToOffsetSizeMap, totalShards)
+	for i := 0; i < totalShards; i++ {
+		shardPrefix := getShardPrefix(i)
+		shardMaps[shardPrefix] = make(map[string]offsetSize)
+	}
+
+	// Create a mask of the required number of bits
+	// eg 3 bit mask = 0000 0000 0000 0111
+	mask := get2ByteMask(shardPrefixBitCount)
+
+	// For each record
+	for _, rec := range recs {
+		// Apply the bit mask to the last 2 bytes of the multihash to get the
+		// shard prefix
+		hash := rec.Cid.Hash()
+		shardPrefix := hashToShardPrefix(hash, mask)
+
+		// Add the record to the shard's map
+		shardMaps[shardPrefix][hash.String()] = offsetSize{
+			Offset: fmt.Sprintf("%d", rec.Offset),
+			Size:   fmt.Sprintf("%d", rec.Size),
+		}
+	}
+
+	// Add each shard's map to couchbase
+	for shardPrefix, shardMap := range shardMaps {
+		if len(shardMap) == 0 {
+			continue
+		}
+
+		cbKey := toCouchKey(sprefixPieceCidToOffsets + pieceCid.String() + shardPrefix)
+		_, err := db.col.Upsert(cbKey, shardMap, &gocb.UpsertOptions{Context: ctx})
+		if err != nil {
+			return fmt.Errorf("adding offset / sizes for piece %s: %w", pieceCid, err)
+		}
+	}
+
+	return nil
 }
 
 // Attempt to perform an update operation. If the operation fails due to a
@@ -467,9 +570,34 @@ func (db *DB) withCasRetry(opName string, f func() error) error {
 }
 
 func toCouchKey(key string) string {
-	return "u:" + key
+	k := "u:" + key
+	if len(k) > maxCouchKeyLen {
+		// There is usually important stuff at the beginning and end of a key,
+		// so cut out the characters in the middle
+		k = k[:maxCouchKeyLen/2] + k[len(k)-maxCouchKeyLen/2:]
+	}
+	return k
 }
 
 func isNotFoundErr(err error) bool {
 	return errors.Is(err, gocb.ErrDocumentNotFound)
+}
+
+// Create a 2 byte mask of the required number of bits
+// eg 3 bit mask = 0000 0000 0000 0111
+func get2ByteMask(bits int) [2]byte {
+	buf := [2]byte{0, 0}
+	buf[1] = (1 << bits) - 1
+	if bits >= 8 {
+		buf[0] = (1 << (bits - 8)) - 1
+	}
+	return buf
+}
+
+// Apply a mask to the last two bytes of the hash to use as the shard prefix
+func hashToShardPrefix(hash multihash.Multihash, mask [2]byte) string {
+	return string([]byte{
+		hash[len(hash)-2] & mask[0],
+		hash[len(hash)-1] & mask[1],
+	})
 }

--- a/extern/boostd-data/couchbase/db_test.go
+++ b/extern/boostd-data/couchbase/db_test.go
@@ -1,0 +1,166 @@
+package couchbase
+
+import (
+	"context"
+	"fmt"
+	"github.com/filecoin-project/boost/testutil"
+	"github.com/filecoin-project/boostd-data/model"
+	"github.com/ipfs/go-cid"
+	"github.com/ipld/go-car/v2"
+	"github.com/ipld/go-car/v2/index"
+	"github.com/multiformats/go-multihash"
+	"github.com/stretchr/testify/require"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestBitMask(t *testing.T) {
+	tcs := []struct {
+		bits     int
+		expected [2]byte
+	}{{
+		bits:     0,
+		expected: [2]byte{0, 0},
+	}, {
+		bits:     1,
+		expected: [2]byte{0, 1},
+	}, {
+		bits:     3,
+		expected: [2]byte{0, 7},
+	}, {
+		bits:     8,
+		expected: [2]byte{0, 255},
+	}, {
+		bits:     9,
+		expected: [2]byte{1, 255},
+	}, {
+		bits:     15,
+		expected: [2]byte{127, 255},
+	}, {
+		bits:     16,
+		expected: [2]byte{255, 255},
+	}}
+
+	for _, tc := range tcs {
+		t.Run(fmt.Sprintf("%d", tc.bits), func(t *testing.T) {
+			mask := get2ByteMask(tc.bits)
+			require.Equal(t, tc.expected, mask)
+		})
+	}
+}
+
+func TestGetShardPrefix(t *testing.T) {
+	tcs := []struct {
+		shardIndex int
+		expected   string
+	}{{
+		shardIndex: 0,
+		expected:   string([]byte{0, 0}),
+	}, {
+		shardIndex: 1,
+		expected:   string([]byte{0, 1}),
+	}, {
+		shardIndex: 3,
+		expected:   string([]byte{0, 3}),
+	}, {
+		shardIndex: 8,
+		expected:   string([]byte{0, 8}),
+	}, {
+		shardIndex: 256,
+		expected:   string([]byte{1, 0}),
+	}, {
+		shardIndex: 257,
+		expected:   string([]byte{1, 1}),
+	}}
+
+	for _, tc := range tcs {
+		t.Run(fmt.Sprintf("%d", tc.shardIndex), func(t *testing.T) {
+			prefix := getShardPrefix(tc.shardIndex)
+			require.Equal(t, tc.expected, prefix)
+		})
+	}
+}
+
+var testCouchSettings = DBSettings{
+	ConnectString: "couchbase://127.0.0.1",
+	Auth: DBSettingsAuth{
+		Username: "Administrator",
+		Password: "boostdemo",
+	},
+	Bucket: DBSettingsBucket{
+		RAMQuotaMB: 256,
+	},
+}
+
+func TestSharding(t *testing.T) {
+	// Skip until the tests are refactored such that we can create a couchbase
+	// instance from docker
+	t.Skip()
+
+	// Reduce the maximum records per shard such that lots of shards will be created
+	saved := maxRecsPerShard
+	maxRecsPerShard = 5
+	defer func() {
+		maxRecsPerShard = saved
+	}()
+
+	fileSize := 2 * 1024 * 1024
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Create a new couchbase db
+	db, err := newDB(context.Background(), testCouchSettings)
+	require.NoError(t, err)
+
+	// Create a CAR file
+	randomFilePath, err := testutil.CreateRandomFile(t.TempDir(), 1, fileSize)
+	require.NoError(t, err)
+	_, carFilePath, err := testutil.CreateDenseCARv2(t.TempDir(), randomFilePath)
+	require.NoError(t, err)
+	carFile, err := os.Open(carFilePath)
+	require.NoError(t, err)
+	defer carFile.Close()
+	idx, err := car.ReadOrGenerateIndex(carFile)
+	require.NoError(t, err)
+
+	// Get the records from the CAR file
+	pieceCid, err := cid.Parse("baga6ea4seaqnfhocd544oidrgsss2ahoaomvxuaqxfmlsizljtzsuivjl5hamka")
+	require.NoError(t, err)
+
+	var recs []model.Record
+	err = idx.(index.IterableIndex).ForEach(func(m multihash.Multihash, offset uint64) error {
+		cid := cid.NewCidV1(cid.Raw, m)
+
+		recs = append(recs, model.Record{
+			Cid: cid,
+			OffsetSize: model.OffsetSize{
+				Offset: offset,
+				Size:   0,
+			},
+		})
+
+		return nil
+	})
+	require.NoError(t, err)
+
+	// Add the records to the db
+	err = db.AddIndexRecords(ctx, pieceCid, recs)
+	require.NoError(t, err)
+
+	// Pick a random record and get its offset and size
+	rec := recs[len(recs)/2]
+	hash := rec.Cid.Hash()
+	offsetSize, err := db.GetOffsetSize(ctx, pieceCid, hash, len(recs))
+	require.NoError(t, err)
+	require.Equal(t, rec.Offset, offsetSize.Offset)
+	require.Equal(t, rec.Size, offsetSize.Size)
+
+	// Get all records and ensure that they are the same as the records that
+	// were put in
+	allRecs, err := db.AllRecords(ctx, pieceCid, len(recs))
+	require.NoError(t, err)
+	require.Equal(t, len(recs), len(allRecs))
+	require.ElementsMatch(t, recs, allRecs)
+}

--- a/extern/boostd-data/couchbase/db_test.go
+++ b/extern/boostd-data/couchbase/db_test.go
@@ -72,14 +72,23 @@ func TestGetShardPrefix(t *testing.T) {
 	}, {
 		shardIndex: 257,
 		expected:   string([]byte{1, 1}),
+	}, {
+		shardIndex: (1 << 16) - 1,
+		expected:   string([]byte{255, 255}),
 	}}
 
 	for _, tc := range tcs {
 		t.Run(fmt.Sprintf("%d", tc.shardIndex), func(t *testing.T) {
-			prefix := getShardPrefix(tc.shardIndex)
+			prefix, err := getShardPrefix(tc.shardIndex)
+			require.NoError(t, err)
 			require.Equal(t, tc.expected, prefix)
 		})
 	}
+
+	t.Run(fmt.Sprintf("%d", 1<<16), func(t *testing.T) {
+		_, err := getShardPrefix(1 << 16)
+		require.Error(t, err)
+	})
 }
 
 var testCouchSettings = DBSettings{

--- a/extern/boostd-data/model/model.go
+++ b/extern/boostd-data/model/model.go
@@ -15,25 +15,26 @@ import (
 // Piece          ......[            ]......
 // CAR            ......[      ]............
 type DealInfo struct {
-	DealUuid    uuid.UUID           `json:"deal_uuid"`
-	ChainDealID abi.DealID          `json:"chain_deal_id"`
-	SectorID    abi.SectorNumber    `json:"sector_id"`
-	PieceOffset abi.PaddedPieceSize `json:"piece_offset"`
-	PieceLength abi.PaddedPieceSize `json:"piece_length"`
+	DealUuid    uuid.UUID           `json:"u"`
+	ChainDealID abi.DealID          `json:"i"`
+	SectorID    abi.SectorNumber    `json:"s"`
+	PieceOffset abi.PaddedPieceSize `json:"o"`
+	PieceLength abi.PaddedPieceSize `json:"l"`
 	// The size of the CAR file without zero-padding.
 	// This value may be zero if the size is unknown.
-	CarLength uint64 `json:"car_length"`
+	CarLength uint64 `json:"c"`
 
-	// If we don't have CarLength, we have to iterate over all offsets, get the largest offset and sum it with length.
+	// If we don't have CarLength, we have to iterate over all offsets, get
+	// the largest offset and sum it with length.
 }
 
 // Metadata for PieceCid
 type Metadata struct {
-	Cursor    uint64     `json:"cursor"`
-	IndexedAt time.Time  `json:"indexed_at"`
-	Deals     []DealInfo `json:"deals"`
-	Error     string     `json:"error"`
-	ErrorType string     `json:"error_type"`
+	Cursor    uint64     `json:"c"`
+	IndexedAt time.Time  `json:"i"`
+	Deals     []DealInfo `json:"d"`
+	Error     string     `json:"e"`
+	ErrorType string     `json:"t"`
 }
 
 // Record is the information stored in the index for each block in a piece


### PR DESCRIPTION
The size of the multihash -> offset/size map is sometimes too large to fit in a couchbase value (max size 20mb)

So this PR splits the map into shards, and adds a shard prefix to the couchbase key.