### PR TITLE
Port https://github.com/filecoin-project/lotus/pull/9627 to Boost

### DIFF
--- a/markets/idxprov/mesh.go
+++ b/markets/idxprov/mesh.go
@@ -38,10 +38,13 @@ func (mc Libp2pMeshCreator) Connect(ctx context.Context) error {
 		return fmt.Errorf("failed to fetch full node listen addrs, err: %w", err)
 	}
 
-	// Connect to the full node, ask it to protect the connection and protect the connection on
-	// markets end too.
-	if err := mc.marketsHost.Connect(ctx, faddrs); err != nil {
-		return fmt.Errorf("failed to connect index provider host with the full node: %w", err)
+	// Connect from the full node, ask it to protect the connection and protect the connection on
+	// markets end too. Connection is initiated from full node to avoid the need to expose libp2p port on full node
+	if err := mc.fullnodeApi.NetConnect(ctx, peer.AddrInfo{
+		ID:    mc.marketsHost.ID(),
+		Addrs: mc.marketsHost.Addrs(),
+	}); err != nil {
+		return fmt.Errorf("failed to connect to index provider host from full node: %w", err)
 	}
 	mc.marketsHost.ConnManager().Protect(faddrs.ID, protectTag)
 


### PR DESCRIPTION
Currently, index-provider requires full node to be publicly exposed. AFAIK, no other lotus-miner module has thing requirement and this becomes another security concern.

If the libp2p address is not reachable we get the below error. This behaviour is consistent on Boost as well.

failed to connect index provider host with the full node: failed to connect index provider host with the full node: failed to dial 12D3KooWJgxyYahRiJ6rHUJPeigWoXJ8SwFKNKHSxXje1D1BvGVR:
  * [/ip4/76.219.232.45/tcp/24002] dial tcp4 76.219.232.45:24002: connect: connection refused
waiting for legacy storage provider 'ready' event 
We need to change the direction of libp2p connection init. Rather than dialling from market to fullNode, we should dial from fullNode to market. Thus removing the requirement to have libp2p exposed.


Reason for port - We have moved the code base from Lotus to Boost and for some reason, older version is present in Boost.
This was tested when I filed the PR for lotus. It was also tested by Casey on his miner.