### PR TITLE
Upgrade to the latest index provider with fixes to bitswap retrieval ads

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -72,7 +72,7 @@ require (
 	github.com/ipld/go-car/v2 v2.5.0
 	github.com/ipld/go-ipld-prime v0.18.0
 	github.com/ipld/go-ipld-selector-text-lite v0.0.1
-	github.com/ipni/index-provider v0.10.0
+	github.com/ipni/index-provider v0.10.1
 	github.com/ipni/storetheindex v0.5.3-0.20221203123030-16745cb63f15
 	github.com/jbenet/go-random v0.0.0-20190219211222-123a90aedc0c
 	github.com/jpillora/backoff v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -904,8 +904,8 @@ github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20211210234204-ce2a1c70cd
 github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20211210234204-ce2a1c70cd73/go.mod h1:2PJ0JgxyB08t0b2WKrcuqI3di0V+5n6RS/LTUJhkoxY=
 github.com/ipld/go-ipld-selector-text-lite v0.0.1 h1:lNqFsQpBHc3p5xHob2KvEg/iM5dIFn6iw4L/Hh+kS1Y=
 github.com/ipld/go-ipld-selector-text-lite v0.0.1/go.mod h1:U2CQmFb+uWzfIEF3I1arrDa5rwtj00PrpiwwCO+k1RM=
-github.com/ipni/index-provider v0.10.0 h1:nu8YBxzRopdjwZHsgCUuC4AHpq88VVHJYrbkqUDx7eg=
-github.com/ipni/index-provider v0.10.0/go.mod h1:InSXbZp2p/ZhAwiDElG/wzjnA1ea1iJ3hhyiAHrD+Vo=
+github.com/ipni/index-provider v0.10.1 h1:LXl3znRTYDqtRPIpmgWzZbHneTVmxfW3vucW5JydS+E=
+github.com/ipni/index-provider v0.10.1/go.mod h1:InSXbZp2p/ZhAwiDElG/wzjnA1ea1iJ3hhyiAHrD+Vo=
 github.com/ipni/storetheindex v0.5.3-0.20221203123030-16745cb63f15 h1:qJq6QtLk+9nQi3CDBhNfJ1cjZ4pghjCHcQUZ1mWbF0k=
 github.com/ipni/storetheindex v0.5.3-0.20221203123030-16745cb63f15/go.mod h1:c/NS640Iu2NrCCIErnUhsUM5KVEyeXymgtNnx6eDwMU=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52 h1:QG4CGBqCeuBo6aZlGAamSkxWdgWfZGeE49eUOWJPA4c=

--- a/indexprovider/wrapper.go
+++ b/indexprovider/wrapper.go
@@ -148,14 +148,19 @@ func (w *Wrapper) AnnounceExtendedProviders(ctx context.Context) error {
 		}
 		var ep xproviders.Info
 		if len(w.cfg.Dealmaking.BitswapPublicAddresses) > 0 {
+			if w.cfg.Dealmaking.BitswapPrivKeyFile == "" {
+				return fmt.Errorf("missing required configuration key BitswapPrivKeyFile: " +
+					"boost is configured with BitswapPublicAddresses but the BitswapPrivKeyFile configuration key is empty")
+			}
+
 			// we need the private key for bitswaps peerID in order to announce publicly
 			keyFile, err := os.ReadFile(w.cfg.Dealmaking.BitswapPrivKeyFile)
 			if err != nil {
-				return err
+				return fmt.Errorf("opening BitswapPrivKeyFile %s: %w", w.cfg.Dealmaking.BitswapPrivKeyFile, err)
 			}
 			privKey, err := crypto.UnmarshalPrivateKey(keyFile)
 			if err != nil {
-				return err
+				return fmt.Errorf("unmarshalling BitswapPrivKeyFile %s: %w", w.cfg.Dealmaking.BitswapPrivKeyFile, err)
 			}
 			// setup an extended provider record, containing the booster-bitswap multi addr,
 			// peer ID, private key for signing, and metadata

--- a/indexprovider/wrapper.go
+++ b/indexprovider/wrapper.go
@@ -15,8 +15,6 @@ import (
 	"go.uber.org/fx"
 
 	dst "github.com/filecoin-project/dagstore"
-	lotus_config "github.com/filecoin-project/lotus/node/config"
-
 	"github.com/filecoin-project/lotus/markets/dagstore"
 	"github.com/filecoin-project/lotus/markets/idxprov"
 
@@ -40,7 +38,7 @@ var shardRegMarker = ".boost-shard-registration-complete"
 var defaultDagStoreDir = "dagstore"
 
 type Wrapper struct {
-	cfg         lotus_config.DAGStoreConfig
+	cfg         *config.Boost
 	enabled     bool
 	dealsDB     *db.DealsDB
 	legacyProv  lotus_storagemarket.StorageProvider
@@ -51,10 +49,6 @@ type Wrapper struct {
 	// bitswapEnabled records whether to announce bitswap as an available
 	// protocol to the network indexer
 	bitswapEnabled bool
-	// when booster bitswap is exposed on a public address, extendedProvider
-	// holds the information needed to announce that multiaddr to the network indexer
-	// as the provider of bitswap
-	extendedProvider *xproviders.Info
 }
 
 func NewWrapper(cfg *config.Boost) func(lc fx.Lifecycle, h host.Host, r repo.LockedRepo, dealsDB *db.DealsDB,
@@ -74,44 +68,16 @@ func NewWrapper(cfg *config.Boost) func(lc fx.Lifecycle, h host.Host, r repo.Loc
 		bitswapEnabled := cfg.Dealmaking.BitswapPeerID != ""
 
 		// setup bitswap extended provider if there is a public multi addr for bitswap
-		var ep *xproviders.Info
-		if bitswapEnabled && len(cfg.Dealmaking.BitswapPublicAddresses) > 0 {
-			// marshal bitswap metadata
-			meta := metadata.Default.New(metadata.Bitswap{})
-			mbytes, err := meta.MarshalBinary()
-			if err != nil {
-				return nil, err
-			}
-			// we need the private key for bitswaps peerID in order to announce publicly
-			keyFile, err := os.ReadFile(cfg.Dealmaking.BitswapPrivKeyFile)
-			if err != nil {
-				return nil, err
-			}
-			privKey, err := crypto.UnmarshalPrivateKey(keyFile)
-			if err != nil {
-				return nil, err
-			}
-			// setup an extended provider record, containing the booster-bitswap multi addr,
-			// peer ID, private key for signing, and metadata
-			ep = &xproviders.Info{
-				ID:       cfg.Dealmaking.BitswapPeerID,
-				Addrs:    cfg.Dealmaking.BitswapPublicAddresses,
-				Priv:     privKey,
-				Metadata: mbytes,
-			}
-		}
-
 		w := &Wrapper{
-			h:                h,
-			dealsDB:          dealsDB,
-			legacyProv:       legacyProv,
-			prov:             prov,
-			dagStore:         dagStore,
-			meshCreator:      meshCreator,
-			cfg:              cfg.DAGStore,
-			bitswapEnabled:   bitswapEnabled,
-			extendedProvider: ep,
-			enabled:          !isDisabled,
+			h:              h,
+			dealsDB:        dealsDB,
+			legacyProv:     legacyProv,
+			prov:           prov,
+			dagStore:       dagStore,
+			meshCreator:    meshCreator,
+			cfg:            cfg,
+			bitswapEnabled: bitswapEnabled,
+			enabled:        !isDisabled,
 		}
 		// announce all deals on startup in case of a config change
 		lc.Append(fx.Hook{
@@ -133,39 +99,95 @@ func (w *Wrapper) Enabled() bool {
 	return w.enabled
 }
 
+// AnnounceExtendedProviders announces changes to Boost configuration in the context of retrieval
+// methods.
+//
+// The advertisement published by this function covers 3 cases:
+//
+// 1. bitswap is completely disabled: in which case an advertisement is
+// published with empty extended providers that should wipe previous
+// support on indexer side.
+//
+// 2. bitswap is enabled with public addresses: in which case publish an
+// advertisement with extended providers records corresponding to the
+// public addresses. Note, according the the IPNI spec, the host ID will
+// also be added to the extended providers for signing reasons with empty
+// metadata making a total of 2 extended provider records.
+//
+// 3. bitswap with boostd address: in which case public an advertisement
+// with one extended provider record that just adds bitswap metadata.
+//
+// Note that in any case one advertisement is published by boost on startup
+// to reflect on bitswap configuration, even if the config remains the
+// same. Future work should detect config change and only publish ads when
+// config changes.
 func (w *Wrapper) AnnounceExtendedProviders(ctx context.Context) error {
 	if !w.enabled {
 		return errors.New("cannot announce all deals: index provider is disabled")
 	}
 	// for now, only generate an indexer provider announcement if bitswap announcements
 	// are enabled -- all other graphsync announcements are context ID specific
-	if !w.bitswapEnabled {
-		log.Info("bitswap is not enabled - skipping bitswap announcements to Indexer")
-		return nil
-	}
 
 	// build the extended providers announcement
-	adBuilder := xproviders.NewAdBuilder(w.h.ID(), w.h.Peerstore().PrivKey(w.h.ID()), w.h.Addrs())
-	// if we're exposing bitswap publicly, we announce bitswap as an extended provider. If we're not
-	// we announce it as metadata on the main provider
-	if w.extendedProvider != nil {
-		log.Infof("bitswap is enabled and endpoint is public - "+
-			"announcing bitswap endpoint to indexer as extended provider: %s %s",
-			w.extendedProvider.ID, w.extendedProvider.Addrs)
+	key := w.h.Peerstore().PrivKey(w.h.ID())
+	adBuilder := xproviders.NewAdBuilder(w.h.ID(), key, w.h.Addrs())
 
-		adBuilder.WithExtendedProviders(*w.extendedProvider)
+	if !w.bitswapEnabled {
+		// If bitswap is completely disabled, publish an advertisement with empty extended providers
+		// which should override previously published extended providers associated to w.h.ID().
+		log.Info("bitswap is not enabled - announcing bitswap disabled to Indexer")
 	} else {
-		log.Infof("bitswap is enabled with boostd as proxy - "+
-			"announcing boostd as endpoint for bitswap to indexer: %s %s",
-			w.h.ID(), w.h.Addrs())
+		// if we're exposing bitswap publicly, we announce bitswap as an extended provider. If we're not
+		// we announce it as metadata on the main provider
 
+		// marshal bitswap metadata
 		meta := metadata.Default.New(metadata.Bitswap{})
 		mbytes, err := meta.MarshalBinary()
 		if err != nil {
 			return err
 		}
-		adBuilder.WithMetadata(mbytes)
+		var ep xproviders.Info
+		if len(w.cfg.Dealmaking.BitswapPublicAddresses) > 0 {
+			// we need the private key for bitswaps peerID in order to announce publicly
+			keyFile, err := os.ReadFile(w.cfg.Dealmaking.BitswapPrivKeyFile)
+			if err != nil {
+				return err
+			}
+			privKey, err := crypto.UnmarshalPrivateKey(keyFile)
+			if err != nil {
+				return err
+			}
+			// setup an extended provider record, containing the booster-bitswap multi addr,
+			// peer ID, private key for signing, and metadata
+			ep = xproviders.Info{
+				ID:       w.cfg.Dealmaking.BitswapPeerID,
+				Addrs:    w.cfg.Dealmaking.BitswapPublicAddresses,
+				Priv:     privKey,
+				Metadata: mbytes,
+			}
+			log.Infof("bitswap is enabled and endpoint is public - "+
+				"announcing bitswap endpoint to indexer as extended provider: %s %s",
+				ep.ID, ep.Addrs)
+		} else {
+			log.Infof("bitswap is enabled with boostd as proxy - "+
+				"announcing boostd as endpoint for bitswap to indexer: %s %s",
+				w.h.ID(), w.h.Addrs())
+
+			addrs := make([]string, 0, len(w.h.Addrs()))
+			for _, addr := range w.h.Addrs() {
+				addrs = append(addrs, addr.String())
+			}
+
+			ep = xproviders.Info{
+				ID:       w.h.ID().String(),
+				Addrs:    addrs,
+				Priv:     key,
+				Metadata: mbytes,
+			}
+		}
+		adBuilder.WithExtendedProviders(ep)
 	}
+
 	last, _, err := w.prov.GetLatestAdv(ctx)
 	if err != nil {
 		return err
@@ -328,7 +350,7 @@ func (w *Wrapper) DagstoreReinitBoostDeals(ctx context.Context) (bool, error) {
 	}
 
 	log := log.Named("boost-migrator")
-	log.Infof("dagstore root is %s", w.cfg.RootDir)
+	log.Infof("dagstore root is %s", w.cfg.DAGStore.RootDir)
 
 	// Check if all deals have already been registered as shards
 	isComplete, err := w.boostRegistrationComplete()
@@ -427,7 +449,7 @@ func (w *Wrapper) DagstoreReinitBoostDeals(ctx context.Context) (bool, error) {
 // Check for the existence of a "marker" file indicating that the migration
 // has completed
 func (w *Wrapper) boostRegistrationComplete() (bool, error) {
-	path := filepath.Join(w.cfg.RootDir, shardRegMarker)
+	path := filepath.Join(w.cfg.DAGStore.RootDir, shardRegMarker)
 	_, err := os.Stat(path)
 	if os.IsNotExist(err) {
 		return false, nil
@@ -440,7 +462,7 @@ func (w *Wrapper) boostRegistrationComplete() (bool, error) {
 
 // Create a "marker" file indicating that the migration has completed
 func (w *Wrapper) markBoostRegistrationComplete() error {
-	path := filepath.Join(w.cfg.RootDir, shardRegMarker)
+	path := filepath.Join(w.cfg.DAGStore.RootDir, shardRegMarker)
 	file, err := os.Create(path)
 	if err != nil {
 		return err


### PR DESCRIPTION
Change the logic of advertisement published on startup to cover 3 cases:
1. bitswap is completely disabled: in which case an advertisement is published with empty extended providers that should wipe previous support on indexer side.

2. bitswap is enabled with public addresses: in which case publish an advertisement with extended providers records corresponding to the public addresses. Note, according the the IPNI spec, the host ID will also be added to the extended providers for signing reasons with empty metadata making a total of 2 extended provider records.

3. bitswap  is enabled with boostd address: in which case public an advertisement with one extended provider record that just adds bitswap metadata.

Note that in any case one advertisement is published by boost on startup to reflect on bitswap configuration, even if the config remains the same. Future work should detect config change and only publish ads when config changes.
