### PR TITLE
migrate piece-dir - use direct connection to store

### DIFF
--- a/extern/boostd-data/client/client.go
+++ b/extern/boostd-data/client/client.go
@@ -19,6 +19,7 @@ type Store struct {
 	client struct {
 		AddDealForPiece           func(context.Context, cid.Cid, model.DealInfo) error
 		AddIndex                  func(context.Context, cid.Cid, []model.Record) error
+		IsIndexed                 func(ctx context.Context, pieceCid cid.Cid) (bool, error)
 		GetIndex                  func(context.Context, cid.Cid) ([]model.Record, error)
 		GetOffsetSize             func(context.Context, cid.Cid, mh.Multihash) (*model.OffsetSize, error)
 		GetPieceDeals             func(context.Context, cid.Cid) ([]model.DealInfo, error)
@@ -86,7 +87,7 @@ func (s *Store) GetPieceDeals(ctx context.Context, pieceCid cid.Cid) ([]model.De
 	return s.client.GetPieceDeals(ctx, pieceCid)
 }
 
-func (s *Store) PiecesContaining(ctx context.Context, m mh.Multihash) ([]cid.Cid, error) {
+func (s *Store) PiecesContainingMultihash(ctx context.Context, m mh.Multihash) ([]cid.Cid, error) {
 	return s.client.PiecesContainingMultihash(ctx, m)
 }
 
@@ -105,11 +106,7 @@ func (s *Store) AddIndex(ctx context.Context, pieceCid cid.Cid, records []model.
 }
 
 func (s *Store) IsIndexed(ctx context.Context, pieceCid cid.Cid) (bool, error) {
-	t, err := s.client.IndexedAt(ctx, pieceCid)
-	if err != nil {
-		return false, err
-	}
-	return !t.IsZero(), nil
+	return s.client.IsIndexed(ctx, pieceCid)
 }
 
 func (s *Store) IndexedAt(ctx context.Context, pieceCid cid.Cid) (time.Time, error) {

--- a/extern/boostd-data/couchbase/service.go
+++ b/extern/boostd-data/couchbase/service.go
@@ -135,6 +135,14 @@ func (s *Store) GetIndex(ctx context.Context, pieceCid cid.Cid) ([]model.Record,
 	return records, nil
 }
 
+func (s *Store) IsIndexed(ctx context.Context, pieceCid cid.Cid) (bool, error) {
+	t, err := s.IndexedAt(ctx, pieceCid)
+	if err != nil {
+		return false, err
+	}
+	return !t.IsZero(), nil
+}
+
 func (s *Store) AddIndex(ctx context.Context, pieceCid cid.Cid, records []model.Record) error {
 	log.Debugw("handle.add-index", "records", len(records))
 

--- a/extern/boostd-data/ldb/service.go
+++ b/extern/boostd-data/ldb/service.go
@@ -201,6 +201,14 @@ func (s *Store) GetIndex(ctx context.Context, pieceCid cid.Cid) ([]model.Record,
 	return records, nil
 }
 
+func (s *Store) IsIndexed(ctx context.Context, pieceCid cid.Cid) (bool, error) {
+	t, err := s.IndexedAt(ctx, pieceCid)
+	if err != nil {
+		return false, err
+	}
+	return !t.IsZero(), nil
+}
+
 func (s *Store) AddIndex(ctx context.Context, pieceCid cid.Cid, records []model.Record) error {
 	log.Debugw("handle.add-index", "records", len(records))
 

--- a/extern/boostd-data/svc/svc.go
+++ b/extern/boostd-data/svc/svc.go
@@ -31,13 +31,22 @@ func NewCouchbase(settings couchbase.DBSettings) *Service {
 
 func NewLevelDB(repoPath string) (*Service, error) {
 	if repoPath != "" { // an empty repo path is used for testing
-		repoPath = path.Join(repoPath, "piece-directory", "leveldb")
-		if err := os.MkdirAll(repoPath, os.ModePerm); err != nil {
-			return nil, fmt.Errorf("creating leveldb repo directory %s: %w", repoPath, err)
+		var err error
+		repoPath, err = MakeLevelDBDir(repoPath)
+		if err != nil {
+			return nil, err
 		}
 	}
 
 	return &Service{impl: ldb.NewStore(repoPath)}, nil
+}
+
+func MakeLevelDBDir(repoPath string) (string, error) {
+	repoPath = path.Join(repoPath, "piece-directory", "leveldb")
+	if err := os.MkdirAll(repoPath, os.ModePerm); err != nil {
+		return "", fmt.Errorf("creating leveldb repo directory %s: %w", repoPath, err)
+	}
+	return repoPath, nil
 }
 
 func (s *Service) Start(ctx context.Context) (string, error) {

--- a/extern/boostd-data/svc/svc_test.go
+++ b/extern/boostd-data/svc/svc_test.go
@@ -115,7 +115,7 @@ func testService(ctx context.Context, t *testing.T, bdsvc *Service) {
 	require.EqualValues(t, 3039040395, offset.Offset)
 	require.EqualValues(t, 0, offset.Size)
 
-	pcids, err := cl.PiecesContaining(ctx, mhash)
+	pcids, err := cl.PiecesContainingMultihash(ctx, mhash)
 	require.NoError(t, err)
 	require.Len(t, pcids, 1)
 	require.Equal(t, pieceCid, pcids[0])
@@ -232,7 +232,7 @@ func testServiceFuzz(ctx context.Context, t *testing.T, bdsvc *Service) {
 						return err
 					}
 
-					pcids, err := cl.PiecesContaining(ctx, mhash)
+					pcids, err := cl.PiecesContainingMultihash(ctx, mhash)
 					if err != nil {
 						return err
 					}

--- a/extern/boostd-data/svc/types/types.go
+++ b/extern/boostd-data/svc/types/types.go
@@ -13,6 +13,7 @@ type Service interface {
 	AddDealForPiece(context.Context, cid.Cid, model.DealInfo) error
 	AddIndex(context.Context, cid.Cid, []model.Record) error
 	GetIndex(context.Context, cid.Cid) ([]model.Record, error)
+	IsIndexed(ctx context.Context, pieceCid cid.Cid) (bool, error)
 	GetOffsetSize(context.Context, cid.Cid, mh.Multihash) (*model.OffsetSize, error)
 	GetPieceDeals(context.Context, cid.Cid) ([]model.DealInfo, error)
 	IndexedAt(context.Context, cid.Cid) (time.Time, error)

--- a/piecemeta/mocks/piecemeta.go
+++ b/piecemeta/mocks/piecemeta.go
@@ -249,7 +249,7 @@ func (mr *MockStoreMockRecorder) MarkIndexErrored(arg0, arg1, arg2 interface{}) 
 }
 
 // PiecesContaining mocks base method.
-func (m *MockStore) PiecesContaining(arg0 context.Context, arg1 multihash.Multihash) ([]cid.Cid, error) {
+func (m *MockStore) PiecesContainingMultihash(arg0 context.Context, arg1 multihash.Multihash) ([]cid.Cid, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PiecesContaining", arg0, arg1)
 	ret0, _ := ret[0].([]cid.Cid)
@@ -258,7 +258,7 @@ func (m *MockStore) PiecesContaining(arg0 context.Context, arg1 multihash.Multih
 }
 
 // PiecesContaining indicates an expected call of PiecesContaining.
-func (mr *MockStoreMockRecorder) PiecesContaining(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockStoreMockRecorder) PiecesContainingMultihash(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PiecesContaining", reflect.TypeOf((*MockStore)(nil).PiecesContaining), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PiecesContaining", reflect.TypeOf((*MockStore)(nil).PiecesContainingMultihash), arg0, arg1)
 }

--- a/piecemeta/piecemeta.go
+++ b/piecemeta/piecemeta.go
@@ -46,7 +46,7 @@ type Store interface {
 	GetIndex(ctx context.Context, pieceCid cid.Cid) (index.Index, error)
 	GetOffsetSize(ctx context.Context, pieceCid cid.Cid, hash mh.Multihash) (*model.OffsetSize, error)
 	GetPieceDeals(ctx context.Context, pieceCid cid.Cid) ([]model.DealInfo, error)
-	PiecesContaining(ctx context.Context, m mh.Multihash) ([]cid.Cid, error)
+	PiecesContainingMultihash(ctx context.Context, m mh.Multihash) ([]cid.Cid, error)
 	MarkIndexErrored(ctx context.Context, pieceCid cid.Cid, err error) error
 
 	//Delete(ctx context.Context, pieceCid cid.Cid) error
@@ -307,7 +307,7 @@ func (ps *PieceMeta) PiecesContainingMultihash(ctx context.Context, m mh.Multiha
 	ctx, span := tracing.Tracer.Start(ctx, "pm.pieces_containing_multihash")
 	defer span.End()
 
-	return ps.store.PiecesContaining(ctx, m)
+	return ps.store.PiecesContainingMultihash(ctx, m)
 }
 
 func (ps *PieceMeta) GetIterableIndex(ctx context.Context, pieceCid cid.Cid) (carindex.IterableIndex, error) {


### PR DESCRIPTION
Instead of starting up a service.
This should improve performance as calls don't need to go through the RPC interface.