### PR TITLE
Inspect by non-root cid

### DIFF
--- a/gql/resolver_piece.go
+++ b/gql/resolver_piece.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-
+	
 	gqltypes "github.com/filecoin-project/boost/gql/types"
 	"github.com/filecoin-project/boost/storagemarket/types/dealcheckpoints"
 	"github.com/filecoin-project/dagstore"
@@ -15,6 +15,7 @@ import (
 	"github.com/filecoin-project/go-state-types/builtin/v9/market"
 	"github.com/graph-gophers/graphql-go"
 	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-datastore"
 )
 
 type IndexStatus string
@@ -62,9 +63,30 @@ func (r *resolver) PiecesWithPayloadCid(ctx context.Context, args struct{ Payloa
 		return nil, fmt.Errorf("%s is not a valid payload cid", args.PayloadCid)
 	}
 
+	pieces, err := r.dagst.ShardsContainingMultihash(ctx, payloadCid.Hash())
+	if err != nil {
+		if errors.Is(err, datastore.ErrNotFound) {
+			return []string{}, nil
+		}
+		return nil, fmt.Errorf("getting shards containing cid %s: %w", payloadCid, err)
+	}
+
+	pieceCids := make([]string, 0, len(pieces))
+	for _, piece := range pieces {
+		pieceCids = append(pieceCids, piece.String())
+	}
+	return pieceCids, nil
+}
+
+func (r *resolver) PiecesWithRootPayloadCid(ctx context.Context, args struct{ PayloadCid string }) ([]string, error) {
+	payloadCid, err := cid.Parse(args.PayloadCid)
+	if err != nil {
+		return nil, fmt.Errorf("%s is not a valid payload cid", args.PayloadCid)
+	}
+
 	var pieceCidSet = make(map[string]struct{})
 
-	// Get boost deals by piece Cid
+	// Get boost deals by payload cid
 	boostDeals, err := r.dealsDB.ByRootPayloadCID(ctx, payloadCid)
 	if err != nil {
 		return nil, err
@@ -73,7 +95,7 @@ func (r *resolver) PiecesWithPayloadCid(ctx context.Context, args struct{ Payloa
 		pieceCidSet[dl.ClientDealProposal.Proposal.PieceCID.String()] = struct{}{}
 	}
 
-	// Get legacy markets deals by payload Cid
+	// Get legacy markets deals by payload cid
 	// TODO: add method to markets to filter deals by payload CID
 	allLegacyDeals, err := r.legacyProv.ListLocalDeals()
 	if err != nil {

--- a/gql/schema.graphql
+++ b/gql/schema.graphql
@@ -425,6 +425,9 @@ type RootQuery {
   """Get the pieces that contain a particular payload CID"""
   piecesWithPayloadCid(payloadCid: String!): [String!]!
 
+  """Get the pieces that have a particular root payload CID"""
+  piecesWithRootPayloadCid(payloadCid: String!): [String!]!
+
   """Get storage space usage"""
   storage: Storage!
 

--- a/react/src/Inspect.css
+++ b/react/src/Inspect.css
@@ -90,3 +90,7 @@
 .inspect .payload-cid {
     padding: 0.5em 1em;
 }
+
+.inspect > p {
+    padding: 2em 1em;
+}

--- a/react/src/gql.js
+++ b/react/src/gql.js
@@ -377,6 +377,12 @@ const LegacyDealQuery = gql`
     }
 `;
 
+const PiecesWithRootPayloadCidQuery = gql`
+    query AppPiecesWithRootPayloadCidQuery($payloadCid: String!) {
+        piecesWithRootPayloadCid(payloadCid: $payloadCid)
+    }
+`;
+
 const PiecesWithPayloadCidQuery = gql`
     query AppPiecesWithPayloadCidQuery($payloadCid: String!) {
         piecesWithPayloadCid(payloadCid: $payloadCid)
@@ -660,6 +666,7 @@ export {
     RetrievalLogQuery,
     RetrievalLogsListQuery,
     RetrievalLogsCountQuery,
+    PiecesWithRootPayloadCidQuery,
     PiecesWithPayloadCidQuery,
     PieceStatusQuery,
     StorageQuery,


### PR DESCRIPTION
Inspect page: search by non-root cid

This is especially useful when debugging retrieval deals where the retrieval deal selector starts from a non-root cid.

<img width="1166" alt="Screenshot 2022-11-23 at 2 46 33 PM" src="https://user-images.githubusercontent.com/169124/203562571-2e2de616-c096-46f1-a4b0-e33284f2064b.png">
