### PR TITLE
update tempo version

### DIFF
--- a/docker/monitoring/docker-compose.yaml
+++ b/docker/monitoring/docker-compose.yaml
@@ -7,8 +7,8 @@ networks:
 services:
   tempo:
     container_name: tempo
-    image: grafana/tempo:r69-9a5eacf
-    command: [ "-search.enabled=true", "-config.file=/etc/tempo.yaml" ]
+    image: grafana/tempo:r80-5710d1b
+    command: [ "-config.file=/etc/tempo.yaml" ]
     volumes:
       - ./tempo-local.yaml:/etc/tempo.yaml
       - ./overrides.yaml:/etc/overrides.yaml

--- a/docker/monitoring/tempo-local.yaml
+++ b/docker/monitoring/tempo-local.yaml
@@ -1,5 +1,3 @@
-metrics_generator_enabled: true
-
 server:
   http_listen_port: 3200
 
@@ -22,11 +20,20 @@ distributor:
     opencensus:
 
 ingester:
+  # Lifecycler is responsible for managing the lifecycle of entries in the ring.
+  # For a complete list of config options check the lifecycler section under the ingester config at the following link -
+  # https://cortexmetrics.io/docs/configuration/configuration-file/#ingester_config
+  lifecycler:
+    ring:
+      # number of replicas of each span to make while pushing to the backend
+      replication_factor: 3
   trace_idle_period: 10s               # the length of time after a trace has not received spans to consider it complete and flush it
   max_block_bytes: 1_000_000           # cut the head block when it hits this size or ...
   max_block_duration: 5m               #   this much time passes
 
 compactor:
+  ring:
+    kvstore:
   compaction:
     compaction_window: 1h              # blocks in this time window will be compacted together
     max_block_bytes: 100_000_000       # maximum size of compacted blocks
@@ -34,12 +41,23 @@ compactor:
     compacted_block_retention: 10m
 
 metrics_generator:
+  ring:
+    kvstore:
+  # Processor-specific configuration
+  processor:
+    service_graphs:
+    span_metrics:
   registry:
     external_labels:
       source: tempo
       cluster: docker-compose
   storage:
+    # Path to store the WAL. Each tenant will be stored in its own subdirectory.
     path: /tmp/tempo/generator/wal
+    # Configuration for the Prometheus Agent WAL
+    wal:
+    # A list of remote write endpoints.
+    # https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write
     remote_write:
       - url: http://prometheus:9090/api/v1/write
         send_exemplars: true
@@ -49,11 +67,11 @@ storage:
     backend: local                     # backend configuration to use
     block:
       bloom_filter_false_positive: .05 # bloom filter false positive rate.  lower values create larger filters but fewer false positives
-      index_downsample_bytes: 1000     # number of bytes per index record
-      encoding: zstd                   # block encoding/compression.  options: none, gzip, lz4-64k, lz4-256k, lz4-1M, lz4, snappy, zstd, s2
+      v2_index_downsample_bytes: 1000  # number of bytes per index record
+      v2_encoding: zstd                # block encoding/compression.  options: none, gzip, lz4-64k, lz4-256k, lz4-1M, lz4, snappy, zstd, s2
     wal:
       path: /tmp/tempo/wal             # where to store the the wal locally
-      encoding: snappy                 # wal encoding/compression.  options: none, gzip, lz4-64k, lz4-256k, lz4-1M, lz4, snappy, zstd, s2
+      v2_encoding: snappy              # wal encoding/compression.  options: none, gzip, lz4-64k, lz4-256k, lz4-1M, lz4, snappy, zstd, s2
     local:
       path: /tmp/tempo/blocks
     pool:


### PR DESCRIPTION
The new version seems to wait no more than 10s for tempo to shutdown:
```
^C
Gracefully stopping... (press Ctrl+C again to force)
[+] Running 4/4
 ⠿ Container loki        Stopped  0.6s
 ⠿ Container prometheus  Stopped  0.6s
 ⠿ Container tempo       Stopped  10.2s
 ⠿ Container grafana     Stopped  0.6s
canceled
```