### PR TITLE
Simplify docker build tasks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,29 +201,19 @@ docsgen-openrpc-boost: docsgen-openrpc-bin
 ## DOCKER IMAGES
 docker_user?=filecoin
 lotus_version?=v1.20.0-rc1
-lotus_src_dir?=
 ffi_from_source?=0
 build_lotus?=0
-ifeq ($(lotus_src_dir),)
-	ifeq ($(build_lotus),1)
+ifeq ($(build_lotus),1)
 # v1: building lotus image with provided lotus version
-		lotus_info_msg=!!! building lotus base image from github: tag $(lotus_version) !!!
-		lotus_src_dir=/tmp/lotus-$(lotus_version)
-		lotus_checkout_dir=$(lotus_src_dir)
-		lotus_build_cmd=docker/lotus-all-in-one
-		lotus_base_image=$(docker_user)/lotus-all-in-one:dev
-	else
-# v2 (defaut): using lotus image
-		lotus_base_image?=filecoin/lotus-all-in-one:$(lotus_version)-debug
-		lotus_info_msg=using lotus image from dockerhub: $(lotus_base_image)
-		lotus_build_cmd=info/lotus-all-in-one
-	endif
-else
-# v3: building lotus image from source
-	lotus_info_msg=!!! building lotus base image from source: $(lotus_src_dir) !!!
-	lotus_base_image=$(docker_user)/lotus-all-in-one:dev
+	lotus_info_msg=!!! building lotus base image from github: tag $(lotus_version) !!!
+	lotus_src_dir?=/tmp/lotus-$(lotus_version)
 	lotus_build_cmd=docker/lotus-all-in-one
-    lotus_checkout_dir=
+	lotus_base_image=$(docker_user)/lotus-all-in-one:dev
+else
+# v2 (default): using lotus image
+	lotus_base_image?=filecoin/lotus-all-in-one:$(lotus_version)-debug
+	lotus_info_msg=using lotus image from dockerhub: $(lotus_base_image)
+	lotus_build_cmd=info/lotus-all-in-one
 endif
 docker_build_cmd=docker build --build-arg LOTUS_TEST_IMAGE=$(lotus_base_image) \
 	--build-arg FFI_BUILD_FROM_SOURCE=$(ffi_from_source) $(docker_args)
@@ -231,16 +221,11 @@ docker_build_cmd=docker build --build-arg LOTUS_TEST_IMAGE=$(lotus_base_image) \
 info/lotus-all-in-one:
 	@echo Docker build info: $(lotus_info_msg)
 .PHONY: info/lotus-all-in-one
-$(lotus_checkout_dir):
+$(lotus_src_dir):
 	git clone --depth 1 --branch $(lotus_version) https://github.com/filecoin-project/lotus $@
-docker/lotus-all-in-one: info/lotus-all-in-one | $(lotus_checkout_dir)
-# new lotus Dockerfile does not exist for older lotus versions
-# temporary use the old Dockerfile.lotus
-	cd $(lotus_src_dir) && $(docker_build_cmd) -f Dockerfile.lotus --target lotus-test \
-		-t $(lotus_base_image) .
-# code using new lotus Dockerfile
-#	cd $(lotus_src_dir) && $(docker_build_cmd) -f Dockerfile --target lotus-all-in-one \
-#		-t $(lotus_base_image) --build-arg GOFLAGS=-tags=debug .
+docker/lotus-all-in-one: info/lotus-all-in-one | $(lotus_src_dir)
+	cd $(lotus_src_dir) && $(docker_build_cmd) -f Dockerfile --target lotus-all-in-one \
+		-t $(lotus_base_image) --build-arg GOFLAGS=-tags=debug .
 .PHONY: docker/lotus-all-in-one
 
 ### devnet images

--- a/Makefile
+++ b/Makefile
@@ -205,8 +205,8 @@ ffi_from_source?=0
 build_lotus?=0
 ifeq ($(build_lotus),1)
 # v1: building lotus image with provided lotus version
-	lotus_info_msg=!!! building lotus base image from github: tag $(lotus_version) !!!
-	lotus_src_dir=/tmp/lotus-$(lotus_version)
+	lotus_info_msg=!!! building lotus base image from github: branch/tag $(lotus_version) !!!
+	override lotus_src_dir=/tmp/lotus-$(lotus_version)
 	lotus_build_cmd=update/lotus docker/lotus-all-in-one
 	lotus_base_image=$(docker_user)/lotus-all-in-one:dev
 else

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ On ARM-based systems (*Apple M1/M2*) you need to force building Filecoin's Rust 
 make docker/all ffi_from_source=1 build_lotus=1
 ```
 
-If you need to build containers using a specific version of lotus then provide the version as a parameter, e.g. `make docker/all lotus_version=v1.20.0-rc2 build_lotus=1`. The version must be a tag name of [Lotus git repo](https://github.com/filecoin-project/lotus/tags). Or you can build using a local source of lotus - `make docker/all lotus_src_dir=<path of lotus source> build_lotus=1`. 
+If you need to build containers using a specific version of lotus then provide the version as a parameter, e.g. `make docker/all lotus_version=v1.20.0-rc2 build_lotus=1`. The version must be a tag or a remote branch name of [Lotus git repo](https://github.com/filecoin-project/lotus).
 
 ### Start devnet docker stack
 

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ On ARM-based systems (*Apple M1/M2*) you need to force building Filecoin's Rust 
 make docker/all ffi_from_source=1 build_lotus=1
 ```
 
-If you need to build containers using a specific version of lotus then provide the version as a parameter, e.g. `make docker/all lotus_version=v1.17.0 build_lotus=1`. The version must be a tag name of [Lotus git repo](https://github.com/filecoin-project/lotus/tags). Or you can build using a local source of lotus - `make docker/all lotus_src_dir=<path of lotus source>`. 
+If you need to build containers using a specific version of lotus then provide the version as a parameter, e.g. `make docker/all lotus_version=v1.20.0-rc2 build_lotus=1`. The version must be a tag name of [Lotus git repo](https://github.com/filecoin-project/lotus/tags). Or you can build using a local source of lotus - `make docker/all lotus_src_dir=<path of lotus source> build_lotus=1`. 
 
 ### Start devnet docker stack
 


### PR DESCRIPTION
## Simplify docker build scripts in Makefile:
- drop excess parameter `lotus_checkout_dir`, use `lotus_src_dir`.
- drop if clause `ifeq ($(lotus_src_dir),)` ...
- use the new lotus `Dockerfile` instead of the old one `Dockerfile.lotus` when building lotus from source