### PR TITLE
fix: BasicDealFilter logic

### DIFF
--- a/node/modules/dealfilter.go
+++ b/node/modules/dealfilter.go
@@ -38,7 +38,7 @@ func BasicDealFilter(cfg config.DealmakingConfig, userCmd dtypes.StorageDealFilt
 				return false, "miner error", err
 			}
 
-			if deal.Transfer.Type != "manual" && !b {
+			if deal.Transfer.Type != "" && !b {
 				log.Warnf("online storage deal consideration disabled; rejecting storage deal proposal from client: %s", deal.ClientDealProposal.Proposal.Client.String())
 				return false, "miner is not considering online storage deals", nil
 			}
@@ -49,7 +49,7 @@ func BasicDealFilter(cfg config.DealmakingConfig, userCmd dtypes.StorageDealFilt
 				return false, "miner error", err
 			}
 
-			if deal.Transfer.Type == "manual" && !b {
+			if deal.Transfer.Type == "" && !b {
 				log.Warnf("offline storage deal consideration disabled; rejecting storage deal proposal from client: %s", deal.ClientDealProposal.Proposal.Client.String())
 				return false, "miner is not accepting offline storage deals", nil
 			}

--- a/node/modules/dealfilter.go
+++ b/node/modules/dealfilter.go
@@ -38,7 +38,7 @@ func BasicDealFilter(cfg config.DealmakingConfig, userCmd dtypes.StorageDealFilt
 				return false, "miner error", err
 			}
 
-			if deal.Transfer.Type != "" && !b {
+			if !deal.IsOffline && !b {
 				log.Warnf("online storage deal consideration disabled; rejecting storage deal proposal from client: %s", deal.ClientDealProposal.Proposal.Client.String())
 				return false, "miner is not considering online storage deals", nil
 			}
@@ -49,7 +49,7 @@ func BasicDealFilter(cfg config.DealmakingConfig, userCmd dtypes.StorageDealFilt
 				return false, "miner error", err
 			}
 
-			if deal.Transfer.Type == "" && !b {
+			if deal.IsOffline && !b {
 				log.Warnf("offline storage deal consideration disabled; rejecting storage deal proposal from client: %s", deal.ClientDealProposal.Proposal.Client.String())
 				return false, "miner is not accepting offline storage deals", nil
 			}

--- a/storagemarket/provider_dealfilter.go
+++ b/storagemarket/provider_dealfilter.go
@@ -46,9 +46,6 @@ func (p *Provider) getDealFilterParams(deal *types.ProviderDealState) (*dealfilt
 		ClientDealProposal: deal.ClientDealProposal,
 		DealDataRoot:       deal.DealDataRoot,
 		Transfer:           deal.Transfer,
-		IsOffline:          deal.IsOffline,
-		SkipIPNIAnnounce:   !deal.AnnounceToIPNI,
-		RemoveUnsealedCopy: !deal.FastRetrieval,
 	}
 
 	// Clear transfer params in case it contains sensitive information

--- a/storagemarket/provider_dealfilter.go
+++ b/storagemarket/provider_dealfilter.go
@@ -46,6 +46,9 @@ func (p *Provider) getDealFilterParams(deal *types.ProviderDealState) (*dealfilt
 		ClientDealProposal: deal.ClientDealProposal,
 		DealDataRoot:       deal.DealDataRoot,
 		Transfer:           deal.Transfer,
+		IsOffline:          deal.IsOffline,
+		SkipIPNIAnnounce:   !deal.AnnounceToIPNI,
+		RemoveUnsealedCopy: !deal.FastRetrieval,
 	}
 
 	// Clear transfer params in case it contains sensitive information


### PR DESCRIPTION
Fixes https://github.com/filecoin-project/boost/issues/1208
This PR also extend the deal params exposed to the external deal filters like CIDGravity. Before this an offline deal was sending a false value for IsOffline to external filter. 