### PR TITLE
feat: boostx command to unseal a sector

### DIFF
--- a/cmd/boostx/main.go
+++ b/cmd/boostx/main.go
@@ -36,6 +36,7 @@ func main() {
 			marketAddCmd,
 			marketWithdrawCmd,
 			statsCmd,
+			sectorCmd,
 		},
 	}
 	app.Setup()

--- a/cmd/boostx/sector.go
+++ b/cmd/boostx/sector.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"fmt"
+	"github.com/filecoin-project/boost/cmd/lib"
+	"github.com/filecoin-project/go-state-types/abi"
+	lcli "github.com/filecoin-project/lotus/cli"
+	"github.com/urfave/cli/v2"
+	"strconv"
+	"time"
+)
+
+var sectorCmd = &cli.Command{
+	Name:  "sector",
+	Usage: "Sector commands",
+	Subcommands: []*cli.Command{
+		sectorUnsealCmd,
+	},
+}
+
+var sectorUnsealCmd = &cli.Command{
+	Name:      "unseal",
+	Usage:     "Unseal a sector",
+	ArgsUsage: "<sector ID>",
+	Before:    before,
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:     "api-fullnode",
+			Usage:    "the endpoint for the full node API",
+			Required: true,
+		},
+		&cli.StringFlag{
+			Name:     "api-storage",
+			Usage:    "the endpoint for the storage node API",
+			Required: true,
+		},
+	},
+	Action: func(cctx *cli.Context) error {
+		if !cctx.Args().Present() {
+			return fmt.Errorf("must pass sector ID as first parameter")
+		}
+
+		sectorIDInt, err := strconv.Atoi(cctx.Args().First())
+		if err != nil {
+			return fmt.Errorf("parsing sector ID %s: %w", cctx.Args().First(), err)
+		}
+		sectorID := abi.SectorNumber(sectorIDInt)
+
+		ctx := lcli.ReqContext(cctx)
+
+		// Connect to the full node API
+		fnApiInfo := cctx.String("api-fullnode")
+		fullnodeApi, ncloser, err := lib.GetFullNodeApi(ctx, fnApiInfo, log)
+		if err != nil {
+			return fmt.Errorf("getting full node API: %w", err)
+		}
+		defer ncloser()
+
+		// Connect to the storage API and create a sector accessor
+		storageApiInfo := cctx.String("api-storage")
+		sa, storageCloser, err := lib.CreateSectorAccessor(ctx, storageApiInfo, fullnodeApi, log)
+		if err != nil {
+			return err
+		}
+		defer storageCloser()
+
+		pieceLength := abi.PaddedPieceSize(1024).Unpadded()
+		isUnsealed, err := sa.IsUnsealed(ctx, sectorID, 0, pieceLength)
+		if err != nil {
+			return fmt.Errorf("getting sealed state of sector: %w", err)
+		}
+
+		if isUnsealed {
+			fmt.Printf("Sector %d is already unsealed\n", sectorID)
+			return nil
+		}
+
+		start := time.Now()
+		fmt.Printf("Unsealing sector %d\n", sectorID)
+		_, err = sa.UnsealSectorAt(ctx, sectorID, 0, pieceLength)
+		if err != nil {
+			return fmt.Errorf("unsealing sector %d: %w", sectorID, err)
+		}
+
+		fmt.Printf("Successfully unsealed sector %d after %s\n", sectorID, time.Since(start).String())
+
+		return nil
+	},
+}


### PR DESCRIPTION
Adds a new command to boostx to unseal a sector.

Example of unsealing a sector that is already unsealed:
```
$ boostx sector unseal --api-fullnode=$FULLNODE_API_INFO --api-storage=$MINER_API_INFO 1
2023-01-11T16:15:51.740+0100	INFO	boostx	lib/api.go:35	Using full node API at ws://127.0.0.1:1234/rpc/v1
2023-01-11T16:15:51.742+0100	INFO	boostx	lib/api.go:61	Using storage API at ws://127.0.0.1:2345/rpc/v0
2023-01-11T16:15:51.743+0100	INFO	boostx	lib/api.go:103	Miner address: f01000
Sector 1 is already unsealed
```

Example of unsealing a sector that is not yet unsealed:
```
$ boostx sector unseal --api-fullnode=$FULLNODE_API_INFO --api-storage=$MINER_API_INFO 1
2023-01-11T16:16:37.988+0100	INFO	boostx	lib/api.go:35	Using full node API at ws://127.0.0.1:1234/rpc/v1
2023-01-11T16:16:37.989+0100	INFO	boostx	lib/api.go:61	Using storage API at ws://127.0.0.1:2345/rpc/v0
2023-01-11T16:16:37.991+0100	INFO	boostx	lib/api.go:103	Miner address: f01000
Unsealing sector 1
Successfully unsealed sector 1 after 4.951231m
```