### PR TITLE
Don't unseal sectors in local index directory

### DIFF
--- a/piecedirectory/types/types.go
+++ b/piecedirectory/types/types.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"context"
+	"errors"
 	"io"
 	"time"
 
@@ -20,6 +21,8 @@ type SectionReader interface {
 	io.Seeker
 	io.Closer
 }
+
+var ErrSealed = errors.New("sector is not unsealed")
 
 type PieceReader interface {
 	// GetReader returns a reader over a piece. If there is no unsealed copy, returns ErrSealed.


### PR DESCRIPTION
When a client makes a request for data, the local index directory gets a reader over the data from the sealing subsystem.
If the data is not unsealed, just return an error.