### PR TITLE
Add meaningful default for start-epoch

### DIFF
--- a/cmd/boost/deal_cmd.go
+++ b/cmd/boost/deal_cmd.go
@@ -56,6 +56,7 @@ var dealFlags = []cli.Flag{
 	&cli.IntFlag{
 		Name:  "start-epoch",
 		Usage: "start epoch by when the deal should be proved by provider on-chain",
+		DefaultText: "current chain head + 2 days",
 	},
 	&cli.IntFlag{
 		Name:  "duration",


### PR DESCRIPTION
The current help output for `boost deal` gives confusing default value for start-epoch because no Value is specified and the Int type defaults to 0:

```
--start-epoch value          start epoch by when the deal should be proved by provider on-chain (default: 0)
```

This does not explain the mechanics of this flag or what the default behavior actually is. This PR adjusts the output to explain what happens:

```
--start-epoch value          start epoch by when the deal should be proved by provider on-chain (default: current chain head + 2 days)
```

IMO this is still a weird behavior as you are far more likely to want a relative time than absolute epoch value for the deadline, which currently requires making an out-of-band call to either lotus API or a boostd graphQL API to get the chain head even though Boost already has/can get that information. However, this documentation improvement should clarify the existing behavior.