### PR TITLE
Devnet images using Lotus from DockerHub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,36 +200,53 @@ docsgen-openrpc-boost: docsgen-openrpc-bin
 
 ## DOCKER IMAGES
 docker_user?=filecoin
-lotus_version?=1.19.0-rc1
+lotus_version?=v1.19.0
 lotus_src_dir?=
 ffi_from_source?=0
+build_lotus?=0
 ifeq ($(lotus_src_dir),)
-    lotus_src_dir=/tmp/lotus-$(lotus_version)
-    lotus_checkout_dir=$(lotus_src_dir)
+	ifeq ($(build_lotus),1)
+# v1: building lotus image with provided lotus version	
+		lotus_info_msg=!!! building lotus base image from github: tag $(lotus_version) !!!
+    	lotus_src_dir=/tmp/lotus-$(lotus_version)
+	    lotus_checkout_dir=$(lotus_src_dir)
+		lotus_build_cmd=docker/lotus-all-in-one		
+		lotus_base_image=$(docker_user)/lotus-all-in-one:dev
+	else
+# v2 (defaut): using lotus image 		
+		lotus_base_image?=filecoin/lotus-all-in-one:$(lotus_version)-debug
+		lotus_info_msg=using lotus image from dockerhub: $(lotus_base_image)
+		lotus_build_cmd=info/lotus-all-in-one
+	endif
 else
-    lotus_version=dev
+# v3: building lotus image from source
+	lotus_info_msg=!!! building lotus base image from source: $(lotus_src_dir) !!!
+	lotus_base_image=$(docker_user)/lotus-all-in-one:dev
+	lotus_build_cmd=docker/lotus-all-in-one
     lotus_checkout_dir=
 endif
-lotus_test_image=$(docker_user)/lotus-test:$(lotus_version)
-docker_build_cmd=docker build --build-arg LOTUS_TEST_IMAGE=$(lotus_test_image) \
+docker_build_cmd=docker build --build-arg LOTUS_TEST_IMAGE=$(lotus_base_image) \
 	--build-arg FFI_BUILD_FROM_SOURCE=$(ffi_from_source) $(docker_args)
-
-### lotus test docker image
-info/lotus-test:
-	@echo Lotus dir = $(lotus_src_dir)
-	@echo Lotus ver = $(lotus_version)
-.PHONY: info/lotus-test
+### lotus-all-in-one docker image build
+info/lotus-all-in-one:
+	@echo Docker build info: $(lotus_info_msg)
+.PHONY: info/lotus-all-in-one
 $(lotus_checkout_dir):
-	git clone --depth 1 --branch v$(lotus_version) https://github.com/filecoin-project/lotus $@
-docker/lotus-test: info/lotus-test | $(lotus_checkout_dir)
+	git clone --depth 1 --branch $(lotus_version) https://github.com/filecoin-project/lotus $@
+docker/lotus-all-in-one: info/lotus-all-in-one | $(lotus_checkout_dir)
+#	new lotus Dockerfile does not exist for older lotus versions
+#	temporary use the old Dockerfile.lotus
 	cd $(lotus_src_dir) && $(docker_build_cmd) -f Dockerfile.lotus --target lotus-test \
-		-t $(lotus_test_image) .
-.PHONY: docker/lotus-test
+		-t $(lotus_base_image) .	
+# 	code using new lotus Dockerfile
+#	cd $(lotus_src_dir) && $(docker_build_cmd) -f Dockerfile --target lotus-all-in-one \
+#		-t $(lotus_base_image) --build-arg GOFLAGS=-tags=debug .
+.PHONY: docker/lotus-all-in-one
 
 ### devnet images
 docker/%:
-	cd docker/devnet/$* && $(docker_build_cmd) -t $(docker_user)/$*-dev:$(lotus_version) \
-		--build-arg BUILD_VERSION=$(lotus_version) .
+	cd docker/devnet/$* && DOCKER_BUILDKIT=1 $(docker_build_cmd) -t $(docker_user)/$*-dev:dev \
+		--build-arg BUILD_VERSION=dev .
 docker/boost: build/.update-modules
 	DOCKER_BUILDKIT=1 $(docker_build_cmd) \
 		-t $(docker_user)/boost-dev:dev --build-arg BUILD_VERSION=dev \
@@ -245,6 +262,6 @@ docker/booster-bitswap:
 		-t $(docker_user)/booster-bitswap-dev:dev --build-arg BUILD_VERSION=dev \
 		-f docker/devnet/Dockerfile.source --target booster-bitswap-dev .
 .PHONY: docker/booster-bitswap
-docker/all: docker/lotus-test docker/boost docker/booster-http docker/booster-bitswap \
+docker/all: $(lotus_build_cmd) docker/boost docker/booster-http docker/booster-bitswap \
 	docker/lotus docker/lotus-miner
 .PHONY: docker/all

