### PR TITLE
Piece Store Reverse migration

### DIFF
--- a/cmd/migrate-piecedir/main.go
+++ b/cmd/migrate-piecedir/main.go
@@ -42,6 +42,7 @@ func main() {
 		Commands: []*cli.Command{
 			migrateLevelDBCmd,
 			migrateCouchDBCmd,
+			migrateReverseCmd,
 		},
 	}
 	app.Setup()


### PR DESCRIPTION
Add a Piece Directory reverse migration tool, for the case that SPs need to switch back to a previous version of the boost binary that does not use the Piece Directory.

Essentially the reverse migrate command just copies all deals that were created since switching to the Piece Directory back into the Piece Store.

In order to be able to serve retrievals with these deals, the user will still need to register each new deal with the dagstore manually:
```
$ boostd dagstore register-shard <piece cid>
```

Demonstration of how to do a reverse migration:
```
$ migrate-piecedir reverse couchbase --connect-string='couchbase://127.0.0.1' --username=Administrator --password=password
Performing couchbase reverse migration with logs at reverse-migrate-couchbase.log
Reverse migration complete

$ cat reverse-migrate-couchbase.log 
2023-01-05T10:21:45.772+0100    INFO    migrate-piecedir/migrate_piece_directory.go:691 starting migration of 53 piece infos from couchbase piece directory to piece store
2023-01-05T10:21:46.013+0100    INFO    migrate-piecedir/migrate_piece_directory.go:716 no deals to migrate for piece   {"pieceCid": "QmPHQG2WgKNY1ZTvPcQRrWbcjxABmSHzDCtD
bjx3w7boJv", "index": 0, "total": 53}
2023-01-05T10:21:46.014+0100    INFO    migrate-piecedir/migrate_piece_directory.go:716 no deals to migrate for piece   {"pieceCid": "QmPnbER8n1TsCj8gjcyPtZMqXFK2eir4ti7j
RnHVAfXx8D", "index": 1, "total": 53}
2023-01-05T10:21:46.015+0100    INFO    migrate-piecedir/migrate_piece_directory.go:716 no deals to migrate for piece   {"pieceCid": "QmPvjpcwLFzn1X4v6ERuEPWjnSDzqh16GZQB
s9iHH2vwRq", "index": 2, "total": 53}
2023-01-05T10:21:46.065+0100    INFO    migrate-piecedir/migrate_piece_directory.go:714 reverse migrated piece  {"pieceCid": "baga6ea4seaqf6bqk7i6t33q2hgg32u3yxdjcipaibaszciyfrto52nocx2cgeii", "index": 37, "total": 53, "migrated-deals": 1}

...

$ boostd pieces piece-info baga6ea4seaqf6bqk7i6t33q2hgg32u3yxdjcipaibaszciyfrto52nocx2cgeii
Piece:  baga6ea4seaqf6bqk7i6t33q2hgg32u3yxdjcipaibaszciyfrto52nocx2cgeii
Deals:
DealID  SectorID  Length  Offset
2       2         2048    0

$ boostd dagstore register-shard baga6ea4seaqf6bqk7i6t33q2hgg32u3yxdjcipaibaszciyfrto52nocx2cgeii
Registered shard baga6ea4seaqf6bqk7i6t33q2hgg32u3yxdjcipaibaszciyfrto52nocx2cgeii

$ boostd dagstore lookup-piece-cid bafk2bzacebazc3nocht463qhbl56u6r7ij4rpoe5e24zwowvqom4qlz2oml7q
Given CID was found in the following pieces: [baga6ea4seaqf6bqk7i6t33q2hgg32u3yxdjcipaibaszciyfrto52nocx2cgeii]

$ lotus client retrieve --provider=t01000 bafk2bzacebazc3nocht463qhbl56u6r7ij4rpoe5e24zwowvqom4qlz2oml7q /tmp/out.file
Recv 0 B, Paid 0 FIL, Open (New), 0s
Recv 0 B, Paid 0 FIL, DealProposed (WaitForAcceptance), 63ms
Recv 0 B, Paid 0 FIL, DealAccepted (Accepted), 483ms
Recv 0 B, Paid 0 FIL, PaymentChannelSkip (Ongoing), 483ms
Recv 1000 B, Paid 0 FIL, BlocksReceived (Ongoing), 817ms
Recv 1000 B, Paid 0 FIL, AllBlocksReceived (BlocksComplete), 880ms
Recv 1000 B, Paid 0 FIL, Complete (CheckComplete), 1.07s
Recv 1000 B, Paid 0 FIL, CompleteVerified (FinalizingBlockstore), 1.153s
Recv 1000 B, Paid 0 FIL, BlockstoreFinalized (Completed), 1.154s
Success
```