### PR TITLE
Adjust booster-bitswap verbosity

### DIFF
--- a/cli/util/verbose.go
+++ b/cli/util/verbose.go
@@ -2,6 +2,19 @@ package cliutil
 
 import "github.com/urfave/cli/v2"
 
+// IsVerbose is a global var signalling if the CLI is running in
+// verbose mode or not (default: false).
+var IsVerbose bool
+
+// FlagVerbose enables verbose mode, which shows verbose information about
+// operations invoked in the CLI. It should be included as a flag on the
+// top-level command (e.g. boost -v).
+var FlagVerbose = &cli.BoolFlag{
+	Name:        "v",
+	Usage:       "enables verbose mode, outputs more logging",
+	Destination: &IsVerbose,
+}
+
 // IsVeryVerbose is a global var signalling if the CLI is running in very
 // verbose mode or not (default: false).
 var IsVeryVerbose bool

--- a/cmd/booster-bitswap/init.go
+++ b/cmd/booster-bitswap/init.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/filecoin-project/boost/build"
 	"github.com/libp2p/go-libp2p"
 	crypto "github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/host"
@@ -106,5 +107,15 @@ var initCmd = &cli.Command{
 		peerID, _, err := configureRepo(repoDir, true)
 		fmt.Println("Initialized booster-bitswap with libp2p peer ID: " + peerID.String())
 		return err
+	},
+}
+
+var versionCmd = &cli.Command{
+	Name:   "version",
+	Usage:  "Print booster-bitswap version",
+	Before: before,
+	Action: func(cctx *cli.Context) error {
+		fmt.Println("booster-bitswap " + build.UserVersion())
+		return nil
 	},
 }

--- a/cmd/booster-bitswap/main.go
+++ b/cmd/booster-bitswap/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"os"
 
-	"github.com/filecoin-project/boost/build"
 	cliutil "github.com/filecoin-project/boost/cli/util"
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/urfave/cli/v2"
@@ -23,8 +22,8 @@ func main() {
 		Name:                 "booster-bitswap",
 		Usage:                "Bitswap endpoint for retrieval from Filecoin",
 		EnableBashCompletion: true,
-		Version:              build.UserVersion(),
 		Flags: []cli.Flag{
+			cliutil.FlagVerbose,
 			cliutil.FlagVeryVerbose,
 			FlagRepo,
 		},
@@ -32,6 +31,7 @@ func main() {
 			initCmd,
 			runCmd,
 			fetchCmd,
+			versionCmd,
 		},
 	}
 	app.Setup()
