### PR TITLE
chore(ci): fix macos build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,6 +123,7 @@ jobs:
     macos:
       xcode: "12.5.1"
     working_directory: ~/go/src/github.com/filecoin-project/boost
+    resource_class: large
     steps:
       - prepare:
           linux: false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,8 +130,8 @@ jobs:
       - run:
           name: Install go
           command: |
-            curl -O https://dl.google.com/go/go1.18.7.darwin-arm64.pkg && \
-            sudo installer -pkg go1.18.7.darwin-arm64.pkg -target /
+            curl -O https://dl.google.com/go/go1.19.5.darwin-amd64.pkg && \
+            sudo installer -pkg go1.19.5.darwin-amd64.pkg -target /
       - run:
           name: Install pkg-config
           command: HOMEBREW_NO_AUTO_UPDATE=1 brew install pkg-config
@@ -279,8 +279,8 @@ workflows:
       - build-macos:
           filters:
             branches:
-              ignore:
-                - /.*/
+              only:
+                - /ci\/.*/
             tags:
               only:
                 - /^v\d+\.\d+\.\d+(-rc\d+)?$/


### PR DESCRIPTION
## Summary

The mac build was previously only running on tagged releases, while this saves CI compute resources it also made it difficult to catch and resolve build failures. 

You can see the previous failure on the most recent RC - https://app.circleci.com/pipelines/github/filecoin-project/boost/3188/workflows/c7bb14a1-2ca6-45ca-ab9c-852325de014a/jobs/30322.

* Macos builds will now be triggered for any branch starting with `ci/`, in addition to running on tags
* Fixed the golang runtime to use amd, it was using arm which isn't supported on circle
* Increased the resource class of the build as it's currently in plan and resulted in a 17% reduction in build time. This does not run frequently so the credit burn impact should be negligible. 

