### PR TITLE
feat: add flags for bitswap server internals

### DIFF
--- a/cmd/booster-bitswap/run.go
+++ b/cmd/booster-bitswap/run.go
@@ -77,6 +77,31 @@ var runCmd = &cli.Command{
 			Usage: "the endpoints for fetching one or more custom BadBits list instead of the default one at https://badbits.dwebops.pub/denylist.json",
 			Value: cli.NewStringSlice("https://badbits.dwebops.pub/denylist.json"),
 		},
+		&cli.IntFlag{
+			Name:  "engine-blockstore-worker-count",
+			Usage: "number of threads for blockstore operations. Used to throttle the number of concurrent requests to the block store",
+			Value: 128,
+		},
+		&cli.IntFlag{
+			Name:  "engine-task-worker-count",
+			Usage: "number of worker threads used for preparing and packaging responses before they are sent out. This number should generally be equal to task-worker-count",
+			Value: 128,
+		},
+		&cli.IntFlag{
+			Name:  "max-outstanding-bytes-per-peer",
+			Usage: "maximum number of bytes (across all tasks) pending to be processed and sent to any individual peer (default 32MiB)",
+			Value: 32 << 20,
+		},
+		&cli.IntFlag{
+			Name:  "target-message-size",
+			Usage: "target size of messages for bitswap to batch messages, actual size may vary depending on the queue (default 1MiB)",
+			Value: 1 << 20,
+		},
+		&cli.IntFlag{
+			Name:  "task-worker-count",
+			Usage: "Number of threads (goroutines) sending outgoing messages. Throttles the number of concurrent send operations",
+			Value: 128,
+		},
 	},
 	Action: func(cctx *cli.Context) error {
 		if cctx.Bool("pprof") {
@@ -143,7 +168,13 @@ var runCmd = &cli.Command{
 
 		// Start the bitswap server
 		log.Infof("Starting booster-bitswap node on port %d", port)
-		err = server.Start(ctx, proxyAddrInfo)
+		err = server.Start(ctx, proxyAddrInfo, &BitswapServerOptions{
+			EngineBlockstoreWorkerCount: cctx.Int("engine-blockstore-worker-count"),
+			EngineTaskWorkerCount:       cctx.Int("engine-task-worker-count"),
+			MaxOutstandingBytesPerPeer:  cctx.Int("max-outstanding-bytes-per-peer"),
+			TargetMessageSize:           cctx.Int("target-message-size"),
+			TaskWorkerCount:             cctx.Int("task-worker-count"),
+		})
 		if err != nil {
 			return err
 		}

--- a/docker/devnet/booster-bitswap/entrypoint.sh
+++ b/docker/devnet/booster-bitswap/entrypoint.sh
@@ -21,4 +21,4 @@ fi
 
 echo Starting booster-bitswap...
 export GOLOG_LOG_LEVEL=remote-blockstore=debug,booster=debug,engine=debug,bitswap-server=debug
-exec booster-bitswap --vv run --api-boost=$BOOST_API_INFO --tracing
+exec booster-bitswap --vv run --api-boost=$BOOST_API_INFO --tracing --engine-blockstore-worker-count=64 --engine-task-worker-count=64 --max-outstanding-bytes-per-peer=8388608 --target-message-size=524288 --task-worker-count=64


### PR DESCRIPTION
## Summary
This PR adds several flags to the `booster-bitswap run` command to set internal parameters on the bitswap server, https://github.com/ipfs/kubo/blob/master/docs/config.md#internalbitswap. The bitswap worked defaults are considerably low, 8, so we are also bumping the defaults here as even small scale SP's will have significantly more hardware than the defaults for bitswap were intended to support.

These are currently added as flags to the process as we don't yet have a dedicated config for booster-bitswap. We should consider whether we want to add and migrate to that in the near future, but I'm leaving that out of the scope for this PR for now as we're targeting a release this week. If we want to go that route, I'll create an issue to track adding the config in a future update.

## Example Usage
```
booster-bitswap --vv run --api-boost=$BOOST_API_INFO \
  --engine-blockstore-worker-count=600 \
  --engine-task-worker-count=600 \
  --max-outstanding-bytes-per-peer=33554432 \
  --target-message-size=1048576 \
  --task-worker-count=600
```

## Refs

fixes https://github.com/filecoin-project/boost/issues/1174