### PR TITLE
chore: enable feature and enhancement report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -9,7 +9,9 @@ body:
     options:
       - label: This is **not** a question or a support request. If you have any boost related questions, please ask in the [discussion forum](https://github.com/filecoin-project/boost/discussions).
         required: true
-      - label: This is **not** a new feature or enhancement request. If it is, please open a [new idea discussion](https://github.com/filecoin-project/boost/discussions/new?category=ideas) instead. New feature and enhancement requests would be entertained by the boost team after a thorough discussion only.
+      - label: This is **not** a new feature request. If it is, please file a [feature request](https://github.com/filecoin-project/boost/issues/new?assignees=&labels=need%2Ftriage%2Ckind%2Ffeature&template=feature_request.yml) instead.
+        required: true
+      - label: This is **not** an enhancement request. If it is, please file a [improvement suggestion](https://github.com/filecoin-project/boost/issues/new?assignees=&labels=need%2Ftriage%2Ckind%2Fenhancement&template=enhancement.yml) instead.
         required: true
       - label: I **have** searched on the [issue tracker](https://github.com/filecoin-project/boost/issues) and the [discussion forum](https://github.com/filecoin-project/boost/discussions), and there is no existing related issue or discussion.
         required: true

--- a/.github/ISSUE_TEMPLATE/enhancement_report.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement_report.yml
@@ -9,7 +9,7 @@ body:
       options:
         - label: This is **not** a question or a support request. If you have any boost related questions, please ask in the [discussion forum](https://github.com/filecoin-project/boost/discussions).
           required: true
-        - label: This is **not** a new feature request. If it is, please open a [new idea discussion](https://github.com/filecoin-project/boost/discussions/new?category=ideas) instead.
+        - label: This is **not** a new feature request. If it is, please file a [feature request](https://github.com/filecoin-project/boost/issues/new?assignees=&labels=need%2Ftriage%2Ckind%2Ffeature&template=feature_request.yml) instead.
           required: true
         - label: I **have** searched on the [issue tracker](https://github.com/filecoin-project/boost/issues) and the [discussion forum](https://github.com/filecoin-project/boost/discussions), and there is no existing related issue or discussion.
           required: true

--- a/.github/ISSUE_TEMPLATE/enhancement_report.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement_report.yml
@@ -1,0 +1,42 @@
+name: "Enhancement Report"
+description: "Suggest an improvement to an existing Boost feature"
+labels: [need/triage, kind/enhancement]
+body:
+  - type: checkboxes
+    attributes:
+      label: Checklist
+      description: Please check off the following boxes before continuing to continuing to create an improvement suggestion!
+      options:
+        - label: This is **not** a question or a support request. If you have any boost related questions, please ask in the [discussion forum](https://github.com/filecoin-project/boost/discussions).
+          required: true
+        - label: This is **not** a new feature request. If it is, please open a [new idea discussion](https://github.com/filecoin-project/boost/discussions/new?category=ideas) instead.
+          required: true
+        - label: I **have** searched on the [issue tracker](https://github.com/filecoin-project/boost/issues) and the [discussion forum](https://github.com/filecoin-project/boost/discussions), and there is no existing related issue or discussion.
+          required: true
+        - label: I am running the [`Latest release`](https://github.com/filecoin-project/boost/releases), or the most recent RC(release canadiate) for the upcoming release or the dev branch(master), or have an issue updating to any of these.
+          required: true
+  - type: checkboxes
+    attributes:
+      label: Boost component
+      description: Please select the boost component you are filing an improvement request for
+      options:
+        - label: boost daemon - storage providers
+          required: false
+        - label: boost client
+          required: false
+        - label: boost UI
+          required: false
+        - label: boost data-transfer
+          required: false
+        - label: boost index-provider
+          required: false
+        - label:  Other
+          required: false
+  - type: textarea
+    id: request
+    attributes:
+      label: Improvement Suggestion
+      description: A clear and concise description of what the motivation or the current problem is and what is the suggested improvement?
+      placeholder: Ex. Currently Boost... However, as a storage provider or client, I'd like...
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,61 @@
+name: Feature request
+description: Suggest an idea for Boost
+labels: [need/triage, kind/feature]
+body:
+  - type: checkboxes
+    attributes:
+      label: Checklist
+      description: Please check off the following boxes before continuing to create a new feature request!
+      options:
+        - label: This is **not** a new feature or an enhancement to the Filecoin protocol. If it is,  please open an [FIP issue](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0001.md).
+          required: true
+        - label: This is **not** brainstorming ideas. If you have an idea you'd like to discuss, please open a new discussion on [the Boost forum](https://github.com/filecoin-project/boost/discussions/categories/ideas) and select the category as `Ideas`.
+          required: true
+        - label: I **have** a specific, actionable, and well motivated feature request to propose.
+          required: true
+  - type: checkboxes
+    attributes:
+      label: Boost component
+      description: Please select the boost component you are filing an improvement request for
+      options:
+        - label: boost daemon - storage providers
+          required: false
+        - label: boost client
+          required: false
+        - label: boost UI
+          required: false
+        - label: boost data-transfer
+          required: false
+        - label: boost index-provider
+          required: false
+        - label:  Other
+          required: false
+  - type: textarea
+    id: request
+    attributes:
+      label: What is the motivation behind this feature request? Is your feature request related to a problem? Please describe.
+      description: A clear and concise description of what the motivation or the problem is.
+      placeholder: Ex. I'm always frustrated when [...]
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Describe the solution you'd like
+      description: A clear and concise description of what you want to happen.
+    validations:
+      required: true
+  - type: textarea
+    id: alternates
+    attributes:
+      label: Describe alternatives you've considered
+      description: A clear and concise description of any alternative solutions or features you've considered.
+    validations:
+      required: false
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional context
+      description: Add any other context, design docs or screenshots about the feature request here.
+    validations:
+      required: false

--- a/node/config/doc_gen.go
+++ b/node/config/doc_gen.go
@@ -296,7 +296,8 @@ Lower this limit if boostd memory is too high during retrievals`,
 			Name: "RemoteCommp",
 			Type: "bool",
 
-			Comment: `Whether to do commp on the Boost node (local) or on the Sealer (remote)`,
+			Comment: `Whether to do commp on the Boost node (local) or on the Sealer (remote)
+Please note that this only works for v1.2.0 deals and not legacy deals`,
 		},
 		{
 			Name: "MaxConcurrentLocalCommp",


### PR DESCRIPTION
When we were launching Boost, it was decided that we will entertain feature/enhancement requests only via discussion. After multiple iterations, we have seen that requests coming in have been reasonable and useful.

If everyone in the team agrees, I would like to enable direct filing of feature requests and enhancement requests at this point. I will also update the docs to point to these templates. 