### PR TITLE
handle blockstore GetSize for indexes imported from the dagstore

### DIFF
--- a/extern/boostd-data/client/client.go
+++ b/extern/boostd-data/client/client.go
@@ -18,8 +18,9 @@ var log = logger.Logger("boostd-data-client")
 type Store struct {
 	client struct {
 		AddDealForPiece           func(context.Context, cid.Cid, model.DealInfo) error
-		AddIndex                  func(context.Context, cid.Cid, []model.Record) error
+		AddIndex                  func(context.Context, cid.Cid, []model.Record, bool) error
 		IsIndexed                 func(ctx context.Context, pieceCid cid.Cid) (bool, error)
+		IsCompleteIndex           func(ctx context.Context, pieceCid cid.Cid) (bool, error)
 		GetIndex                  func(context.Context, cid.Cid) ([]model.Record, error)
 		GetOffsetSize             func(context.Context, cid.Cid, mh.Multihash) (*model.OffsetSize, error)
 		ListPieces                func(ctx context.Context) ([]cid.Cid, error)
@@ -118,14 +119,18 @@ func (s *Store) SetCarSize(ctx context.Context, pieceCid cid.Cid, size uint64) e
 	return s.client.SetCarSize(ctx, pieceCid, size)
 }
 
-func (s *Store) AddIndex(ctx context.Context, pieceCid cid.Cid, records []model.Record) error {
+func (s *Store) AddIndex(ctx context.Context, pieceCid cid.Cid, records []model.Record, isCompleteIndex bool) error {
 	log.Debugw("add-index", "piece-cid", pieceCid, "records", len(records))
 
-	return s.client.AddIndex(ctx, pieceCid, records)
+	return s.client.AddIndex(ctx, pieceCid, records, isCompleteIndex)
 }
 
 func (s *Store) IsIndexed(ctx context.Context, pieceCid cid.Cid) (bool, error) {
 	return s.client.IsIndexed(ctx, pieceCid)
+}
+
+func (s *Store) IsCompleteIndex(ctx context.Context, pieceCid cid.Cid) (bool, error) {
+	return s.client.IsCompleteIndex(ctx, pieceCid)
 }
 
 func (s *Store) IndexedAt(ctx context.Context, pieceCid cid.Cid) (time.Time, error) {

--- a/extern/boostd-data/couchbase/db.go
+++ b/extern/boostd-data/couchbase/db.go
@@ -335,13 +335,14 @@ func (db *DB) MarkIndexErrored(ctx context.Context, pieceCid cid.Cid, idxErr err
 	})
 }
 
-func (db *DB) MarkIndexingComplete(ctx context.Context, pieceCid cid.Cid, blockCount int) error {
+func (db *DB) MarkIndexingComplete(ctx context.Context, pieceCid cid.Cid, blockCount int, isCompleteIndex bool) error {
 	ctx, span := tracing.Tracer.Start(ctx, "db.mark_indexing_complete")
 	defer span.End()
 
 	return db.mutatePieceMetadata(ctx, pieceCid, "mark-indexing-complete", func(metadata CouchbaseMetadata) *CouchbaseMetadata {
 		// Mark indexing as complete
 		metadata.IndexedAt = time.Now()
+		metadata.CompleteIndex = isCompleteIndex
 		metadata.BlockCount = blockCount
 		metadata.Error = ""
 		metadata.ErrorType = ""

--- a/extern/boostd-data/ldb/service.go
+++ b/extern/boostd-data/ldb/service.go
@@ -267,7 +267,25 @@ func (s *Store) IsIndexed(ctx context.Context, pieceCid cid.Cid) (bool, error) {
 	return !t.IsZero(), nil
 }
 
-func (s *Store) AddIndex(ctx context.Context, pieceCid cid.Cid, records []model.Record) error {
+func (s *Store) IsCompleteIndex(ctx context.Context, pieceCid cid.Cid) (bool, error) {
+	log.Debugw("handle.is-complete-index", "pieceCid", pieceCid)
+
+	ctx, span := tracing.Tracer.Start(ctx, "store.is_incomplete_index")
+	defer span.End()
+
+	defer func(now time.Time) {
+		log.Debugw("handled.is-complete-index", "took", fmt.Sprintf("%s", time.Since(now)))
+	}(time.Now())
+
+	md, err := s.db.GetPieceCidToMetadata(ctx, pieceCid)
+	if err != nil {
+		return false, normalizePieceCidError(pieceCid, err)
+	}
+
+	return md.CompleteIndex, nil
+}
+
+func (s *Store) AddIndex(ctx context.Context, pieceCid cid.Cid, records []model.Record, isCompleteIndex bool) error {
 	log.Debugw("handle.add-index", "records", len(records))
 
 	ctx, span := tracing.Tracer.Start(ctx, "store.add_index")
@@ -326,6 +344,9 @@ func (s *Store) AddIndex(ctx context.Context, pieceCid cid.Cid, records []model.
 	// mark indexing as complete
 	md.Cursor = cursor
 	md.IndexedAt = time.Now()
+	md.CompleteIndex = isCompleteIndex
+	md.Error = ""
+	md.ErrorType = ""
 
 	err = s.db.SetPieceCidToMetadata(ctx, pieceCid, md)
 	if err != nil {

--- a/extern/boostd-data/model/model.go
+++ b/extern/boostd-data/model/model.go
@@ -35,10 +35,14 @@ type DealInfo struct {
 
 // Metadata for PieceCid
 type Metadata struct {
-	IndexedAt time.Time  `json:"i"`
-	Deals     []DealInfo `json:"d"`
-	Error     string     `json:"e"`
-	ErrorType string     `json:"t"`
+	IndexedAt time.Time `json:"i"`
+	// CompleteIndex indicates whether the index has all information or is
+	// missing block size information. Note that indexes imported from the
+	// dagstore do not have block size information.
+	CompleteIndex bool       `json:"c"`
+	Deals         []DealInfo `json:"d"`
+	Error         string     `json:"e"`
+	ErrorType     string     `json:"t"`
 }
 
 // Record is the information stored in the index for each block in a piece

--- a/extern/boostd-data/svc/svc_test.go
+++ b/extern/boostd-data/svc/svc_test.go
@@ -93,7 +93,7 @@ func testService(ctx context.Context, t *testing.T, bdsvc *Service, port int) {
 	randomuuid, err := uuid.Parse("4d8f5ce6-dbfd-40dc-8b03-29308e97357b")
 	require.NoError(t, err)
 
-	err = cl.AddIndex(ctx, pieceCid, records)
+	err = cl.AddIndex(ctx, pieceCid, records, true)
 	require.NoError(t, err)
 
 	di := model.DealInfo{
@@ -201,7 +201,7 @@ func testServiceFuzz(ctx context.Context, t *testing.T, bdsvc *Service, port int
 
 			randomuuid := uuid.New()
 			pieceCid := testutil.GenerateCid()
-			err = cl.AddIndex(ctx, pieceCid, records)
+			err = cl.AddIndex(ctx, pieceCid, records, true)
 			require.NoError(t, err)
 
 			di := model.DealInfo{
@@ -419,7 +419,7 @@ func testCleanup(ctx context.Context, t *testing.T, bdsvc *Service, port int) {
 	randomuuid, err := uuid.Parse("4d8f5ce6-dbfd-40dc-8b03-29308e97357b")
 	require.NoError(t, err)
 
-	err = cl.AddIndex(ctx, pieceCid, records)
+	err = cl.AddIndex(ctx, pieceCid, records, true)
 	require.NoError(t, err)
 
 	di := model.DealInfo{

--- a/extern/boostd-data/svc/types/types.go
+++ b/extern/boostd-data/svc/types/types.go
@@ -23,9 +23,10 @@ func IsNotFound(err error) bool {
 
 type Service interface {
 	AddDealForPiece(context.Context, cid.Cid, model.DealInfo) error
-	AddIndex(context.Context, cid.Cid, []model.Record) error
+	AddIndex(context.Context, cid.Cid, []model.Record, bool) error
 	GetIndex(context.Context, cid.Cid) ([]model.Record, error)
 	IsIndexed(ctx context.Context, pieceCid cid.Cid) (bool, error)
+	IsCompleteIndex(ctx context.Context, pieceCid cid.Cid) (bool, error)
 	GetOffsetSize(context.Context, cid.Cid, mh.Multihash) (*model.OffsetSize, error)
 	ListPieces(ctx context.Context) ([]cid.Cid, error)
 	GetPieceMetadata(ctx context.Context, pieceCid cid.Cid) (model.Metadata, error)

--- a/node/impl/boost.go
+++ b/node/impl/boost.go
@@ -512,19 +512,15 @@ func (sm *BoostAPI) BoostDagstoreDestroyShard(ctx context.Context, key string) e
 }
 
 func (sm *BoostAPI) BlockstoreGet(ctx context.Context, c cid.Cid) ([]byte, error) {
-	blk, err := sm.IndexBackedBlockstore.Get(ctx, c)
-	if err != nil {
-		return nil, err
-	}
-	return blk.RawData(), nil
+	return sm.Pd.BlockstoreGet(ctx, c)
 }
 
 func (sm *BoostAPI) BlockstoreHas(ctx context.Context, c cid.Cid) (bool, error) {
-	return sm.IndexBackedBlockstore.Has(ctx, c)
+	return sm.Pd.BlockstoreHas(ctx, c)
 }
 
 func (sm *BoostAPI) BlockstoreGetSize(ctx context.Context, c cid.Cid) (int, error) {
-	return sm.IndexBackedBlockstore.GetSize(ctx, c)
+	return sm.Pd.BlockstoreGetSize(ctx, c)
 }
 
 func (sm *BoostAPI) PdBuildIndexForPieceCid(ctx context.Context, piececid cid.Cid) error {

--- a/piecedirectory/doctor_test.go
+++ b/piecedirectory/doctor_test.go
@@ -279,7 +279,7 @@ func testCheckPieces(ctx context.Context, t *testing.T, cl *client.Store) {
 
 	// Create an index for the piece
 	recs := GetRecords(t, carv1Reader)
-	err = cl.AddIndex(ctx, commpCalc.PieceCID, recs)
+	err = cl.AddIndex(ctx, commpCalc.PieceCID, recs, true)
 	require.NoError(t, err)
 
 	// Check the piece

--- a/piecedirectory/piecedirectory_test.go
+++ b/piecedirectory/piecedirectory_test.go
@@ -187,7 +187,7 @@ func testImportedIndex(ctx context.Context, t *testing.T, cl *client.Store) {
 
 	recs := GetRecords(t, carv1Reader)
 	pieceCid := CalculateCommp(t, carv1Reader).PieceCID
-	err = cl.AddIndex(ctx, pieceCid, recs)
+	err = cl.AddIndex(ctx, pieceCid, recs, false)
 	require.NoError(t, err)
 
 	// Add deal info for the piece - it doesn't matter what it is, the piece
@@ -216,8 +216,8 @@ func testImportedIndex(ctx context.Context, t *testing.T, cl *client.Store) {
 		}
 	}
 
-	// Add the index to the local index directory
-	err = cl.AddIndex(ctx, pieceCid, recs)
+	// Add the index to the local index directory, marked as incomplete
+	err = cl.AddIndex(ctx, pieceCid, recs, false)
 	require.NoError(t, err)
 
 	// Create a CARv2 index over the CAR file
@@ -272,7 +272,7 @@ func testCarFileSize(ctx context.Context, t *testing.T, cl *client.Store) {
 
 	recs := GetRecords(t, carv1Reader)
 	commpCalc := CalculateCommp(t, carv1Reader)
-	err = cl.AddIndex(ctx, commpCalc.PieceCID, recs)
+	err = cl.AddIndex(ctx, commpCalc.PieceCID, recs, false)
 	require.NoError(t, err)
 
 	// Add deal info for the piece without a CAR file
@@ -310,7 +310,7 @@ func testFlaggingPieces(ctx context.Context, t *testing.T, cl *client.Store) {
 
 	recs := GetRecords(t, carv1Reader)
 	commpCalc := CalculateCommp(t, carv1Reader)
-	err = cl.AddIndex(ctx, commpCalc.PieceCID, recs)
+	err = cl.AddIndex(ctx, commpCalc.PieceCID, recs, true)
 	require.NoError(t, err)
 
 	// Add deal info for the piece

--- a/piecedirectory/types/mocks/piecedirectory.go
+++ b/piecedirectory/types/mocks/piecedirectory.go
@@ -176,17 +176,17 @@ func (mr *MockStoreMockRecorder) AddDealForPiece(arg0, arg1, arg2 interface{}) *
 }
 
 // AddIndex mocks base method.
-func (m *MockStore) AddIndex(arg0 context.Context, arg1 cid.Cid, arg2 []model.Record) error {
+func (m *MockStore) AddIndex(arg0 context.Context, arg1 cid.Cid, arg2 []model.Record, arg3 bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddIndex", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "AddIndex", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // AddIndex indicates an expected call of AddIndex.
-func (mr *MockStoreMockRecorder) AddIndex(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockStoreMockRecorder) AddIndex(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddIndex", reflect.TypeOf((*MockStore)(nil).AddIndex), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddIndex", reflect.TypeOf((*MockStore)(nil).AddIndex), arg0, arg1, arg2, arg3)
 }
 
 // FlagPiece mocks base method.
@@ -291,6 +291,21 @@ func (m *MockStore) GetPieceMetadata(arg0 context.Context, arg1 cid.Cid) (model.
 func (mr *MockStoreMockRecorder) GetPieceMetadata(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPieceMetadata", reflect.TypeOf((*MockStore)(nil).GetPieceMetadata), arg0, arg1)
+}
+
+// IsCompleteIndex mocks base method.
+func (m *MockStore) IsCompleteIndex(arg0 context.Context, arg1 cid.Cid) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsCompleteIndex", arg0, arg1)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IsCompleteIndex indicates an expected call of IsCompleteIndex.
+func (mr *MockStoreMockRecorder) IsCompleteIndex(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsCompleteIndex", reflect.TypeOf((*MockStore)(nil).IsCompleteIndex), arg0, arg1)
 }
 
 // IsIndexed mocks base method.

--- a/piecedirectory/types/types.go
+++ b/piecedirectory/types/types.go
@@ -28,8 +28,9 @@ type PieceReader interface {
 
 type Store interface {
 	AddDealForPiece(ctx context.Context, pieceCid cid.Cid, dealInfo model.DealInfo) error
-	AddIndex(ctx context.Context, pieceCid cid.Cid, records []model.Record) error
+	AddIndex(ctx context.Context, pieceCid cid.Cid, records []model.Record, isCompleteIndex bool) error
 	IsIndexed(ctx context.Context, pieceCid cid.Cid) (bool, error)
+	IsCompleteIndex(ctx context.Context, pieceCid cid.Cid) (bool, error)
 	GetIndex(ctx context.Context, pieceCid cid.Cid) (index.Index, error)
 	GetOffsetSize(ctx context.Context, pieceCid cid.Cid, hash multihash.Multihash) (*model.OffsetSize, error)
 	GetPieceMetadata(ctx context.Context, pieceCid cid.Cid) (model.Metadata, error)


### PR DESCRIPTION
Adds a `CompleteIndex` flag to the local index directory model to indicate whether the index is complete, or missing block size information (because it was imported from the dagstore)