### PR TITLE
Allow building docker from Mac M1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,9 +200,9 @@ docsgen-openrpc-boost: docsgen-openrpc-bin
 
 ## DOCKER IMAGES
 docker_user?=filecoin
-lotus_version?=1.17.2-rc2
+lotus_version?=1.19.0-rc1
 lotus_src_dir?=
-
+ffi_from_source?=0
 ifeq ($(lotus_src_dir),)
     lotus_src_dir=/tmp/lotus-$(lotus_version)
     lotus_checkout_dir=$(lotus_src_dir)
@@ -211,7 +211,8 @@ else
     lotus_checkout_dir=
 endif
 lotus_test_image=$(docker_user)/lotus-test:$(lotus_version)
-docker_build_cmd=docker build --build-arg LOTUS_TEST_IMAGE=$(lotus_test_image) $(docker_args)
+docker_build_cmd=docker build --build-arg LOTUS_TEST_IMAGE=$(lotus_test_image) \
+	--build-arg FFI_BUILD_FROM_SOURCE=$(ffi_from_source) $(docker_args)
 
 ### lotus test docker image
 info/lotus-test:

--- a/README.md
+++ b/README.md
@@ -212,6 +212,11 @@ Note also that the provider address is `t01000` and you will need to supply an a
 make docker/all
 ```
 
+On ARM-based systems (*Apple M1/M2*) you need to force building Filecoin's Rust libraries from the source
+```
+make docker/all ffi_from_source=1 
+```
+
 If you need to build containers using a specific version of lotus then provide the version as a parameter, e.g. `make docker/all lotus_version=1.17.0`. The version must be a tag name of [Lotus git repo](https://github.com/filecoin-project/lotus/tags) without `v` prefix. Or you can build using a local source of lotus - `make docker/all lotus_src_dir=<path of lotus source>`. Also, before starting devnet, you need to update versions in the [.env](docker/devnet/.env) file.
 
 ### Start devnet docker stack

--- a/docker/devnet/.env
+++ b/docker/devnet/.env
@@ -1,6 +1,6 @@
 DOCKER_USER=filecoin
-LOTUS_IMAGE=${DOCKER_USER}/lotus-dev:1.17.2-rc2
-LOTUS_MINER_IMAGE=${DOCKER_USER}/lotus-miner-dev:1.17.2-rc2
+LOTUS_IMAGE=${DOCKER_USER}/lotus-dev:1.19.0-rc1
+LOTUS_MINER_IMAGE=${DOCKER_USER}/lotus-miner-dev:1.19.0-rc1
 BOOST_IMAGE=${DOCKER_USER}/boost-dev:dev
 BOOSTER_HTTP_IMAGE=${DOCKER_USER}/booster-http-dev:dev
 BOOSTER_BITSWAP_IMAGE=${DOCKER_USER}/booster-bitswap-dev:dev

--- a/docker/devnet/Dockerfile.source
+++ b/docker/devnet/Dockerfile.source
@@ -27,9 +27,37 @@ RUN apt update && apt install -y \
       mesa-opencl-icd \
       ocl-icd-opencl-dev
 
+### taken from https://github.com/rust-lang/docker-rust/blob/master/1.63.0/buster/Dockerfile
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH \
+    RUST_VERSION=1.63.0
+
+RUN set -eux; \
+    dpkgArch="$(dpkg --print-architecture)"; \
+    case "${dpkgArch##*-}" in \
+        amd64) rustArch='x86_64-unknown-linux-gnu'; rustupSha256='5cc9ffd1026e82e7fb2eec2121ad71f4b0f044e88bca39207b3f6b769aaa799c' ;; \
+        arm64) rustArch='aarch64-unknown-linux-gnu'; rustupSha256='e189948e396d47254103a49c987e7fb0e5dd8e34b200aa4481ecc4b8e41fb929' ;; \
+        *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
+    esac; \
+    url="https://static.rust-lang.org/rustup/archive/1.25.1/${rustArch}/rustup-init"; \
+    wget "$url"; \
+    echo "${rustupSha256} *rustup-init" | sha256sum -c -; \
+    chmod +x rustup-init; \
+    ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${rustArch}; \
+    rm rustup-init; \
+    chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
+    rustup --version; \
+    cargo --version; \
+    rustc --version;
+### end rust
+
 WORKDIR /go/src/
 
 COPY Makefile /go/src/
+### make configurable filecoin-ffi build
+ARG FFI_BUILD_FROM_SOURCE=0
+ENV FFI_BUILD_FROM_SOURCE=${FFI_BUILD_FROM_SOURCE}
 ##############################################
 # prebuild filecoin-ffi
 COPY extern /go/src/extern


### PR DESCRIPTION
Solves task (building docker on Mac M1) for https://github.com/filecoin-project/boost/issues/742.

It changes dockerfiles to help build filecoin-ffi from the source:
 - adds rust compiled
 - allows configuring FFI_BUILD_FROM_SOURCE

The complete solution depends on: https://github.com/filecoin-project/lotus/pull/9363
To build images on mac M1:  `make docker/all ffi_from_source=1`