@@ -44,6 +44,9 @@ func main() {
 func before(cctx *cli.Context) error {
 	_ = logging.SetLogLevel("booster", "INFO")
 
+	if cliutil.IsVerbose {
+		_ = logging.SetLogLevel("remote-blockstore", "INFO")
+	}
 	if cliutil.IsVeryVerbose {
 		_ = logging.SetLogLevel("booster", "DEBUG")
 		_ = logging.SetLogLevel("remote-blockstore", "DEBUG")

--- a/cmd/booster-bitswap/remoteblockstore/remoteblockstore.go
+++ b/cmd/booster-bitswap/remoteblockstore/remoteblockstore.go
@@ -47,11 +47,13 @@ func (ro *RemoteBlockstore) Get(ctx context.Context, c cid.Cid) (b blocks.Block,
 	log.Debugw("Get", "cid", c)
 	data, err := ro.api.BlockstoreGet(ctx, c)
 	err = normalizeError(err)
-	log.Debugw("Get response", "cid", c, "error", err)
+	log.Debugw("Get response", "cid", c, "size", len(data), "error", err)
 	if err != nil {
+		log.Infow("Get failed", "cid", c, "error", err)
 		stats.Record(ctx, metrics.BitswapRblsGetFailResponseCount.M(1))
 		return nil, err
 	}
+	log.Infow("Get", "cid", c, "size", len(data))
 	stats.Record(ctx, metrics.BitswapRblsGetSuccessResponseCount.M(1))
 	return blocks.NewBlockWithCid(data, c)
 }


### PR DESCRIPTION
There are now three modes:
- Normal:
  Just output startup message with booster-bitswap listen address
- Verbose `-v`
  Output a message for each block served
- Very verbose `-vv`
  Output a message for each request received (has, get size, get block)


The `-v` flag was being used to output the version. So instead I added a `version` command so we can use `-v` for Verbose mode.

```
$ booster-bitswap version
booster-bitswap 1.5.1-rc3+git.b31dbff.dirty

$ booster-bitswap -v run --api-boost=$BOOST_API_INFO
2023-01-24T11:51:36.977+0100	INFO	booster	booster-bitswap/run.go:187	Using boost API at ws://127.0.0.1:1288/rpc/v0
2023-01-24T11:51:37.015+0100	INFO	booster	booster-bitswap/run.go:145	Starting booster-bitswap node on port 8888
2023-01-24T11:51:37.016+0100	INFO	booster	booster-bitswap/server.go:82	bitswap server running	{"multiaddrs": ["/ip4/192.168.1.2/tcp/8888","/ip4/127.0.0.1/tcp/8888","/ip4/192.168.1.2/udp/8888/quic","/ip4/127.0.0.1/udp/8888/quic"], "peerId": "12D3KooWSP1SwCpRzgW8WZPty4T6dZJfWKjqsp2tntxBtDCmQbHf"}
2023-01-24T11:51:37.016+0100	INFO	booster	booster-bitswap/run.go:153	Starting booster-bitswap metrics web server on port 9696
2023-01-24T11:51:49.746+0100	INFO	remote-blockstore	remoteblockstore/remoteblockstore.go:56	Get	{"cid": "bafk2bzacedsnewk7clxwab2wgwyoi7u5tzdhldx7fkxpqdq7unrxz2zoy4d2g", "size": 1000}
2023-01-24T11:51:56.518+0100	INFO	booster	booster-bitswap/run.go:164	Shutting down...
2023-01-24T11:51:56.518+0100	INFO	booster	booster-bitswap/run.go:170	Graceful shutdown successful


$ booster-bitswap -vv run --api-boost=$BOOST_API_INFO
2023-01-24T11:57:18.504+0100	INFO	booster	booster-bitswap/run.go:187	Using boost API at ws://127.0.0.1:1288/rpc/v0
2023-01-24T11:57:18.540+0100	INFO	booster	booster-bitswap/run.go:145	Starting booster-bitswap node on port 8888
2023-01-24T11:57:18.540+0100	INFO	booster	booster-bitswap/server.go:82	bitswap server running	{"multiaddrs": ["/ip4/192.168.1.2/tcp/8888","/ip4/127.0.0.1/tcp/8888","/ip4/192.168.1.2/udp/8888/quic","/ip4/127.0.0.1/udp/8888/quic"], "peerId": "12D3KooWSP1SwCpRzgW8WZPty4T6dZJfWKjqsp2tntxBtDCmQbHf"}
2023-01-24T11:57:18.541+0100	INFO	booster	booster-bitswap/run.go:153	Starting booster-bitswap metrics web server on port 9696
2023-01-24T11:57:25.666+0100	DEBUG	remote-blockstore	remoteblockstore/remoteblockstore.go:84	GetSize	{"cid": "bafk2bzacedsnewk7clxwab2wgwyoi7u5tzdhldx7fkxpqdq7unrxz2zoy4d2g"}
2023-01-24T11:57:25.668+0100	DEBUG	remote-blockstore	remoteblockstore/remoteblockstore.go:87	GetSize response	{"cid": "bafk2bzacedsnewk7clxwab2wgwyoi7u5tzdhldx7fkxpqdq7unrxz2zoy4d2g", "size": 1000, "error": null}
2023-01-24T11:57:25.668+0100	DEBUG	remote-blockstore	remoteblockstore/remoteblockstore.go:47	Get	{"cid": "bafk2bzacedsnewk7clxwab2wgwyoi7u5tzdhldx7fkxpqdq7unrxz2zoy4d2g"}
2023-01-24T11:57:25.671+0100	DEBUG	remote-blockstore	remoteblockstore/remoteblockstore.go:50	Get response	{"cid": "bafk2bzacedsnewk7clxwab2wgwyoi7u5tzdhldx7fkxpqdq7unrxz2zoy4d2g", "size": 1000, "error": null}
2023-01-24T11:57:25.671+0100	INFO	remote-blockstore	remoteblockstore/remoteblockstore.go:56	Get	{"cid": "bafk2bzacedsnewk7clxwab2wgwyoi7u5tzdhldx7fkxpqdq7unrxz2zoy4d2g", "size": 1000}
```