--- a/Makefile
+++ b/Makefile
@@ -208,8 +208,8 @@ ifeq ($(lotus_src_dir),)
 	ifeq ($(build_lotus),1)
 # v1: building lotus image with provided lotus version	
 		lotus_info_msg=!!! building lotus base image from github: tag $(lotus_version) !!!
-    	lotus_src_dir=/tmp/lotus-$(lotus_version)
-	    lotus_checkout_dir=$(lotus_src_dir)
+		lotus_src_dir=/tmp/lotus-$(lotus_version)
+		lotus_checkout_dir=$(lotus_src_dir)
 		lotus_build_cmd=docker/lotus-all-in-one		
 		lotus_base_image=$(docker_user)/lotus-all-in-one:dev
 	else
@@ -234,11 +234,11 @@ info/lotus-all-in-one:
 $(lotus_checkout_dir):
 	git clone --depth 1 --branch $(lotus_version) https://github.com/filecoin-project/lotus $@
 docker/lotus-all-in-one: info/lotus-all-in-one | $(lotus_checkout_dir)
-#	new lotus Dockerfile does not exist for older lotus versions
-#	temporary use the old Dockerfile.lotus
+# new lotus Dockerfile does not exist for older lotus versions
+# temporary use the old Dockerfile.lotus
 	cd $(lotus_src_dir) && $(docker_build_cmd) -f Dockerfile.lotus --target lotus-test \
 		-t $(lotus_base_image) .	
-# 	code using new lotus Dockerfile
+# code using new lotus Dockerfile
 #	cd $(lotus_src_dir) && $(docker_build_cmd) -f Dockerfile --target lotus-all-in-one \
 #		-t $(lotus_base_image) --build-arg GOFLAGS=-tags=debug .
 .PHONY: docker/lotus-all-in-one

--- a/README.md
+++ b/README.md
@@ -216,10 +216,10 @@ make docker/all
 
 On ARM-based systems (*Apple M1/M2*) you need to force building Filecoin's Rust libraries from the source
 ```
-make docker/all ffi_from_source=1
+make docker/all ffi_from_source=1 build_lotus=1
 ```
 
-If you need to build containers using a specific version of lotus then provide the version as a parameter, e.g. `make docker/all lotus_version=1.17.0`. The version must be a tag name of [Lotus git repo](https://github.com/filecoin-project/lotus/tags) without `v` prefix. Or you can build using a local source of lotus - `make docker/all lotus_src_dir=<path of lotus source>`. Also, before starting devnet, you need to update versions in the [.env](docker/devnet/.env) file.
+If you need to build containers using a specific version of lotus then provide the version as a parameter, e.g. `make docker/all lotus_version=v1.17.0 build_lotus=1`. The version must be a tag name of [Lotus git repo](https://github.com/filecoin-project/lotus/tags). Or you can build using a local source of lotus - `make docker/all lotus_src_dir=<path of lotus source>`. 
 
 ### Start devnet docker stack
 

--- a/docker/devnet/.env
+++ b/docker/devnet/.env
@@ -1,6 +1,6 @@
 DOCKER_USER=filecoin
-LOTUS_IMAGE=${DOCKER_USER}/lotus-dev:1.19.0-rc1
-LOTUS_MINER_IMAGE=${DOCKER_USER}/lotus-miner-dev:1.19.0-rc1
+LOTUS_IMAGE=${DOCKER_USER}/lotus-dev:dev
+LOTUS_MINER_IMAGE=${DOCKER_USER}/lotus-miner-dev:dev
 BOOST_IMAGE=${DOCKER_USER}/boost-dev:dev
 BOOSTER_HTTP_IMAGE=${DOCKER_USER}/booster-http-dev:dev
 BOOSTER_BITSWAP_IMAGE=${DOCKER_USER}/booster-bitswap-dev:dev


### PR DESCRIPTION
Implemented as requested in  (#1084).
Now building images the first time for devnet should be twice faster.

### Changes
- tested with an official lotus image: [v1.19.0-debug](https://hub.docker.com/layers/filecoin/lotus-all-in-one/v1.19.0-debug/images/sha256-295f057ad0fbae829b168592d486c91e801bcf053e9be95f217869acbb5b8d44?context=explore). The image works out of the box, without any other changes
- updated Makefile to use the official lotus docker image instead of building locally as the default case
- ~~refactored makefile to use a new lotus dockerfile~~, but rollbacked. The tag 1.19.0 (default now) of the lotus repo does not contain the new Dockerfile, so the building did not work out-of-the-box
- updated readme

### Options to prepare devnet images
#### with the official lotus image 
Works only for amd64 platforms
```bash
make docker/all
# with another image, e.g.: filecoin/lotus-all-in-one:nightly-debug
make docker/all lotus_version=nightly
```
#### with specific version of lotus
```bash
make docker/all lotus_version=v1.17.0 build_lotus=1
# for M1, M2
make docker/all lotus_version=v1.17.0 build_lotus=1 ffi_from_source=1
```
#### from lotus source
```bash
make docker/all lotus_src_dir=../lotus
```

