### PR TITLE
feat: cache sealing pipeline status

### DIFF
--- a/node/config/def.go
+++ b/node/config/def.go
@@ -113,6 +113,7 @@ func DefaultBoost() *Boost {
 			HttpTransferStallTimeout:           Duration(5 * time.Minute),
 			HttpTransferStallCheckPeriod:       Duration(30 * time.Second),
 			DealLogDurationDays:                30,
+			SealingPipelineCacheTimeout:        30,
 		},
 
 		LotusDealmaking: lotus_config.DealmakingConfig{

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -113,7 +113,7 @@ func DefaultBoost() *Boost {
 			HttpTransferStallTimeout:           Duration(5 * time.Minute),
 			HttpTransferStallCheckPeriod:       Duration(30 * time.Second),
 			DealLogDurationDays:                30,
-			SealingPipelineCacheTimeout:        30,
+			SealingPipelineCacheTimeout:        Duration(30 * time.Second),
 		},
 
 		LotusDealmaking: lotus_config.DealmakingConfig{

--- a/node/config/doc_gen.go
+++ b/node/config/doc_gen.go
@@ -352,7 +352,7 @@ to keep the size of logsDB in check. Set the value as "0" to disable log cleanup
 		},
 		{
 			Name: "SealingPipelineCacheTimeout",
-			Type: "int",
+			Type: "Duration",
 
 			Comment: `The sealing pipeline status is cached by Boost if deal filters are enabled to avoid constant call to
 lotus-miner API. SealingPipelineCacheTimeout defines cache timeout value in seconds. Default is 30 seconds.

--- a/node/config/doc_gen.go
+++ b/node/config/doc_gen.go
@@ -350,6 +350,14 @@ a file containing the booster-bitswap peer id's private key. Can be left blank w
 			Comment: `The deal logs older than DealLogDurationDays are deleted from the logsDB
 to keep the size of logsDB in check. Set the value as "0" to disable log cleanup`,
 		},
+		{
+			Name: "SealingPipelineCacheTimeout",
+			Type: "int",
+
+			Comment: `The sealing pipeline status is cached by Boost if deal filters are enabled to avoid constant call to
+lotus-miner API. SealingPipelineCacheTimeout defines cache timeout value in seconds. Default is 30 seconds.
+Any value less than 0 will result in use of default`,
+		},
 	},
 	"FeeConfig": []DocField{
 		{

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -245,6 +245,11 @@ type DealmakingConfig struct {
 	// The deal logs older than DealLogDurationDays are deleted from the logsDB
 	// to keep the size of logsDB in check. Set the value as "0" to disable log cleanup
 	DealLogDurationDays int
+
+	// The sealing pipeline status is cached by Boost if deal filters are enabled to avoid constant call to
+	// lotus-miner API. SealingPipelineCacheTimeout defines cache timeout value in seconds. Default is 30 seconds.
+	// Any value less than 0 will result in use of default
+	SealingPipelineCacheTimeout int
 }
 
 type FeeConfig struct {

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -249,7 +249,7 @@ type DealmakingConfig struct {
 	// The sealing pipeline status is cached by Boost if deal filters are enabled to avoid constant call to
 	// lotus-miner API. SealingPipelineCacheTimeout defines cache timeout value in seconds. Default is 30 seconds.
 	// Any value less than 0 will result in use of default
-	SealingPipelineCacheTimeout int
+	SealingPipelineCacheTimeout Duration
 }
 
 type FeeConfig struct {

--- a/node/modules/storageminer.go
+++ b/node/modules/storageminer.go
@@ -468,8 +468,9 @@ func NewStorageMarketProvider(provAddr address.Address, cfg *config.Boost) func(
 				StallCheckPeriod: time.Duration(cfg.Dealmaking.HttpTransferStallCheckPeriod),
 				StallTimeout:     time.Duration(cfg.Dealmaking.HttpTransferStallTimeout),
 			},
-			DealLogDurationDays: cfg.Dealmaking.DealLogDurationDays,
-			StorageFilter:       cfg.Dealmaking.Filter,
+			DealLogDurationDays:         cfg.Dealmaking.DealLogDurationDays,
+			StorageFilter:               cfg.Dealmaking.Filter,
+			SealingPipelineCacheTimeout: cfg.Dealmaking.SealingPipelineCacheTimeout,
 		}
 		dl := logs.NewDealLogger(logsDB)
 		tspt := httptransport.New(h, dl)

--- a/node/modules/storageminer.go
+++ b/node/modules/storageminer.go
@@ -470,7 +470,7 @@ func NewStorageMarketProvider(provAddr address.Address, cfg *config.Boost) func(
 			},
 			DealLogDurationDays:         cfg.Dealmaking.DealLogDurationDays,
 			StorageFilter:               cfg.Dealmaking.Filter,
-			SealingPipelineCacheTimeout: cfg.Dealmaking.SealingPipelineCacheTimeout,
+			SealingPipelineCacheTimeout: time.Duration(cfg.Dealmaking.SealingPipelineCacheTimeout),
 		}
 		dl := logs.NewDealLogger(logsDB)
 		tspt := httptransport.New(h, dl)

--- a/node/modules/storageminer.go
+++ b/node/modules/storageminer.go
@@ -469,6 +469,7 @@ func NewStorageMarketProvider(provAddr address.Address, cfg *config.Boost) func(
 				StallTimeout:     time.Duration(cfg.Dealmaking.HttpTransferStallTimeout),
 			},
 			DealLogDurationDays: cfg.Dealmaking.DealLogDurationDays,
+			StorageFilter:       cfg.Dealmaking.Filter,
 		}
 		dl := logs.NewDealLogger(logsDB)
 		tspt := httptransport.New(h, dl)

--- a/storagemarket/provider.go
+++ b/storagemarket/provider.go
@@ -158,7 +158,7 @@ func NewProvider(cfg Config, sqldb *sql.DB, dealsDB *db.DealsDB, fundMgr *fundma
 	}
 
 	if cfg.SealingPipelineCacheTimeout < 0 {
-		cfg.SealingPipelineCacheTimeout = 30
+		cfg.SealingPipelineCacheTimeout = 30 * time.Second
 	}
 
 	return &Provider{

--- a/storagemarket/provider.go
+++ b/storagemarket/provider.go
@@ -157,8 +157,9 @@ func NewProvider(cfg Config, sqldb *sql.DB, dealsDB *db.DealsDB, fundMgr *fundma
 		cfg.MaxConcurrentLocalCommp = 1
 	}
 
-	// Set the timeout to 30 seconds
-	cfg.SealingPipelineCacheTimeout = 30
+	if cfg.SealingPipelineCacheTimeout < 0 {
+		cfg.SealingPipelineCacheTimeout = 30
+	}
 
 	return &Provider{
 		ctx:       ctx,

--- a/storagemarket/provider.go
+++ b/storagemarket/provider.go
@@ -69,7 +69,7 @@ type Config struct {
 	// Cleanup deal logs from DB older than this many number of days
 	DealLogDurationDays int
 	// Cache timeout for Sealing Pipeline status
-	SealingPipelineCacheTimeout int
+	SealingPipelineCacheTimeout time.Duration
 	StorageFilter               string
 }
 
@@ -468,11 +468,6 @@ func (p *Provider) Start() error {
 		if err != nil {
 			p.dealLogger.LogError(deal.DealUuid, "failed to restart deal", err)
 		}
-	}
-
-	// Populate Sealing Pipeline Status Cache if deal filter is enabled
-	if p.config.StorageFilter != "" {
-		go p.sealingPipelineStatus()
 	}
 
 	// Start provider run loop

--- a/storagemarket/provider_dealfilter.go
+++ b/storagemarket/provider_dealfilter.go
@@ -64,6 +64,17 @@ func (p *Provider) getDealFilterParams(deal *types.ProviderDealState) (*dealfilt
 // sealingPipelineStatus updates the SealingPipelineCache to reduce constant sealingpipeline.GetStatus calls
 // to the lotus-miner. This is to speed up the deal filter processing
 func (p *Provider) sealingPipelineStatus() {
+
+	sealingStatus, err := sealingpipeline.GetStatus(p.ctx, p.sps)
+	if err != nil {
+		p.spsCache.CacheError = err
+		p.spsCache.CacheTime = time.Now()
+	} else {
+		p.spsCache.Status = *sealingStatus
+		p.spsCache.CacheTime = time.Now()
+		p.spsCache.CacheError = nil
+	}
+
 	// Create a ticker with a second tick
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()

--- a/storagemarket/provider_loop.go
+++ b/storagemarket/provider_loop.go
@@ -70,6 +70,10 @@ type acceptError struct {
 }
 
 func (p *Provider) runDealFilters(deal *types.ProviderDealState) *acceptError {
+	if p.config.StorageFilter == "" {
+		return nil
+	}
+
 	// run custom storage deal filter decision logic
 	dealFilterParams, aerr := p.getDealFilterParams(deal)
 	if aerr != nil {
@@ -115,10 +119,8 @@ func (p *Provider) processDealProposal(deal *types.ProviderDealState) *acceptErr
 	}
 
 	// Run deal through the filter if deal filter is set
-	if p.config.StorageFilter != "" {
-		if aerr := p.runDealFilters(deal); aerr != nil {
-			return aerr
-		}
+	if aerr := p.runDealFilters(deal); aerr != nil {
+		return aerr
 	}
 
 	cleanup := func() {
@@ -228,10 +230,8 @@ func (p *Provider) processOfflineDealProposal(ds *smtypes.ProviderDealState, dh 
 	}
 
 	// Run deal through the filter if deal filter is set
-	if p.config.StorageFilter != "" {
-		if aerr := p.runDealFilters(ds); aerr != nil {
-			return aerr
-		}
+	if aerr := p.runDealFilters(ds); aerr != nil {
+		return aerr
 	}
 
 	// Save deal to DB

--- a/storagemarket/provider_loop.go
+++ b/storagemarket/provider_loop.go
@@ -114,9 +114,11 @@ func (p *Provider) processDealProposal(deal *types.ProviderDealState) *acceptErr
 		return aerr
 	}
 
-	// Run deal through the filter
-	if aerr := p.runDealFilters(deal); aerr != nil {
-		return aerr
+	// Run deal through the filter if deal filter is set
+	if p.config.StorageFilter != "" {
+		if aerr := p.runDealFilters(deal); aerr != nil {
+			return aerr
+		}
 	}
 
 	cleanup := func() {
@@ -225,9 +227,11 @@ func (p *Provider) processOfflineDealProposal(ds *smtypes.ProviderDealState, dh 
 		return aerr
 	}
 
-	// Run deal through the filter
-	if aerr := p.runDealFilters(ds); aerr != nil {
-		return aerr
+	// Run deal through the filter if deal filter is set
+	if p.config.StorageFilter != "" {
+		if aerr := p.runDealFilters(ds); aerr != nil {
+			return aerr
+		}
 	}
 
 	// Save deal to DB

--- a/storagemarket/provider_test.go
+++ b/storagemarket/provider_test.go
@@ -1506,7 +1506,7 @@ func NewHarness(t *testing.T, opts ...harnessOpt) *ProviderHarness {
 			StallCheckPeriod: time.Millisecond,
 			StallTimeout:     time.Hour,
 		},
-		SealingPipelineCacheTimeout: 1,
+		SealingPipelineCacheTimeout: time.Second,
 		StorageFilter:               "1",
 	}
 	prov, err := NewProvider(prvCfg, sqldb, dealsDB, fm, sm, fn, minerStub, minerAddr, minerStub, minerStub, sps, minerStub, df, sqldb,

--- a/storagemarket/provider_test.go
+++ b/storagemarket/provider_test.go
@@ -1506,6 +1506,8 @@ func NewHarness(t *testing.T, opts ...harnessOpt) *ProviderHarness {
 			StallCheckPeriod: time.Millisecond,
 			StallTimeout:     time.Hour,
 		},
+		SealingPipelineCacheTimeout: 1,
+		StorageFilter:               "1",
 	}
 	prov, err := NewProvider(prvCfg, sqldb, dealsDB, fm, sm, fn, minerStub, minerAddr, minerStub, minerStub, sps, minerStub, df, sqldb,
 		logsDB, dagStore, ps, minerStub, askStore, &mockSignatureVerifier{true, nil}, dl, tspt)


### PR DESCRIPTION
Fixes https://github.com/filecoin-project/boost/issues/1207

Suggested design by DIrk:

if there is no deal filter enabled in config, don't call the method at all

if the deal filter is enabled
> check the cache
> if the cache is empty
> > call the method
> > store the results in the cache
>> expire the result after x time (where x is configurable)
> return the result