### PR TITLE
Use global context for rebuild piece

### DIFF
--- a/gql/resolver.go
+++ b/gql/resolver.go
@@ -41,6 +41,9 @@ type dealListResolver struct {
 // resolver translates from a request for a graphql field to the data for
 // that field
 type resolver struct {
+	// This context is closed when boost shuts down
+	ctx context.Context
+
 	cfg            *config.Boost
 	repo           lotus_repo.LockedRepo
 	h              host.Host
@@ -62,8 +65,9 @@ type resolver struct {
 	fullNode       v1api.FullNode
 }
 
-func NewResolver(cfg *config.Boost, r lotus_repo.LockedRepo, h host.Host, dealsDB *db.DealsDB, logsDB *db.LogsDB, retDB *rtvllog.RetrievalLogDB, plDB *db.ProposalLogsDB, fundsDB *db.FundsDB, fundMgr *fundmanager.FundManager, storageMgr *storagemanager.StorageManager, spApi sealingpipeline.API, provider *storagemarket.Provider, legacyProv lotus_storagemarket.StorageProvider, legacyDT lotus_dtypes.ProviderDataTransfer, ps piecestore.PieceStore, sa retrievalmarket.SectorAccessor, piecedirectory *piecedirectory.PieceDirectory, publisher *storageadapter.DealPublisher, fullNode v1api.FullNode) *resolver {
+func NewResolver(ctx context.Context, cfg *config.Boost, r lotus_repo.LockedRepo, h host.Host, dealsDB *db.DealsDB, logsDB *db.LogsDB, retDB *rtvllog.RetrievalLogDB, plDB *db.ProposalLogsDB, fundsDB *db.FundsDB, fundMgr *fundmanager.FundManager, storageMgr *storagemanager.StorageManager, spApi sealingpipeline.API, provider *storagemarket.Provider, legacyProv lotus_storagemarket.StorageProvider, legacyDT lotus_dtypes.ProviderDataTransfer, ps piecestore.PieceStore, sa retrievalmarket.SectorAccessor, piecedirectory *piecedirectory.PieceDirectory, publisher *storageadapter.DealPublisher, fullNode v1api.FullNode) *resolver {
 	return &resolver{
+		ctx:            ctx,
 		cfg:            cfg,
 		repo:           r,
 		h:              h,

--- a/gql/resolver_piece.go
+++ b/gql/resolver_piece.go
@@ -182,13 +182,16 @@ func (r *resolver) PiecesWithRootPayloadCid(ctx context.Context, args struct{ Pa
 	return pieceCids, nil
 }
 
-func (r *resolver) PieceBuildIndex(ctx context.Context, args struct{ PieceCid string }) (bool, error) {
+func (r *resolver) PieceBuildIndex(args struct{ PieceCid string }) (bool, error) {
 	pieceCid, err := cid.Parse(args.PieceCid)
 	if err != nil {
 		return false, fmt.Errorf("%s is not a valid piece cid", args.PieceCid)
 	}
 
-	err = r.piecedirectory.BuildIndexForPiece(ctx, pieceCid)
+	// Use the global boost context for build piece, because if the user
+	// navigates away from the page we don't want to cancel the build piece
+	// operation
+	err = r.piecedirectory.BuildIndexForPiece(r.ctx, pieceCid)
 	if err != nil {
 		return false, err
 	}

--- a/piecedirectory/piecedirectory.go
+++ b/piecedirectory/piecedirectory.go
@@ -77,15 +77,18 @@ func (ps *PieceDirectory) GetPieceMetadata(ctx context.Context, pieceCid cid.Cid
 	defer span.End()
 
 	// Get the piece metadata from the DB
+	log.Debugw("piece metadata: get", "pieceCid", pieceCid)
 	md, err := ps.store.GetPieceMetadata(ctx, pieceCid)
 	if err != nil {
 		return types.PieceDirMetadata{}, err
 	}
 
 	// Check if this process is currently indexing the piece
+	log.Debugw("piece metadata: get indexing status", "pieceCid", pieceCid)
 	_, indexing := ps.addIdxOpByCid.Load(pieceCid)
 
 	// Return the db piece metadata along with the indexing flag
+	log.Debugw("piece metadata: get complete", "pieceCid", pieceCid)
 	return types.PieceDirMetadata{
 		Metadata: md,
 		Indexing: indexing,

--- a/react/src/Inspect.js
+++ b/react/src/Inspect.js
@@ -127,13 +127,8 @@ function FlaggedPieces({setSearchQuery}) {
     </div>
 }
 
-function FlaggedPieceRow({piece, setSearchQuery}) {
-    var isUnsealed = false
-    for (var dl of piece.Deals) {
-        if (dl.SealStatus.IsUnsealed) {
-            isUnsealed = true
-        }
-    }
+function FlaggedPieceRow({piece}) {
+    var isUnsealed = hasUnsealedCopy(piece)
     return <tr>
         <td>
             <Link to={"/inspect/piece/"+piece.PieceCid}>
@@ -144,6 +139,15 @@ function FlaggedPieceRow({piece, setSearchQuery}) {
         <td>{isUnsealed ? 'Yes' : 'No'}</td>
         <td>{piece.Deals.length}</td>
     </tr>
+}
+
+function hasUnsealedCopy(piece) {
+    for (var dl of piece.Deals) {
+        if (dl.SealStatus.IsUnsealed) {
+            return true
+        }
+    }
+    return false
 }
 
 // Page showing information about a particular piece
@@ -282,7 +286,7 @@ function PieceStatus({pieceCid, pieceStatus, searchQuery}) {
     const searchIsRootCid = searchQuery && searchQuery == rootCid
     const indexFailed = pieceStatus.IndexStatus.Status === 'Failed'
     const indexRegistered = pieceStatus.IndexStatus.Status === 'Registered'
-    const canReIndex = indexFailed || indexRegistered
+    const canReIndex = (indexFailed || indexRegistered) && hasUnsealedCopy(pieceStatus)
 
     return <div className="piece-detail" id={pieceCid}>
         <div className="content">


### PR DESCRIPTION
This PR fixes a bug where
1. User clicks Re-Index for a piece
2. Server begins re-indexing piece
3. User clicks away to a different page
4. Context is cancelled and the re-indexing fails

Instead of using the request context, we now use a context that is only cancelled when boost shuts down.