### PR TITLE
Add bitswap bytes served grafana dashboard

### DIFF
--- a/cmd/booster-bitswap/remoteblockstore/remoteblockstore.go
+++ b/cmd/booster-bitswap/remoteblockstore/remoteblockstore.go
@@ -53,6 +53,7 @@ func (ro *RemoteBlockstore) Get(ctx context.Context, c cid.Cid) (b blocks.Block,
 		return nil, err
 	}
 	stats.Record(ctx, metrics.BitswapRblsGetSuccessResponseCount.M(1))
+	stats.Record(ctx, metrics.BitswapRblsBytesSentCount.M(int64(len(data))))
 	return blocks.NewBlockWithCid(data, c)
 }
 

--- a/docker/monitoring/grafana/dashboards/provider-retrievals.json
+++ b/docker/monitoring/grafana/dashboards/provider-retrievals.json
@@ -24,7 +24,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 833,
+  "id": 5,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -328,10 +328,106 @@
         "overrides": []
       },
       "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 10
+      },
+      "id": 60,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prom1234"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "irate(booster_bitswap_bitswap_rbls_bytes_sent_count{}[$__rate_interval]) * 15",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Bitswap Bytes Served",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prom1234"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 10
+        "y": 17
       },
       "id": 36,
       "options": {
@@ -425,195 +521,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 10
-      },
-      "id": 41,
-      "options": {
-        "legend": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prom1234"
-          },
-          "editorMode": "code",
-          "expr": "irate(booster_bitswap_bitswap_rbls_has_request_count{}[$__rate_interval]) * 15",
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Bitswap Block Has Requests",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prom1234"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 16,
-        "y": 10
-      },
-      "id": 40,
-      "options": {
-        "legend": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prom1234"
-          },
-          "editorMode": "code",
-          "expr": "irate(booster_bitswap_bitswap_rbls_getsize_request_count{}[$__rate_interval]) * 15",
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Bitswap Block GetSize Requests",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prom1234"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 0,
-        "y": 18
+        "y": 17
       },
       "id": 39,
       "options": {
@@ -711,29 +619,31 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "percentunit"
         },
         "overrides": []
       },
       "gridPos": {
         "h": 8,
         "w": 8,
-        "x": 8,
-        "y": 18
+        "x": 16,
+        "y": 17
       },
-      "id": 42,
+      "id": 46,
       "options": {
         "legend": {
           "calcs": [
-            "lastNotNull"
+            "last",
+            "mean"
           ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
         },
         "tooltip": {
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "targets": [
@@ -743,8 +653,8 @@
             "uid": "prom1234"
           },
           "editorMode": "code",
-          "expr": "irate(booster_bitswap_bitswap_rbls_has_success_response_count{}[$__rate_interval]) * 15",
-          "legendFormat": "__auto",
+          "expr": "(irate(booster_bitswap_bitswap_rbls_get_success_response_count{}[$__rate_interval]) * 15) / (irate(booster_bitswap_bitswap_rbls_get_request_count{}[$__rate_interval]) * 15)",
+          "legendFormat": "Success",
           "range": true,
           "refId": "A"
         },
@@ -754,14 +664,14 @@
             "uid": "prom1234"
           },
           "editorMode": "code",
-          "expr": "irate(booster_bitswap_bitswap_rbls_has_fail_response_count{}[$__rate_interval]) * 15",
+          "expr": "(irate(booster_bitswap_bitswap_rbls_get_fail_response_count{}[$__rate_interval]) * 15) / (irate(booster_bitswap_bitswap_rbls_get_request_count{}[$__rate_interval]) * 15)",
           "hide": false,
-          "legendFormat": "__auto",
+          "legendFormat": "Fail",
           "range": true,
           "refId": "B"
         }
       ],
-      "title": "Bitswap Block Has Response Counts",
+      "title": "Bitswap Block Get Success / Failure Rate",
       "type": "timeseries"
     },
     {
@@ -824,8 +734,102 @@
       "gridPos": {
         "h": 8,
         "w": 8,
-        "x": 16,
-        "y": 18
+        "x": 0,
+        "y": 25
+      },
+      "id": 40,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prom1234"
+          },
+          "editorMode": "code",
+          "expr": "irate(booster_bitswap_bitswap_rbls_getsize_request_count{}[$__rate_interval]) * 15",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Bitswap Block GetSize Requests",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prom1234"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 25
       },
       "id": 43,
       "options": {
@@ -930,11 +934,11 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 24,
-        "x": 0,
-        "y": 26
+        "w": 8,
+        "x": 16,
+        "y": 25
       },
