### PR TITLE
test: add utilities and improvements for local testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,8 @@ docker compose exec boost /bin/bash
 root@83260455bbd2:/app# ./sample/make-a-deal.sh
 ```
 
+You can also generate, dense, random cars and automatically make deals by leveraging the script at `./docker/devnet/boost/sample/random-deal.sh`. See the scripts comments for usage details.
+
 ### Accessing Lotus from localhost
 
 By default the [docker-compose.yaml](./docker-compose.yaml) does not expose any port of the `lotus` container. To access the `lotus` from a local machine:

--- a/cmd/boostx/main.go
+++ b/cmd/boostx/main.go
@@ -33,6 +33,7 @@ func main() {
 		Commands: []*cli.Command{
 			commpCmd,
 			generatecarCmd,
+			generateRandCar,
 			marketAddCmd,
 			marketWithdrawCmd,
 			statsCmd,

--- a/cmd/boostx/utils_cmd.go
+++ b/cmd/boostx/utils_cmd.go
@@ -5,12 +5,15 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"path/filepath"
+	"time"
 
 	clinode "github.com/filecoin-project/boost/cli/node"
 	"github.com/filecoin-project/boost/cmd"
 	"github.com/filecoin-project/boost/node"
 	"github.com/filecoin-project/boost/node/config"
+	"github.com/filecoin-project/boost/testutil"
 	"github.com/filecoin-project/go-commp-utils/writer"
 	"github.com/filecoin-project/go-fil-markets/stores"
 	"github.com/filecoin-project/go-state-types/abi"
@@ -34,6 +37,8 @@ import (
 	"github.com/ipfs/go-datastore/namespace"
 	ds_sync "github.com/ipfs/go-datastore/sync"
 	"github.com/ipld/go-car"
+	carv2 "github.com/ipld/go-car/v2"
+	"github.com/ipld/go-car/v2/blockstore"
 	selectorparse "github.com/ipld/go-ipld-prime/traversal/selector/parse"
 	"github.com/multiformats/go-multibase"
 	"github.com/urfave/cli/v2"
@@ -233,6 +238,77 @@ var commpCmd = &cli.Command{
 		fmt.Println("CommP CID: ", encoder.Encode(commp.PieceCID))
 		fmt.Println("Piece size: ", types.NewInt(uint64(commp.PieceSize.Unpadded().Padded())))
 		fmt.Println("Car file size: ", stat.Size())
+		return nil
+	},
+}
+
+var generateRandCar = &cli.Command{
+	Name:      "generate-rand-car",
+	Usage:     "creates a randomly generated dense car",
+	ArgsUsage: "<outputPath>",
+	Before:    before,
+	Flags: []cli.Flag{
+		&cli.IntFlag{
+			Name:    "size",
+			Aliases: []string{"s"},
+			Usage:   "The size of the data to turn into a car",
+			Value:   8000000,
+		},
+		&cli.IntFlag{
+			Name:    "chunksize",
+			Aliases: []string{"c"},
+			Value:   512,
+			Usage:   "Size of chunking that should occur",
+		},
+		&cli.IntFlag{
+			Name:    "maxlinks",
+			Aliases: []string{"l"},
+			Value:   8,
+			Usage:   "Max number of leaves per level",
+		},
+	},
+	Action: func(cctx *cli.Context) error {
+		if cctx.Args().Len() < 1 {
+			return fmt.Errorf("usage: generate-car <outputPath> -size -chunksize -maxleaves")
+		}
+
+		outPath := cctx.Args().Get(0)
+		size := cctx.Int("size")
+		cs := cctx.Int64("chunksize")
+		ml := cctx.Int("maxlinks")
+
+		rf, err := testutil.CreateRandomFile(outPath, int(time.Now().Unix()), size)
+		if err != nil {
+			return err
+		}
+
+		// carv1
+		caropts := []carv2.Option{
+			blockstore.WriteAsCarV1(true),
+		}
+
+		root, cn, err := testutil.CreateDenseCARWith(outPath, rf, cs, ml, caropts)
+		if err != nil {
+			return err
+		}
+
+		err = os.Remove(rf)
+		if err != nil {
+			return err
+		}
+
+		encoder := cidenc.Encoder{Base: multibase.MustNewEncoder(multibase.Base32)}
+		rn := encoder.Encode(root)
+		base := path.Dir(cn)
+		np := path.Join(base, rn+".car")
+
+		err = os.Rename(cn, np)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("Payload CID: %s, written to: %s\n", rn, np)
+
 		return nil
 	},
 }

--- a/docker/devnet/boost/sample/random-deal.sh
+++ b/docker/devnet/boost/sample/random-deal.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+###################################################################################
+# Generates a random, dense car file in the /app/public/ directory and issues
+# a deal for it. This command assumes you have already transfered the needed funds.
+# Example (from ./docker/devnet):
+# $ docker compose exec boost /bin/bash
+# $ export `lotus auth api-info --perm=admin`
+# $ boost init
+# $ lotus send --from=`lotus wallet default` `boost wallet default` 100
+# $ boostx market-add 50
+# $ ./sample/random-deal.sh
+###################################################################################
+set -e
+
+ci="\e[3m"
+cn="\e[0m"
+
+FILE=`boostx generate-rand-car -c=512 -l=8 -s=5120000 /app/public/ | awk '{print $NF}'`
+PAYLOAD_CID=$(find "$FILE" | xargs -I{} basename {} | sed 's/\.car//')
+
+COMMP_CID=`boostx commp $FILE 2> /dev/null | grep CID | cut -d: -f2 | xargs`
+PIECE=`boostx commp $FILE 2> /dev/null | grep Piece | cut -d: -f2 | xargs`
+CAR=`boostx commp $FILE 2> /dev/null | grep Car | cut -d: -f2 | xargs`
+
+###################################################################################
+printf "${ci}boost deal --verified=false --provider=t01000 \
+--http-url=http://demo-http-server/$FILE \
+--commp=$COMMP_CID --car-size=$CAR --piece-size=$PIECE \
+--payload-cid=$PAYLOAD_CID --storage-price 20000000000\n\n${cn}"
+
+boost deal --verified=false --provider=t01000 --http-url=http://demo-http-server/$PAYLOAD_CID.car --commp=$COMMP_CID --car-size=$CAR --piece-size=$PIECE --payload-cid=$PAYLOAD_CID --storage-price 20000000000

--- a/docker/devnet/docker-compose.yaml
+++ b/docker/devnet/docker-compose.yaml
@@ -54,6 +54,7 @@ services:
     ports:
       - "8080:8080"
       - "1288:1288" # For the /metrics endpoint
+      - "50000:50000" # Exposed libp2p port
     environment:
       - LOTUS_API_LISTENADDRESS=/dns/boost/tcp/1288/http
       - LOTUS_PATH=/var/lib/lotus
@@ -84,6 +85,9 @@ services:
       - ./data/boost:/var/lib/boost:ro
       - ./data/lotus:/var/lib/lotus:ro
       - ./data/lotus-miner:/var/lib/lotus-miner:ro
+    labels:
+      - "com.docker-tc.enabled=1"
+      - "com.docker-tc.delay=10ms"
 
   booster-bitswap:
     container_name: booster-bitswap
@@ -102,6 +106,9 @@ services:
       - ./data/boost:/var/lib/boost:ro
       - ./data/lotus:/var/lib/lotus:ro
       - ./data/lotus-miner:/var/lib/lotus-miner:ro
+    labels:
+      - "com.docker-tc.enabled=1"
+      - "com.docker-tc.delay=10ms"
 
   demo-http-server:
     container_name: demo-http-server
@@ -110,3 +117,24 @@ services:
     logging: *default-logging
     volumes:
       - ./data/sample:/usr/share/nginx/html:ro
+    labels:
+      - "com.docker-tc.enabled=1"
+      - "com.docker-tc.limit=1mbps"
+      - "com.docker-tc.delay=100ms"
+
+  tc:
+    image: "${DOCKER_IMAGE_TERMINAL:-lukaszlach/docker-tc}"
+    container_name: docker-tc
+    cap_add:
+      - NET_ADMIN
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /var/docker-tc:/var/docker-tc
+    deploy:
+      mode: global
+      restart_policy:
+        condition: any
+    environment:
+      HTTP_BIND: "${HTTP_BIND:-127.0.0.1}"
+      HTTP_PORT: "${HTTP_PORT:-4080}"
+    network_mode: host


### PR DESCRIPTION
### Summary
This PR contains a few dev utilities that I'm bundling together as a followup of doing retrieval testing of booster-bitswap

#### Docker Traffic Control
* [364367e](https://github.com/filecoin-project/boost/pull/1143/commits/364367e9c9fed458ec99975c49de2186d1afaf41) adds traffic control to the docker setup. It also adds a small latency to bitswap and http retrievals which mimics a reasonable local region latency of 10ms. The demo http server also now has a rate limited 1m connection and 100ms latency. This is probably excessive, but should also make it easier to test transfer components. This TC setup also has support for things like corrupted packets, but I've skipped including that for now.

#### Dense car file generator
* [b9653ae](https://github.com/filecoin-project/boost/pull/1143/commits/b9653ae9d6d266b0a76a3a25a87e9bbcd1bca290) adds a `generate-rand-car` command to `boostx`, making it easy to create car files with very dense dag structures, which is helpful in retrieval testing. This would probably be better located in a separate dev/test utils command, but I added it to boostx for the time being as its intended for experimental commands anyway. Happy to switch this over to a test/dev util command if we have more things we'd like to live there. You can see an example usage of it in the script added in https://github.com/filecoin-project/boost/pull/1143/commits/aa965b9420daeffed186ed5bf795b10efdd764d2:

```
# Generate a 5M random file. Chunk it into 512byte chunks, with a max if 8 links per level
$ boostx generate-rand-car -c=512 -l=8 -s=5120000 ./
```

#### Deal script
* [aa965b9](https://github.com/filecoin-project/boost/pull/1143/commits/aa965b9420daeffed186ed5bf795b10efdd764d2) adds a new deal script that will automatically generate a random, dense car file and execute a deal. This makes it easy to seed a local devnet with data without going through the slower, tutorial style script. Future work here could turn this in an actual deal seed script with more variety in the car files being generated.

```
$ ./sample/random-deal.sh 
boost deal --verified=false --provider=t01000 --http-url=http://demo-http-server//app/public/bafykbzacec7kd4emrq66myjatybthq6eikczq2x2vloymro5uphvmkh6u2e6a.car --commp=baga6ea4seaqgudqjlkmvztlqarigpl65vloqs7v2qsamd3rvljewhgztqfb6kla --car-size=6159289 --piece-size=8388608 --payload-cid=bafykbzacec7kd4emrq66myjatybthq6eikczq2x2vloymro5uphvmkh6u2e6a --storage-price 20000000000

sent deal proposal
  deal uuid: a858d887-74d7-430c-8c07-d126442fd166
  storage provider: t01000
  client wallet: t3ql744hzi3cvvczmzbbcq72xse7qlqmoakjhukqrsn5opajqeayjpzwvd7kdill242c5ckqheofwdkx6fey5a
  payload cid: bafykbzacec7kd4emrq66myjatybthq6eikczq2x2vloymro5uphvmkh6u2e6a
  url: http://demo-http-server/bafykbzacec7kd4emrq66myjatybthq6eikczq2x2vloymro5uphvmkh6u2e6a.car
  commp: baga6ea4seaqgudqjlkmvztlqarigpl65vloqs7v2qsamd3rvljewhgztqfb6kla
  start epoch: 7485
  end epoch: 525885
  provider collateral: 0
```