### PR TITLE
docs: instruct devs to delete data folder for docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ make docker/all
 
 On ARM-based systems (*Apple M1/M2*) you need to force building Filecoin's Rust libraries from the source
 ```
-make docker/all ffi_from_source=1 
+make docker/all ffi_from_source=1
 ```
 
 If you need to build containers using a specific version of lotus then provide the version as a parameter, e.g. `make docker/all lotus_version=1.17.0`. The version must be a tag name of [Lotus git repo](https://github.com/filecoin-project/lotus/tags) without `v` prefix. Or you can build using a local source of lotus - `make docker/all lotus_src_dir=<path of lotus source>`. Also, before starting devnet, you need to update versions in the [.env](docker/devnet/.env) file.
@@ -225,6 +225,7 @@ If you need to build containers using a specific version of lotus then provide t
 
 ```
 cd docker/devnet
+rm -r ./data
 docker compose up -d
 ```
 


### PR DESCRIPTION
Removal of the data folder in the docker devnet folder is required between restarts, so just have users always delete it.