-      "id": 45,
+      "id": 48,
       "options": {
         "legend": {
           "calcs": [
@@ -957,7 +961,7 @@
             "uid": "prom1234"
           },
           "editorMode": "code",
-          "expr": "sum((irate(booster_bitswap_bitswap_rbls_get_success_response_count{}[$__rate_interval]) * 15) + (irate(booster_bitswap_bitswap_rbls_has_success_response_count{}[$__rate_interval]) * 15) + (irate(booster_bitswap_bitswap_rbls_getsize_success_response_count{}[$__rate_interval]) * 15)) / sum((irate(booster_bitswap_bitswap_rbls_get_request_count{}[$__rate_interval]) * 15) + (irate(booster_bitswap_bitswap_rbls_has_request_count{}[$__rate_interval]) * 15) + (irate(booster_bitswap_bitswap_rbls_getsize_request_count{}[$__rate_interval]) * 15))",
+          "expr": "(irate(booster_bitswap_bitswap_rbls_getsize_success_response_count{}[$__rate_interval]) * 15) / (irate(booster_bitswap_bitswap_rbls_getsize_request_count{}[$__rate_interval]) * 15)",
           "legendFormat": "Success",
           "range": true,
           "refId": "A"
@@ -968,14 +972,14 @@
             "uid": "prom1234"
           },
           "editorMode": "code",
-          "expr": "sum((irate(booster_bitswap_bitswap_rbls_get_fail_response_count{}[$__rate_interval]) * 15) + (irate(booster_bitswap_bitswap_rbls_has_fail_response_count{}[$__rate_interval]) * 15) + (irate(booster_bitswap_bitswap_rbls_getsize_fail_response_count{}[$__rate_interval]) * 15)) / sum((irate(booster_bitswap_bitswap_rbls_get_request_count{}[$__rate_interval]) * 15) + (irate(booster_bitswap_bitswap_rbls_has_request_count{}[$__rate_interval]) * 15) + (irate(booster_bitswap_bitswap_rbls_getsize_request_count{}[$__rate_interval]) * 15))",
+          "expr": "(irate(booster_bitswap_bitswap_rbls_getsize_fail_response_count{}[$__rate_interval]) * 15) / (irate(booster_bitswap_bitswap_rbls_getsize_fail_count{}[$__rate_interval]) * 15)",
           "hide": false,
           "legendFormat": "Fail",
           "range": true,
           "refId": "B"
         }
       ],
-      "title": "Bitswap Success / Failure Rate",
+      "title": "Bitswap Block GetSize Success / Failure Rate",
       "type": "timeseries"
     },
     {
@@ -1023,15 +1027,15 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
                 "value": 80
               }
             ]
-          },
-          "unit": "percentunit"
+          }
         },
         "overrides": []
       },
@@ -1039,22 +1043,21 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 34
+        "y": 33
       },
-      "id": 46,
+      "id": 41,
       "options": {
         "legend": {
           "calcs": [
-            "last",
-            "mean"
+            "lastNotNull"
           ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
         },
         "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
+          "mode": "single",
+          "sort": "none"
         }
       },
       "targets": [
@@ -1064,25 +1067,13 @@
             "uid": "prom1234"
           },
           "editorMode": "code",
-          "expr": "(irate(booster_bitswap_bitswap_rbls_get_success_response_count{}[$__rate_interval]) * 15) / (irate(booster_bitswap_bitswap_rbls_get_request_count{}[$__rate_interval]) * 15)",
-          "legendFormat": "Success",
+          "expr": "irate(booster_bitswap_bitswap_rbls_has_request_count{}[$__rate_interval]) * 15",
+          "legendFormat": "__auto",
           "range": true,
           "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prom1234"
-          },
-          "editorMode": "code",
-          "expr": "(irate(booster_bitswap_bitswap_rbls_get_fail_response_count{}[$__rate_interval]) * 15) / (irate(booster_bitswap_bitswap_rbls_get_request_count{}[$__rate_interval]) * 15)",
-          "hide": false,
-          "legendFormat": "Fail",
-          "range": true,
-          "refId": "B"
         }
       ],
