### PR TITLE
Enable couchbase tests with docker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,6 +114,12 @@ jobs:
           command: make boostci
           no_output_timeout: 30m
       - download-params
+      # Note: setup_remote_docker takes about 10s and it's only needed for
+      # piece-directory tests so it may be worth refactoring so that it's
+      # only included for piece-directory
+      - setup_remote_docker:
+          version: 20.10.18
+          docker_layer_caching: true
       - run:
           name: go test
           command: |

--- a/extern/boostd-data/svc/couchbase_test.go
+++ b/extern/boostd-data/svc/couchbase_test.go
@@ -84,7 +84,7 @@ func setupCouchbase(t *testing.T) {
 	})
 
 	tlog.Info("wait for couchbase start...")
-	awaitCouchbaseUp(t, time.Minute)
+	awaitCouchbaseUp(t, 10*time.Minute)
 	tlog.Info("couchbase started")
 
 	tlog.Info("couchbase initialize cluster...")

--- a/extern/boostd-data/svc/couchbase_test.go
+++ b/extern/boostd-data/svc/couchbase_test.go
@@ -1,67 +1,45 @@
 package svc
 
 import (
+	"fmt"
 	"io"
+	"net/http"
+	"net/url"
 	"os"
 	"testing"
 	"time"
 
+	"github.com/couchbase/gocb/v2"
+	"github.com/davecgh/go-spew/spew"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
-	cl "github.com/docker/docker/client"
+	dockercl "github.com/docker/docker/client"
 	"github.com/docker/go-connections/nat"
-	"github.com/filecoin-project/boostd-data/client"
-	"github.com/filecoin-project/boostd-data/model"
-	"github.com/ipfs/go-cid"
+	"github.com/filecoin-project/boostd-data/couchbase"
+	logging "github.com/ipfs/go-log/v2"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
 )
 
