### PR TITLE
fix: http redirect for /piece/ in booster-http

### DIFF
--- a/cmd/booster-http/http_test.go
+++ b/cmd/booster-http/http_test.go
@@ -75,12 +75,7 @@ func TestHttpGzipResponse(t *testing.T) {
 	mockHttpServer.EXPECT().PiecesContainingMultihash(gomock.Any(), gomock.Any()).AnyTimes().Return(cids, nil)
 	mockHttpServer.EXPECT().GetPieceInfo(gomock.Any()).AnyTimes().Return(&pieceInfo, nil)
 
-	// Create a client and make request with Encoding header
-	//client := &http.Client{
-	//	CheckRedirect: func(req *http.Request, via []*http.Request) error {
-	//		return http.ErrUseLastResponse
-	//	},
-	//}
+	//Create a client and make request with Encoding header
 	client := new(http.Client)
 	request, err := http.NewRequest("GET", "http://localhost:7777/piece?payloadCid=bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi&format=piece", nil)
 	require.NoError(t, err)
@@ -144,7 +139,7 @@ func TestHttpResponseRedirects(t *testing.T) {
 	mockHttpServer.EXPECT().PiecesContainingMultihash(gomock.Any(), gomock.Any()).AnyTimes().Return(cids, nil)
 	mockHttpServer.EXPECT().GetPieceInfo(gomock.Any()).AnyTimes().Return(&pieceInfo, nil)
 
-	//Create a client and make request with Encoding header
+	// Create a client with check against redirects
 	client := &http.Client{
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			return http.ErrUseLastResponse

--- a/cmd/booster-http/http_test.go
+++ b/cmd/booster-http/http_test.go
@@ -76,6 +76,11 @@ func TestHttpGzipResponse(t *testing.T) {
 	mockHttpServer.EXPECT().GetPieceInfo(gomock.Any()).AnyTimes().Return(&pieceInfo, nil)
 
 	// Create a client and make request with Encoding header
+	//client := &http.Client{
+	//	CheckRedirect: func(req *http.Request, via []*http.Request) error {
+	//		return http.ErrUseLastResponse
+	//	},
+	//}
 	client := new(http.Client)
 	request, err := http.NewRequest("GET", "http://localhost:7777/piece?payloadCid=bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi&format=piece", nil)
 	require.NoError(t, err)
@@ -96,6 +101,61 @@ func TestHttpGzipResponse(t *testing.T) {
 
 	// Compare bytes from original file to uncompressed http response
 	require.Equal(t, testFileBytes, out)
+
+	// Stop the server
+	err = httpServer.Stop()
+	require.NoError(t, err)
+}
+
+func TestHttpResponseRedirects(t *testing.T) {
+
+	// Create a new mock Http server with custom functions
+	ctrl := gomock.NewController(t)
+	mockHttpServer := mocks_booster_http.NewMockHttpServerApi(ctrl)
+	httpServer := NewHttpServer("", 7777, false, mockHttpServer)
+	httpServer.Start(context.Background())
+
+	// Create mock unsealed file for piece/car
+	f, _ := os.Open(testFile)
+	defer f.Close()
+
+	//Create CID
+	var cids []cid.Cid
+	cid, err := cid.Parse("bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi")
+	require.NoError(t, err)
+	cids = append(cids, cid)
+
+	// Crate pieceInfo
+	deal := piecestore.DealInfo{
+		DealID:   1234567,
+		SectorID: 0,
+		Offset:   1233,
+		Length:   123,
+	}
+	var deals []piecestore.DealInfo
+
+	pieceInfo := piecestore.PieceInfo{
+		PieceCID: cid,
+		Deals:    append(deals, deal),
+	}
+
+	mockHttpServer.EXPECT().UnsealSectorAt(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(f, nil)
+	mockHttpServer.EXPECT().IsUnsealed(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(true, nil)
+	mockHttpServer.EXPECT().PiecesContainingMultihash(gomock.Any(), gomock.Any()).AnyTimes().Return(cids, nil)
+	mockHttpServer.EXPECT().GetPieceInfo(gomock.Any()).AnyTimes().Return(&pieceInfo, nil)
+
+	//Create a client and make request with Encoding header
+	client := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	request, err := http.NewRequest("GET", "http://localhost:7777/piece?payloadCid=bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi&format=piece", nil)
+	require.NoError(t, err)
+
+	response, err := client.Do(request)
+	require.NoError(t, err)
+	require.Equal(t, 200, response.StatusCode)
 
 	// Stop the server
 	err = httpServer.Stop()

--- a/cmd/booster-http/server.go
+++ b/cmd/booster-http/server.go
@@ -67,7 +67,7 @@ func NewHttpServer(path string, port int, allowIndexing bool, api HttpServerApi)
 }
 
 func (s *HttpServer) pieceBasePath() string {
-	return s.path + "/piece/"
+	return s.path + "/piece"
 }
 
 func (s *HttpServer) Start(ctx context.Context) {


### PR DESCRIPTION
$ curl -v "http://localhost:7777/piece?payloadCid=QmbSLYv6EbbctX5MCuUR6PLxh2sCZLVg5JsUsEMy86tXD2&format=car" --output /tmp/out.car 
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 127.0.0.1:7777...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 7777 (#0)
> GET /piece?payloadCid=QmbSLYv6EbbctX5MCuUR6PLxh2sCZLVg5JsUsEMy86tXD2&format=car HTTP/1.1
> Host: localhost:7777
> User-Agent: curl/7.68.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 301 Moved Permanently
< Content-Type: text/html; charset=utf-8
< Location: /piece/?payloadCid=QmbSLYv6EbbctX5MCuUR6PLxh2sCZLVg5JsUsEMy86tXD2&format=car
< Date: Wed, 16 Nov 2022 08:45:17 GMT
< Content-Length: 115
< 

By default, mux handler removes the succeeding "/" and incorrect URL format is also served after a redirect. A strict client side check reveals the problem. 