-      "title": "Bitswap Block Get Success / Failure Rate",
+      "title": "Bitswap Block Has Requests",
       "type": "timeseries"
     },
     {
@@ -1130,15 +1121,15 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
                 "value": 80
               }
             ]
-          },
-          "unit": "percentunit"
+          }
         },
         "overrides": []
       },
@@ -1146,7 +1137,114 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 34
+        "y": 33
+      },
+      "id": 42,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prom1234"
+          },
+          "editorMode": "code",
+          "expr": "irate(booster_bitswap_bitswap_rbls_has_success_response_count{}[$__rate_interval]) * 15",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prom1234"
+          },
+          "editorMode": "code",
+          "expr": "irate(booster_bitswap_bitswap_rbls_has_fail_response_count{}[$__rate_interval]) * 15",
+          "hide": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Bitswap Block Has Response Counts",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prom1234"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 33
       },
       "id": 47,
       "options": {
@@ -1237,7 +1335,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1252,10 +1351,10 @@
       "gridPos": {
         "h": 8,
         "w": 8,
-        "x": 16,
-        "y": 34
+        "x": 0,
+        "y": 41
       },
-      "id": 48,
+      "id": 45,
       "options": {
         "legend": {
           "calcs": [
@@ -1278,7 +1377,7 @@
             "uid": "prom1234"
           },
           "editorMode": "code",
-          "expr": "(irate(booster_bitswap_bitswap_rbls_getsize_success_response_count{}[$__rate_interval]) * 15) / (irate(booster_bitswap_bitswap_rbls_getsize_request_count{}[$__rate_interval]) * 15)",
+          "expr": "sum((irate(booster_bitswap_bitswap_rbls_get_success_response_count{}[$__rate_interval]) * 15) + (irate(booster_bitswap_bitswap_rbls_has_success_response_count{}[$__rate_interval]) * 15) + (irate(booster_bitswap_bitswap_rbls_getsize_success_response_count{}[$__rate_interval]) * 15)) / sum((irate(booster_bitswap_bitswap_rbls_get_request_count{}[$__rate_interval]) * 15) + (irate(booster_bitswap_bitswap_rbls_has_request_count{}[$__rate_interval]) * 15) + (irate(booster_bitswap_bitswap_rbls_getsize_request_count{}[$__rate_interval]) * 15))",
           "legendFormat": "Success",
           "range": true,
           "refId": "A"
@@ -1289,14 +1388,14 @@
             "uid": "prom1234"
           },
           "editorMode": "code",
-          "expr": "(irate(booster_bitswap_bitswap_rbls_getsize_fail_response_count{}[$__rate_interval]) * 15) / (irate(booster_bitswap_bitswap_rbls_getsize_fail_count{}[$__rate_interval]) * 15)",
+          "expr": "sum((irate(booster_bitswap_bitswap_rbls_get_fail_response_count{}[$__rate_interval]) * 15) + (irate(booster_bitswap_bitswap_rbls_has_fail_response_count{}[$__rate_interval]) * 15) + (irate(booster_bitswap_bitswap_rbls_getsize_fail_response_count{}[$__rate_interval]) * 15)) / sum((irate(booster_bitswap_bitswap_rbls_get_request_count{}[$__rate_interval]) * 15) + (irate(booster_bitswap_bitswap_rbls_has_request_count{}[$__rate_interval]) * 15) + (irate(booster_bitswap_bitswap_rbls_getsize_request_count{}[$__rate_interval]) * 15))",
           "hide": false,
           "legendFormat": "Fail",
           "range": true,
           "refId": "B"
         }
       ],
-      "title": "Bitswap Block GetSize Success / Failure Rate",
+      "title": "Bitswap Success / Failure Rate",
       "type": "timeseries"
     },
     {
@@ -1345,7 +1444,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1360,8 +1460,8 @@
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 6,
-        "y": 42
+        "x": 8,
+        "y": 41
       },
       "id": 59,
       "options": {
@@ -1396,842 +1496,848 @@
       "type": "timeseries"
     },
     {
-      "collapsed": true,
+      "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 50
+        "y": 49
       },
       "id": 30,
