### PR TITLE
booster-bitswap init: output keyfile path

### DIFF
--- a/cmd/booster-bitswap/init.go
+++ b/cmd/booster-bitswap/init.go
@@ -61,7 +61,7 @@ func setupHost(cfgDir string, port int) (host.Host, error) {
 }
 
 func loadPeerKey(cfgDir string, createIfNotExists bool) (crypto.PrivKey, error) {
-	keyPath := filepath.Join(cfgDir, "libp2p.key")
+	keyPath := getKeyPath(cfgDir)
 	keyFile, err := os.ReadFile(keyPath)
 	if err == nil {
 		return crypto.UnmarshalPrivateKey(keyFile)
@@ -92,6 +92,10 @@ func loadPeerKey(cfgDir string, createIfNotExists bool) (crypto.PrivKey, error) 
 	return key, nil
 }
 
+func getKeyPath(cfgDir string) string {
+	return filepath.Join(cfgDir, "libp2p.key")
+}
+
 var initCmd = &cli.Command{
 	Name:   "init",
 	Usage:  "Init booster-bitswap config",
@@ -104,7 +108,8 @@ var initCmd = &cli.Command{
 		}
 
 		peerID, _, err := configureRepo(repoDir, true)
-		fmt.Println("Initialized booster-bitswap with libp2p peer ID: " + peerID.String())
+		fmt.Println("Initialized booster-bitswap with libp2p peer ID " + peerID.String())
+		fmt.Println("Key file: " + getKeyPath(repoDir))
 		return err
 	},
 }


### PR DESCRIPTION
When adding a connection between boostd and booster-bitswap, the Storage Provider needs to configure the peer ID and the path to the key file.
This PR modifies the `booster-bitswap init` command to also output the key file path.

```
$ booster-bitswap init
Initialized booster-bitswap with libp2p peer ID 12D3KooWSP1SwCpRzgW8WZPty4T6dZJfWKjqsp2tntxBtDCmQbHf
Key file: /home/user/.booster-bitswap/libp2p.key
```