-func XTestCouchbaseService(t *testing.T) {
-	removeContainer := setupCouchbase(t)
-	defer removeContainer()
+var tlog = logging.Logger("cbtest")
 
-	bdsvc := NewCouchbase(testCouchSettings)
-	err := bdsvc.Start(context.Background(), 8042)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	cl := client.NewStore()
-	err = cl.Dial(context.Background(), "http://localhost:8042")
-	defer cl.Close(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	pieceCid, err := cid.Parse("baga6ea4seaqj2j4zfi2xk7okc7fnuw42pip6vjv2tnc4ojsbzlt3rfrdroa7qly")
-	if err != nil {
-		t.Fatal(err)
-	}
-	dealInfo := model.DealInfo{}
-	err = cl.AddDealForPiece(context.TODO(), pieceCid, dealInfo)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	log.Debug("sleeping for a while.. running tests..")
-	time.Sleep(2 * time.Second)
+func init() {
+	logging.SetLogLevel("cbtest", "debug")
 }
 
-func setupCouchbase(t *testing.T) func() {
+func setupCouchbase(t *testing.T) {
 	ctx := context.Background()
-	cli, err := cl.NewEnvClient()
-	if err != nil {
-		t.Fatal(err)
-	}
+	cli, err := dockercl.NewClientWithOpts(dockercl.FromEnv)
+	require.NoError(t, err)
 
 	imageName := "couchbase"
-
 	out, err := cli.ImagePull(ctx, imageName, types.ImagePullOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	io.Copy(os.Stdout, out)
+	require.NoError(t, err)
 
+	_, err = io.Copy(os.Stdout, out)
+	require.NoError(t, err)
+
+	tlog.Info("couchbase docker container create...")
 	resp, err := cli.ContainerCreate(ctx, &container.Config{
 		Image: imageName,
 		ExposedPorts: nat.PortSet{
@@ -86,24 +64,192 @@ func setupCouchbase(t *testing.T) func() {
 			nat.Port("11211"): {{HostIP: "127.0.0.1", HostPort: "11211"}},
 		},
 	}, nil, nil, "")
+	require.NoError(t, err)
+	tlog.Info("couchbase docker container created")
 
-	if err != nil {
-		t.Fatal(err)
-	}
+	tlog.Info("couchbase docker container start...")
+	err = cli.ContainerStart(ctx, resp.ID, types.ContainerStartOptions{})
+	require.NoError(t, err)
+	tlog.Info("couchbase docker container started")
 
-	if err := cli.ContainerStart(ctx, resp.ID, types.ContainerStartOptions{}); err != nil {
-		t.Fatal(err)
-	}
+	inspect, err := cli.ContainerInspect(ctx, resp.ID)
+	require.NoError(t, err)
+	spew.Dump(inspect)
 
-	cleanup := func() {
+	t.Cleanup(func() {
+		tlog.Info("couchbase docker container remove...")
 		err := cli.ContainerRemove(ctx, resp.ID, types.ContainerRemoveOptions{Force: true})
-		if err != nil {
-			t.Fatal(err)
+		require.NoError(t, err)
+		tlog.Info("couchbase docker container removed")
+	})
+
+	tlog.Info("wait for couchbase start...")
+	awaitCouchbaseUp(t, time.Minute)
+	tlog.Info("couchbase started")
+
+	tlog.Info("couchbase initialize cluster...")
+	err = initializeCouchbaseCluster(t)
+	require.NoError(t, err)
+	tlog.Info("couchbase initialized cluster")
+}
+
+func initializeCouchbaseCluster(t *testing.T) error {
+	couchDir := "/opt/couchbase/var/lib/couchbase"
+	apiCall(t, "/nodes/self/controller/settings", url.Values{
+		"data_path":     {couchDir + "/data"},
+		"index_path":    {couchDir + "/idata"},
+		"cbas_path":     {couchDir + "/adata"},
+		"eventing_path": {couchDir + "e/edata"},
+	})
+
+	apiCall(t, "/node/controller/rename", url.Values{
+		"hostname": {"127.0.0.1"},
+	})
+
+	apiCall(t, "/node/controller/setupServices", url.Values{
+		"services": {"kv,n1ql,index"},
+	})
+
+	apiCall(t, "/pools/default", url.Values{
+		"memoryQuota":      {"1024"},
+		"indexMemoryQuota": {"512"},
+		"ftsMemoryQuota":   {"512"},
+	})
+
+	apiCall(t, "/settings/indexes", url.Values{
+		"storageMode": {"plasma"},
+	})
+
+	tlog.Info("wait for services start...")
+	awaitServicesReady(t, time.Minute)
+	tlog.Info("services started")
+
+	apiCall(t, "/settings/web", url.Values{
+		"port":     {"8091"},
+		"username": {testCouchSettings.Auth.Username},
+		"password": {testCouchSettings.Auth.Password},
+	})
+
+	tlog.Info("wait for bucket creation and indexing...")
+	awaitBucketCreationReady(t, 5*time.Minute)
+	tlog.Info("bucket creation and indexing started")
+
+	return nil
+}
+
+func awaitServicesReady(t *testing.T, duration time.Duration) {
+	start := time.Now()
+	cluster, err := gocb.Connect(testCouchSettings.ConnectString, gocb.ClusterOptions{
+		TimeoutsConfig: gocb.TimeoutsConfig{
+			ConnectTimeout: duration,
+		},
+	})
+	require.NoError(t, err)
+
+	var res *gocb.DiagnosticsResult
+	for res == nil || res.State != gocb.ClusterStateOnline {
+		res, err := cluster.Diagnostics(nil)
+		require.NoError(t, err)
+
+		allOnline := true
+		tlog.Info("Services")
+		for name, svc := range res.Services {
+			tlog.Info("  " + name + ":")
+			for _, endpoint := range svc {
+				tlog.Info("    " + couchbase.ServiceName(endpoint.Type) + ": " + couchbase.EndpointStateName(endpoint.State))
+				if endpoint.State != gocb.EndpointStateConnected {
+					allOnline = false
+				}
+			}
 		}
+
+		if allOnline {
+			return
+		}
+
+		if time.Now().Sub(start) > duration {
+			require.Fail(t, "timed out waiting for couchbase services to come up after "+duration.String())
+		}
+		time.Sleep(time.Second)
 	}
+}
 
-	// TODO: setup admin password
-	// TODO: create bucket -- see: https://docs.couchbase.com/server/current/manage/manage-buckets/create-bucket.html
+func awaitBucketCreationReady(t *testing.T, duration time.Duration) {
+	start := time.Now()
+	cluster, err := gocb.Connect(testCouchSettings.ConnectString, gocb.ClusterOptions{
+		TimeoutsConfig: gocb.TimeoutsConfig{
+			ConnectTimeout: time.Minute,
+		},
+		Authenticator: gocb.PasswordAuthenticator{
+			Username: testCouchSettings.Auth.Username,
+			Password: testCouchSettings.Auth.Password,
+		},
+	})
+	require.NoError(t, err)
 
-	return cleanup
+	// Repeatedly try to create a dummy bucket as a way to ensure that the
+	// services needed for bucket creation and indexing are up
+	for {
+		// It may take several seconds to create the index, so we want to use
+		// a relatively long timeout here
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		_, err := couchbase.CreateBucket(ctx, cluster, "dummy", 128)
+		if err == nil {
+			return
+		}
+
+		if time.Now().Sub(start) > duration {
+			require.Fail(t, "timed out trying to create dummy bucket after "+duration.String())
+		}
+
+		tlog.Infow("got err creating dummy bucket - probably services are not all up yet, retrying", "err", err.Error())
+		time.Sleep(time.Second)
+	}
+}
+
+func awaitCouchbaseUp(t *testing.T, duration time.Duration) {
+	waitForOkResponse(t, "/internalSettings", duration)
+}
+
+func waitForOkResponse(t *testing.T, path string, duration time.Duration) {
+	start := time.Now()
+	for {
+		fullPath := "http://127.0.0.1:8091" + path
+		resp, err := http.Get(fullPath)
+		if resp != nil && resp.Body != nil {
+			_ = resp.Body.Close()
+		}
+		if err == nil && resp != nil {
+			if resp.StatusCode < 300 {
+				return
+			} else if resp.StatusCode >= 400 && resp.StatusCode < 500 {
+				msg := fmt.Sprintf("failed to GET %s: %d - %s", fullPath, resp.StatusCode, resp.Status)
+				require.Fail(t, msg)
+			}
+		}
+
+		if time.Now().Sub(start) > duration {
+			msg := "failed to GET " + fullPath + " after " + duration.String()
+			if resp != nil {
+				msg += fmt.Sprintf(": %d - %s", resp.StatusCode, resp.Status)
+			}
+			if err != nil {
+				msg += ": " + err.Error()
+			}
+			require.Fail(t, msg)
+		}
+		time.Sleep(time.Second)
+	}
+}
+
+func apiCall(t *testing.T, path string, values url.Values) {
+	fullPath := "http://127.0.0.1:8091" + path
+	resp, err := http.PostForm(fullPath, values)
+	require.NoError(t, err)
+	if resp.StatusCode >= 300 {
+		require.Fail(t, fmt.Sprintf("%s: %d %s", fullPath, resp.StatusCode, resp.Status))
+	}
+	err = resp.Body.Close()
+	require.NoError(t, err)
 }


### PR DESCRIPTION
Load couchbase from docker and run tests against the dockerized instance.

TODO:
- [ ] Get docker networking setup correctly
        At the moment the [piece directory test is failing](https://app.circleci.com/pipelines/github/filecoin-project/boost/2893/workflows/9bab4a12-2ad1-45b8-a406-fb1cbb18a57e/jobs/26552) because it's trying to connect to couchbase at 127.0.0.1
        This works on my local machine but doesn't work on circleci:
```
  Error:      	failed to GET http://127.0.0.1:8091/internalSettings after 1m0s: Get "http://127.0.0.1:8091/internalSettings": dial tcp 127.0.0.1:8091: connect: connection refused
```