-      "panels": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prom1234"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "none"
-            },
-            "overrides": [
-              {
-                "__systemRef": "hideSeriesFrom",
-                "matcher": {
-                  "id": "byNames",
-                  "options": {
-                    "mode": "exclude",
-                    "names": [
-                      "Requests"
-                    ],
-                    "prefix": "All except:",
-                    "readOnly": true
-                  }
-                },
-                "properties": [
-                  {
-                    "id": "custom.hideFrom",
-                    "value": {
-                      "legend": false,
-                      "tooltip": false,
-                      "viz": true
-                    }
-                  }
-                ]
-              }
-            ]
-          },
-          "gridPos": {
-            "h": 7,
-            "w": 12,
-            "x": 0,
-            "y": 19
-          },
-          "id": 2,
-          "options": {
-            "legend": {
-              "calcs": [
-                "sum"
-              ],
-              "displayMode": "table",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "multi",
-              "sort": "none"
-            }
-          },
-          "pluginVersion": "9.2.0-77684pre",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prom1234"
-              },
-              "editorMode": "code",
-              "expr": "irate(booster_http_http_payload_by_cid_request_count{host=~\"$host\"}[$__rate_interval]) * 15",
-              "legendFormat": "Requests",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "Payload by CID Requests",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prom1234"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "none"
-            },
-            "overrides": [
-              {
-                "__systemRef": "hideSeriesFrom",
-                "matcher": {
-                  "id": "byNames",
-                  "options": {
-                    "mode": "exclude",
-                    "names": [
-                      "Requests"
-                    ],
-                    "prefix": "All except:",
-                    "readOnly": true
-                  }
-                },
-                "properties": [
-                  {
-                    "id": "custom.hideFrom",
-                    "value": {
-                      "legend": false,
-                      "tooltip": false,
-                      "viz": true
-                    }
-                  }
-                ]
-              }
-            ]
-          },
-          "gridPos": {
-            "h": 7,
-            "w": 12,
-            "x": 12,
-            "y": 19
-          },
-          "id": 3,
-          "options": {
-            "legend": {
-              "calcs": [
-                "sum"
-              ],
-              "displayMode": "table",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "multi",
-              "sort": "none"
-            }
-          },
-          "pluginVersion": "9.2.0-77684pre",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prom1234"
-              },
-              "editorMode": "code",
-              "expr": "irate(booster_http_http_piece_by_cid_request_count{host=~\"$host\"}[$__rate_interval]) * 15",
-              "legendFormat": "Requests",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "Piece by CID Requests",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prom1234"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "none"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 26
-          },
-          "id": 36,
-          "options": {
-            "legend": {
-              "calcs": [
-                "sum"
-              ],
-              "displayMode": "table",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "multi",
-              "sort": "desc"
-            }
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prom1234"
-              },
-              "editorMode": "code",
-              "expr": "irate(booster_http_http_payload_by_cid_200_response_count{host=~\"$host\"}[$__rate_interval]) * 15",
-              "legendFormat": "200",
-              "range": true,
-              "refId": "A"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prom1234"
-              },
-              "editorMode": "code",
-              "expr": "irate(booster_http_http_payload_by_cid_400_response_count{host=~\"$host\"}[$__rate_interval]) * 15",
-              "hide": false,
-              "legendFormat": "400",
-              "range": true,
-              "refId": "B"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prom1234"
-              },
-              "editorMode": "code",
-              "expr": "irate(booster_http_http_payload_by_cid_404_response_count{host=~\"$host\"}[$__rate_interval]) * 15",
-              "hide": false,
-              "legendFormat": "404",
-              "range": true,
-              "refId": "C"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prom1234"
-              },
-              "editorMode": "code",
-              "expr": "irate(booster_http_http_payload_by_cid_500_response_count{host=~\"$host\"}[$__rate_interval]) * 15",
-              "hide": false,
-              "legendFormat": "500",
-              "range": true,
-              "refId": "D"
-            }
-          ],
-          "title": "Payload by CID Status Response Counts",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prom1234"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "none"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 26
-          },
-          "id": 37,
-          "options": {
-            "legend": {
-              "calcs": [
-                "sum"
-              ],
-              "displayMode": "table",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "multi",
-              "sort": "desc"
-            }
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prom1234"
-              },
-              "editorMode": "code",
-              "expr": "irate(booster_http_http_piece_by_cid_200_response_count{host=~\"$host\"}[$__rate_interval]) * 15",
-              "legendFormat": "200",
-              "range": true,
-              "refId": "A"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prom1234"
-              },
-              "editorMode": "code",
-              "expr": "irate(booster_http_http_piece_by_cid_400_response_count{host=~\"$host\"}[$__rate_interval]) * 15",
-              "hide": false,
-              "legendFormat": "400",
-              "range": true,
-              "refId": "B"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prom1234"
-              },
-              "editorMode": "code",
-              "expr": "irate(booster_http_http_piece_by_cid_404_response_count{host=~\"$host\"}[$__rate_interval]) * 15",
-              "hide": false,
-              "legendFormat": "404",
-              "range": true,
-              "refId": "C"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prom1234"
-              },
-              "editorMode": "code",
-              "expr": "irate(booster_http_http_piece_by_cid_500_response_count{host=~\"$host\"}[$__rate_interval]) * 15",
-              "hide": false,
-              "legendFormat": "500",
-              "range": true,
-              "refId": "D"
-            }
-          ],
-          "title": "Piece by CID Status Response Counts",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prom1234"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  }
-                ]
-              },
-              "unit": "ms"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 7,
-            "w": 12,
-            "x": 0,
-            "y": 34
-          },
-          "id": 5,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "multi",
-              "sort": "desc"
-            }
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prom1234"
-              },
-              "editorMode": "code",
-              "exemplar": false,
-              "expr": "histogram_quantile(0.5, sum(irate(booster_http_http_payload_by_cid_request_duration_ms_bucket{host=~\"$host\"}[$__rate_interval]) * 15) by (le))",
-              "format": "time_series",
-              "hide": false,
-              "instant": false,
-              "legendFormat": "50%",
-              "range": true,
-              "refId": "A"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prom1234"
-              },
-              "editorMode": "code",
-              "expr": "histogram_quantile(0.95, sum(irate(booster_http_http_payload_by_cid_request_duration_ms_bucket{host=~\"$host\"}[$__rate_interval]) * 15) by (le))",
-              "hide": false,
-              "legendFormat": "95%",
-              "range": true,
-              "refId": "B"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prom1234"
-              },
-              "editorMode": "code",
-              "expr": "histogram_quantile(0.98, sum(irate(booster_http_http_payload_by_cid_request_duration_ms_bucket{host=~\"$host\"}[$__rate_interval]) * 15) by (le))",
-              "hide": false,
-              "legendFormat": "98%",
-              "range": true,
-              "refId": "C"
-            }
-          ],
-          "title": "Payload by CID Request Durations",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prom1234"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  }
-                ]
-              },
-              "unit": "ms"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 7,
-            "w": 12,
-            "x": 12,
-            "y": 34
-          },
-          "id": 6,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "multi",
-              "sort": "desc"
-            }
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prom1234"
-              },
-              "editorMode": "code",
-              "expr": "histogram_quantile(0.5, sum(irate(booster_http_http_piece_by_cid_request_duration_ms_bucket{host=~\"$host\"}[$__rate_interval]) * 15) by (le))",
-              "format": "time_series",
-              "legendFormat": "50%",
-              "range": true,
-              "refId": "A"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prom1234"
-              },
-              "editorMode": "code",
-              "expr": "histogram_quantile(0.95, sum(irate(booster_http_http_piece_by_cid_request_duration_ms_bucket{host=~\"$host\"}[$__rate_interval]) * 15) by (le))",
-              "hide": false,
-              "legendFormat": "95%",
-              "range": true,
-              "refId": "B"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prom1234"
-              },
-              "editorMode": "code",
-              "expr": "histogram_quantile(0.98, sum(irate(booster_http_http_piece_by_cid_request_duration_ms_bucket{host=~\"$host\"}[$__rate_interval]) * 15) by (le))",
-              "hide": false,
-              "legendFormat": "98%",
-              "range": true,
-              "refId": "C"
-            }
-          ],
-          "title": "Piece by CID Request Durations",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prom1234"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": true,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "links": [],
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "short"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 41
-          },
-          "id": 9,
-          "links": [],
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": false
-            },
-            "tooltip": {
-              "mode": "multi",
-              "sort": "none"
-            }
-          },
-          "pluginVersion": "8.5.2",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prom1234"
-              },
-              "editorMode": "code",
-              "expr": "go_goroutines{job=~\"booster-http\", host=~\"$host\"}",
-              "legendFormat": "Goroutines",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "Goroutines",
-          "type": "timeseries"
-        }
-      ],
+      "panels": [],
       "title": "booster-http",
       "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prom1234"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "Requests"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 50
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [
+            "sum"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.2.0-77684pre",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prom1234"
+          },
+          "editorMode": "code",
+          "expr": "irate(booster_http_http_payload_by_cid_request_count{host=~\"$host\"}[$__rate_interval]) * 15",
+          "legendFormat": "Requests",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Payload by CID Requests",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prom1234"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "Requests"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 50
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [
+            "sum"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.2.0-77684pre",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prom1234"
+          },
+          "editorMode": "code",
+          "expr": "irate(booster_http_http_piece_by_cid_request_count{host=~\"$host\"}[$__rate_interval]) * 15",
+          "legendFormat": "Requests",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Piece by CID Requests",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prom1234"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 57
+      },
+      "id": 36,
+      "options": {
+        "legend": {
+          "calcs": [
+            "sum"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prom1234"
+          },
+          "editorMode": "code",
+          "expr": "irate(booster_http_http_payload_by_cid_200_response_count{host=~\"$host\"}[$__rate_interval]) * 15",
+          "legendFormat": "200",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prom1234"
+          },
+          "editorMode": "code",
+          "expr": "irate(booster_http_http_payload_by_cid_400_response_count{host=~\"$host\"}[$__rate_interval]) * 15",
+          "hide": false,
+          "legendFormat": "400",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prom1234"
+          },
+          "editorMode": "code",
+          "expr": "irate(booster_http_http_payload_by_cid_404_response_count{host=~\"$host\"}[$__rate_interval]) * 15",
+          "hide": false,
+          "legendFormat": "404",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prom1234"
+          },
+          "editorMode": "code",
+          "expr": "irate(booster_http_http_payload_by_cid_500_response_count{host=~\"$host\"}[$__rate_interval]) * 15",
+          "hide": false,
+          "legendFormat": "500",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "Payload by CID Status Response Counts",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prom1234"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 57
+      },
+      "id": 37,
+      "options": {
+        "legend": {
+          "calcs": [
+            "sum"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prom1234"
+          },
+          "editorMode": "code",
+          "expr": "irate(booster_http_http_piece_by_cid_200_response_count{host=~\"$host\"}[$__rate_interval]) * 15",
+          "legendFormat": "200",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prom1234"
+          },
+          "editorMode": "code",
+          "expr": "irate(booster_http_http_piece_by_cid_400_response_count{host=~\"$host\"}[$__rate_interval]) * 15",
+          "hide": false,
+          "legendFormat": "400",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prom1234"
+          },
+          "editorMode": "code",
+          "expr": "irate(booster_http_http_piece_by_cid_404_response_count{host=~\"$host\"}[$__rate_interval]) * 15",
+          "hide": false,
+          "legendFormat": "404",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prom1234"
+          },
+          "editorMode": "code",
+          "expr": "irate(booster_http_http_piece_by_cid_500_response_count{host=~\"$host\"}[$__rate_interval]) * 15",
+          "hide": false,
+          "legendFormat": "500",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "Piece by CID Status Response Counts",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prom1234"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 65
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prom1234"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "histogram_quantile(0.5, sum(irate(booster_http_http_payload_by_cid_request_duration_ms_bucket{host=~\"$host\"}[$__rate_interval]) * 15) by (le))",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "50%",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prom1234"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(irate(booster_http_http_payload_by_cid_request_duration_ms_bucket{host=~\"$host\"}[$__rate_interval]) * 15) by (le))",
+          "hide": false,
+          "legendFormat": "95%",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prom1234"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.98, sum(irate(booster_http_http_payload_by_cid_request_duration_ms_bucket{host=~\"$host\"}[$__rate_interval]) * 15) by (le))",
+          "hide": false,
+          "legendFormat": "98%",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Payload by CID Request Durations",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prom1234"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 65
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prom1234"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.5, sum(irate(booster_http_http_piece_by_cid_request_duration_ms_bucket{host=~\"$host\"}[$__rate_interval]) * 15) by (le))",
+          "format": "time_series",
+          "legendFormat": "50%",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prom1234"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(irate(booster_http_http_piece_by_cid_request_duration_ms_bucket{host=~\"$host\"}[$__rate_interval]) * 15) by (le))",
+          "hide": false,
+          "legendFormat": "95%",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prom1234"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.98, sum(irate(booster_http_http_piece_by_cid_request_duration_ms_bucket{host=~\"$host\"}[$__rate_interval]) * 15) by (le))",
+          "hide": false,
+          "legendFormat": "98%",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Piece by CID Request Durations",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prom1234"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 72
+      },
+      "id": 9,
+      "links": [],
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "8.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prom1234"
+          },
+          "editorMode": "code",
+          "expr": "go_goroutines{job=~\"booster-http\", host=~\"$host\"}",
+          "legendFormat": "Goroutines",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Goroutines",
+      "type": "timeseries"
     },
     {
       "collapsed": false,
@@ -2239,7 +2345,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 51
+        "y": 80
       },
       "id": 39,
       "panels": [],
@@ -2308,7 +2414,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 52
+        "y": 81
       },
       "id": 49,
       "options": {
@@ -2405,7 +2511,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 52
+        "y": 81
       },
       "id": 50,
       "options": {
@@ -2501,7 +2607,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 60
+        "y": 89
       },
       "id": 51,
       "options": {
@@ -2597,7 +2703,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 60
+        "y": 89
       },
       "id": 52,
       "options": {
@@ -2676,7 +2782,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -2691,7 +2798,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 68
+        "y": 97
       },
       "id": 54,
       "options": {
@@ -2770,7 +2877,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -2785,7 +2893,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 68
+        "y": 97
       },
       "id": 57,
       "options": {
@@ -2864,7 +2972,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -2880,7 +2989,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 76
+        "y": 105
       },
       "id": 56,
       "options": {
@@ -2959,7 +3068,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -2975,7 +3085,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 76
+        "y": 105
       },
       "id": 55,
       "options": {
@@ -3010,17 +3120,17 @@
     }
   ],
   "refresh": false,
