### PR TITLE
verify deal proposal for f4 address

### DIFF
--- a/storagemarket/provider_test.go
+++ b/storagemarket/provider_test.go
@@ -33,7 +33,6 @@ import (
 	tspttypes "github.com/filecoin-project/boost/transport/types"
 	"github.com/filecoin-project/go-address"
 	piecestoreimpl "github.com/filecoin-project/go-fil-markets/piecestore/impl"
-	"github.com/filecoin-project/go-fil-markets/shared"
 	"github.com/filecoin-project/go-fil-markets/shared_testutil"
 	"github.com/filecoin-project/go-fil-markets/storagemarket"
 	"github.com/filecoin-project/go-state-types/abi"
@@ -2184,6 +2183,6 @@ type mockSignatureVerifier struct {
 	err   error
 }
 
-func (m *mockSignatureVerifier) VerifySignature(ctx context.Context, sig acrypto.Signature, addr address.Address, input []byte, encodedTs shared.TipSetToken) (bool, error) {
+func (m *mockSignatureVerifier) VerifySignature(ctx context.Context, sig acrypto.Signature, addr address.Address, input []byte) (bool, error) {
 	return m.valid, m.err
 }

--- a/storagemarket/types/types.go
+++ b/storagemarket/types/types.go
@@ -11,7 +11,6 @@ import (
 	"github.com/filecoin-project/boost/transport/httptransport/util"
 	"github.com/filecoin-project/boost/transport/types"
 	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/go-fil-markets/shared"
 	"github.com/filecoin-project/go-fil-markets/storagemarket"
 	multiaddrutil "github.com/filecoin-project/go-legs/httpsync/multiaddr"
 	"github.com/filecoin-project/go-state-types/abi"
@@ -175,5 +174,5 @@ type AskGetter interface {
 }
 
 type SignatureVerifier interface {
-	VerifySignature(ctx context.Context, sig crypto.Signature, addr address.Address, input []byte, encodedTs shared.TipSetToken) (bool, error)
+	VerifySignature(ctx context.Context, sig crypto.Signature, addr address.Address, input []byte) (bool, error)
 }


### PR DESCRIPTION
This code is ported from https://github.com/filecoin-project/lotus/blob/ef3b2046b6765bb76517563cc3957a595621bf9f/markets/storageadapter/client.go#L98

Questions:
- [ ] The original code [uses account v10](https://github.com/filecoin-project/lotus/blob/ef3b2046b6765bb76517563cc3957a595621bf9f/markets/storageadapter/client.go#L20). I've updated to account v11. Verify that this is correct.
- [ ] Verify that it's correct to check if it's an f4 address _after_ calling StateAccountKey on the address