### PR TITLE
Remove block endpoint from booster-http

### DIFF
--- a/cmd/booster-http/http_test.go
+++ b/cmd/booster-http/http_test.go
@@ -91,35 +91,6 @@ func TestHttpGzipResponse(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestBlockRetrieval(t *testing.T) {
-	//Create a new mock Http server with custom functions
-	ctrl := gomock.NewController(t)
-	mockHttpServer := mocks_booster_http.NewMockHttpServerApi(ctrl)
-	httpServer := NewHttpServer("", 7779, mockHttpServer)
-	httpServer.Start(context.Background())
-
-	data := []byte("Hello World!")
-
-	mockHttpServer.EXPECT().GetBlockByCid(gomock.Any(), gomock.Any()).AnyTimes().Return(data, nil)
-
-	// Create a client and make request with Encoding header
-	client := new(http.Client)
-	request, err := http.NewRequest("GET", "http://localhost:7779/ipfs/bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi", nil)
-	require.NoError(t, err)
-
-	response, err := client.Do(request)
-	require.NoError(t, err)
-	defer response.Body.Close()
-	require.Equal(t, "nosniff", response.Header.Get("X-Content-Type-Options"))
-	require.Equal(t, "application/vnd.ipld.raw", response.Header.Get("Content-Type"))
-	require.Equal(t, "attachment; filename=\"bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi\"; filename*=UTF-8''bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi", response.Header.Get("Content-Disposition"))
-
-	out, err := io.ReadAll(response.Body)
-	require.NoError(t, err)
-
-	require.Equal(t, data, out)
-}
-
 func TestHttpInfo(t *testing.T) {
 	var v apiVersion
 

--- a/cmd/booster-http/run.go
+++ b/cmd/booster-http/run.go
@@ -168,7 +168,3 @@ func (s serverApi) IsUnsealed(ctx context.Context, sectorID abi.SectorNumber, of
 func (s serverApi) UnsealSectorAt(ctx context.Context, sectorID abi.SectorNumber, offset abi.UnpaddedPieceSize, length abi.UnpaddedPieceSize) (mount.Reader, error) {
 	return s.sa.UnsealSectorAt(ctx, sectorID, offset, length)
 }
-
-func (s serverApi) GetBlockByCid(ctx context.Context, blockCid cid.Cid) ([]byte, error) {
-	return s.piecedirectory.BlockstoreGet(ctx, blockCid)
-}


### PR DESCRIPTION
I also ran a retrieval on the piece endpoint to make sure that's all still working as expected:

```
$ booster-http run --api-piece-directory="http://localhost:8042" --api-fullnode=$FULLNODE_API_INFO --api-storage=$MINER_API_INFO
2023-01-13T16:29:10.511+0100	INFO	booster	lib/api.go:35	Using full node API at ws://127.0.0.1:1234/rpc/v1
2023-01-13T16:29:10.513+0100	INFO	booster	lib/api.go:61	Using storage API at ws://127.0.0.1:2345/rpc/v0
2023-01-13T16:29:10.514+0100	INFO	booster	lib/api.go:103	Miner address: f01000
2023-01-13T16:29:10.514+0100	INFO	booster	booster-http/run.go:123	Starting booster-http node on port 7777 with base path ''
2023-01-13T16:31:00.280+0100	200	GET /piece/baga6ea4seaqf6bqk7i6t33q2hgg32u3yxdjcipaibaszciyfrto52nocx2cgeii
2023-01-13T16:31:00.280+0100	DONE	GET /piece/baga6ea4seaqf6bqk7i6t33q2hgg32u3yxdjcipaibaszciyfrto52nocx2cgeii
2023-01-13T16:31:00.280+0100 - 2023-01-13T16:31:00.280+0100: 57.555µs / 2,032 bytes transferred
```