-  "schemaVersion": 37,
+  "revision": 1,
+  "schemaVersion": 38,
   "style": "dark",
   "tags": [],
   "templating": {
     "list": [
       {
         "current": {
-          "isNone": true,
           "selected": false,
-          "text": "None",
-          "value": ""
+          "text": "local",
+          "value": "local"
         },
         "datasource": {
           "type": "prometheus",
@@ -3052,6 +3162,6 @@
   "timezone": "",
   "title": "provider retrievals",
   "uid": "VG2IXa4Vk",
-  "version": 29,
+  "version": 4,
   "weekStart": ""
 }

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -139,6 +139,7 @@ var (
 	BitswapRblsHasRequestCount             = stats.Int64("bitswap/rbls_has_request_count", "Counter of RemoteBlockstore Has requests", stats.UnitDimensionless)
 	BitswapRblsHasSuccessResponseCount     = stats.Int64("bitswap/rbls_has_success_response_count", "Counter of successful RemoteBlockstore Has responses", stats.UnitDimensionless)
 	BitswapRblsHasFailResponseCount        = stats.Int64("bitswap/rbls_has_fail_response_count", "Counter of failed RemoteBlockstore Has responses", stats.UnitDimensionless)
+	BitswapRblsBytesSentCount              = stats.Int64("bitswap/rbls_bytes_sent_count", "Counter of the number of bytes sent by bitswap since startup", stats.UnitBytes)
 )
 
 var (
@@ -228,6 +229,10 @@ var (
 	BitswapRblsHasFailResponseCountView = &view.View{
 		Measure:     BitswapRblsHasFailResponseCount,
 		Aggregation: view.Count(),
+	}
+	BitswapRblsBytesSentCountView = &view.View{
+		Measure:     BitswapRblsBytesSentCount,
+		Aggregation: view.Sum(),
 	}
 
 	InfoView = &view.View{
@@ -521,6 +526,7 @@ var DefaultViews = func() []*view.View {
 		BitswapRblsHasRequestCountView,
 		BitswapRblsHasSuccessResponseCountView,
 		BitswapRblsHasFailResponseCountView,
+		BitswapRblsBytesSentCountView,
 		lotusmetrics.DagStorePRBytesDiscardedView,
 		lotusmetrics.DagStorePRBytesRequestedView,
 		lotusmetrics.DagStorePRDiscardCountView,


### PR DESCRIPTION
Adds a "Bytes Served" dashboard in grafana

<img width="1361" alt="Screenshot 2023-01-25 at 11 08 24 AM" src="https://user-images.githubusercontent.com/169124/214537369-e397b8e1-a4da-40af-8304-0f79f3045e79.png">
