### PR TITLE
use long running context for add index operations

### DIFF
--- a/cmd/booster-bitswap/run.go
+++ b/cmd/booster-bitswap/run.go
@@ -53,7 +53,7 @@ var runCmd = &cli.Command{
 		},
 		&cli.StringFlag{
 			Name:     "api-lid",
-			Usage:    "the endpoint for the local index directory API",
+			Usage:    "the endpoint for the local index directory API, eg 'http://localhost:8042'",
 			Required: true,
 		},
 		&cli.IntFlag{
@@ -169,6 +169,9 @@ var runCmd = &cli.Command{
 				return fmt.Errorf("parsing proxy multiaddr %s: %w", proxy, err)
 			}
 		}
+
+		// Start the local index directory
+		piecedirectory.Start(ctx)
 
 		// Start the bitswap server
 		log.Infof("Starting booster-bitswap node on port %d", port)

--- a/cmd/booster-http/run.go
+++ b/cmd/booster-http/run.go
@@ -39,8 +39,13 @@ var runCmd = &cli.Command{
 		},
 		&cli.StringFlag{
 			Name:     "api-lid",
-			Usage:    "the endpoint for the local index directory API",
+			Usage:    "the endpoint for the local index directory API, eg 'http://localhost:8042'",
 			Required: true,
+		},
+		&cli.IntFlag{
+			Name:  "add-index-throttle",
+			Usage: "the maximum number of add index operations that can run in parallel",
+			Value: 4,
 		},
 		&cli.StringFlag{
 			Name:     "api-fullnode",
@@ -118,6 +123,9 @@ var runCmd = &cli.Command{
 			cctx.Int("port"),
 			sapi,
 		)
+
+		// Start the local index directory
+		piecedirectory.Start(ctx)
 
 		// Start the server
 		log.Infof("Starting booster-http node on port %d with base path '%s'",

--- a/piecedirectory/piecedirectory_test.go
+++ b/piecedirectory/piecedirectory_test.go
@@ -74,6 +74,7 @@ func testPieceDirectoryNotFound(ctx context.Context, t *testing.T, cl *client.St
 	ctrl := gomock.NewController(t)
 	pr := mock_piecedirectory.NewMockPieceReader(ctrl)
 	pm := NewPieceDirectory(cl, pr, 1)
+	pm.Start(ctx)
 
 	nonExistentPieceCid, err := cid.Parse("bafkqaaa")
 	require.NoError(t, err)
@@ -117,6 +118,7 @@ func testBasicBlockstoreMethods(ctx context.Context, t *testing.T, cl *client.St
 	pr := CreateMockPieceReader(t, carv1Reader)
 
 	pm := NewPieceDirectory(cl, pr, 1)
+	pm.Start(ctx)
 	pieceCid := CalculateCommp(t, carv1Reader).PieceCID
 
 	// Add deal info for the piece - it doesn't matter what it is, the piece
@@ -242,6 +244,7 @@ func testImportedIndex(ctx context.Context, t *testing.T, cl *client.Store) {
 	// There is no size information in the index so the piece
 	// directory should re-build the index and then return the size.
 	pm := NewPieceDirectory(cl, pr, 1)
+	pm.Start(ctx)
 	sz, err := pm.BlockstoreGetSize(ctx, rec.Cid)
 	require.NoError(t, err)
 	require.Equal(t, len(blk.RawData()), sz)
@@ -290,6 +293,7 @@ func testCarFileSize(ctx context.Context, t *testing.T, cl *client.Store) {
 	// There is no CAR size information in the deal info, so the piece
 	// directory should work it out from the index and piece data.
 	pm := NewPieceDirectory(cl, pr, 1)
+	pm.Start(ctx)
 	size, err := pm.GetCarSize(ctx, commpCalc.PieceCID)
 	require.NoError(t, err)
 	require.Equal(t, len(carBytes), int(size))

--- a/storagemarket/provider_test.go
+++ b/storagemarket/provider_test.go
@@ -1447,7 +1447,10 @@ func NewHarness(t *testing.T, opts ...harnessOpt) *ProviderHarness {
 	store.EXPECT().IsIndexed(gomock.Any(), gomock.Any()).Return(true, nil).AnyTimes()
 	store.EXPECT().AddDealForPiece(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
+	pdctx, cancel := context.WithCancel(context.Background())
 	pm := piecedirectory.NewPieceDirectory(store, nil, 1)
+	pm.Start(pdctx)
+	t.Cleanup(cancel)
 
 	prvCfg := Config{
 		MaxTransferDuration: time.Hour,


### PR DESCRIPTION
When an index is imported from the dagstore, it does not have block size information.
When a bitswap request comes in, and the local index directory notices that the index for the corresponding piece is incomplete, the local index directory starts a new add index operation (to rebuild the index).
Add index operations are put into a queue. Once the add index operation starts, we don't want to cancel it if one of the threads waiting on the operation cancels its context. So instead of using the waiting thread context, use the local index directory's context.