### PR TITLE
Add option to output fx dependency injection log on startup

### DIFF
--- a/cmd/boostd/main.go
+++ b/cmd/boostd/main.go
@@ -79,6 +79,7 @@ func before(cctx *cli.Context) error {
 		_ = logging.SetLogLevel("dagstore", "DEBUG")
 		_ = logging.SetLogLevel("migrator", "DEBUG")
 		_ = logging.SetLogLevel("piecedir", "DEBUG")
+		_ = logging.SetLogLevel("fxlog", "DEBUG")
 	}
 
 	return nil

--- a/node/builder.go
+++ b/node/builder.go
@@ -78,10 +78,12 @@ import (
 	"github.com/libp2p/go-libp2p/p2p/net/conngater"
 	"github.com/multiformats/go-multiaddr"
 	"go.uber.org/fx"
+	"go.uber.org/fx/fxevent"
 )
 
 //nolint:deadcode,varcheck
 var log = logging.Logger("builder")
+var fxlog = logging.Logger("fxlog")
 
 // special is a type used to give keys to modules which
 //
@@ -386,7 +388,9 @@ func New(ctx context.Context, opts ...Option) (StopFunc, error) {
 		fx.Options(ctors...),
 		fx.Options(settings.invokes...),
 
-		fx.NopLogger,
+		fx.WithLogger(func() fxevent.Logger {
+			return &fxevent.ZapLogger{Logger: fxlog.Desugar()}
+		}),
 	)
 
 	// TODO: we probably should have a 'firewall' for Closing signal


### PR DESCRIPTION
This makes it easier to diagnose issues with dependency injection (eg if it takes a long time for boostd to startup).
Enable fx logging by running boostd in very verbose mode:
```
boostd run --vv
```