### PR TITLE
feat: add job to cancel stalled retrievals

### DIFF
--- a/node/builder.go
+++ b/node/builder.go
@@ -535,7 +535,7 @@ func ConfigBoost(cfg *config.Boost) Option {
 		Override(new(retrievalmarket.RetrievalProviderNode), retrievaladapter.NewRetrievalProviderNode),
 		Override(new(rmnet.RetrievalMarketNetwork), lotus_modules.RetrievalNetwork),
 		Override(new(retrievalmarket.RetrievalProvider), lotus_modules.RetrievalProvider),
-		Override(HandleRetrievalEventsKey, modules.HandleRetrievalGraphsyncUpdates(time.Duration(cfg.Dealmaking.RetrievalLogDuration), time.Duration(cfg.Dealmaking.StalledRetrievalDuration))),
+		Override(HandleRetrievalEventsKey, modules.HandleRetrievalGraphsyncUpdates(time.Duration(cfg.Dealmaking.RetrievalLogDuration), time.Duration(cfg.Dealmaking.StalledRetrievalTimeout))),
 		Override(HandleRetrievalKey, lotus_modules.HandleRetrieval),
 		Override(new(*lp2pimpl.TransportsListener), modules.NewTransportsListener(cfg)),
 		Override(new(*protocolproxy.ProtocolProxy), modules.NewProtocolProxy(cfg)),

--- a/node/builder.go
+++ b/node/builder.go
@@ -535,7 +535,7 @@ func ConfigBoost(cfg *config.Boost) Option {
 		Override(new(retrievalmarket.RetrievalProviderNode), retrievaladapter.NewRetrievalProviderNode),
 		Override(new(rmnet.RetrievalMarketNetwork), lotus_modules.RetrievalNetwork),
 		Override(new(retrievalmarket.RetrievalProvider), lotus_modules.RetrievalProvider),
-		Override(HandleRetrievalEventsKey, modules.HandleRetrievalGraphsyncUpdates(time.Duration(cfg.Dealmaking.RetrievalLogDuration))),
+		Override(HandleRetrievalEventsKey, modules.HandleRetrievalGraphsyncUpdates(time.Duration(cfg.Dealmaking.RetrievalLogDuration), time.Duration(cfg.Dealmaking.StalledRetrievalDuration))),
 		Override(HandleRetrievalKey, lotus_modules.HandleRetrieval),
 		Override(new(*lp2pimpl.TransportsListener), modules.NewTransportsListener(cfg)),
 		Override(new(*protocolproxy.ProtocolProxy), modules.NewProtocolProxy(cfg)),

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -87,9 +87,9 @@ func DefaultBoost() *Boost {
 
 			StartEpochSealingBuffer: 480, // 480 epochs buffer == 4 hours from adding deal to sector to sector being sealed
 
-			DealProposalLogDuration:  Duration(time.Hour * 24),
-			RetrievalLogDuration:     Duration(time.Hour * 24),
-			StalledRetrievalDuration: Duration(time.Minute * 30),
+			DealProposalLogDuration: Duration(time.Hour * 24),
+			RetrievalLogDuration:    Duration(time.Hour * 24),
+			StalledRetrievalTimeout: Duration(time.Minute * 30),
 
 			RetrievalPricing: &lotus_config.RetrievalPricing{
 				Strategy: RetrievalPricingDefaultMode,

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -87,8 +87,9 @@ func DefaultBoost() *Boost {
 
 			StartEpochSealingBuffer: 480, // 480 epochs buffer == 4 hours from adding deal to sector to sector being sealed
 
-			DealProposalLogDuration: Duration(time.Hour * 24),
-			RetrievalLogDuration:    Duration(time.Hour * 24),
+			DealProposalLogDuration:  Duration(time.Hour * 24),
+			RetrievalLogDuration:     Duration(time.Hour * 24),
+			StalledRetrievalDuration: Duration(time.Minute * 30),
 
 			RetrievalPricing: &lotus_config.RetrievalPricing{
 				Strategy: RetrievalPricingDefaultMode,

--- a/node/config/doc_gen.go
+++ b/node/config/doc_gen.go
@@ -252,11 +252,11 @@ Set this value to 0 to indicate there is no limit per host.`,
 			Type: "Duration",
 
 			Comment: `The amount of time to keep retrieval deal logs for before cleaning them up.
-Note RetrievalLogDuration should exceed the StalledRetrievalDuration as the
+Note RetrievalLogDuration should exceed the StalledRetrievalTimeout as the
 logs db is leveraged for pruning stalled retrievals.`,
 		},
 		{
-			Name: "StalledRetrievalDuration",
+			Name: "StalledRetrievalTimeout",
 			Type: "Duration",
 
 			Comment: `The amount of time stalled retrieval deals will remain open before being canceled.`,

--- a/node/config/doc_gen.go
+++ b/node/config/doc_gen.go
@@ -251,7 +251,15 @@ Set this value to 0 to indicate there is no limit per host.`,
 			Name: "RetrievalLogDuration",
 			Type: "Duration",
 
-			Comment: `The amount of time to keep retrieval deal logs for before cleaning them up.`,
+			Comment: `The amount of time to keep retrieval deal logs for before cleaning them up.
+Note RetrievalLogDuration should exceed the StalledRetrievalDuration as the
+logs db is leveraged for pruning stalled retrievals.`,
+		},
+		{
+			Name: "StalledRetrievalDuration",
+			Type: "Duration",
+
+			Comment: `The amount of time stalled retrieval deals will remain open before being canceled.`,
 		},
 		{
 			Name: "Filter",

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -176,7 +176,11 @@ type DealmakingConfig struct {
 	// The amount of time to keep deal proposal logs for before cleaning them up.
 	DealProposalLogDuration Duration
 	// The amount of time to keep retrieval deal logs for before cleaning them up.
+	// Note RetrievalLogDuration should exceed the StalledRetrievalDuration as the
+	// logs db is leveraged for pruning stalled retrievals.
 	RetrievalLogDuration Duration
+	// The amount of time stalled retrieval deals will remain open before being canceled.
+	StalledRetrievalDuration Duration
 
 	// A command used for fine-grained evaluation of storage deals
 	// see https://boost.filecoin.io/configuration/deal-filters for more details

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -176,11 +176,11 @@ type DealmakingConfig struct {
 	// The amount of time to keep deal proposal logs for before cleaning them up.
 	DealProposalLogDuration Duration
 	// The amount of time to keep retrieval deal logs for before cleaning them up.
-	// Note RetrievalLogDuration should exceed the StalledRetrievalDuration as the
+	// Note RetrievalLogDuration should exceed the StalledRetrievalTimeout as the
 	// logs db is leveraged for pruning stalled retrievals.
 	RetrievalLogDuration Duration
 	// The amount of time stalled retrieval deals will remain open before being canceled.
-	StalledRetrievalDuration Duration
+	StalledRetrievalTimeout Duration
 
 	// A command used for fine-grained evaluation of storage deals
 	// see https://boost.filecoin.io/configuration/deal-filters for more details

--- a/node/modules/retrieval.go
+++ b/node/modules/retrieval.go
@@ -142,9 +142,9 @@ func NewRetrievalLogDB(db *RetrievalSqlDB) *rtvllog.RetrievalLogDB {
 }
 
 // Write graphsync retrieval updates to the database
-func HandleRetrievalGraphsyncUpdates(duration time.Duration) func(lc fx.Lifecycle, db *rtvllog.RetrievalLogDB, m lotus_retrievalmarket.RetrievalProvider, dt lotus_dtypes.ProviderDataTransfer) {
+func HandleRetrievalGraphsyncUpdates(duration time.Duration, stalledDuration time.Duration) func(lc fx.Lifecycle, db *rtvllog.RetrievalLogDB, m lotus_retrievalmarket.RetrievalProvider, dt lotus_dtypes.ProviderDataTransfer) {
 	return func(lc fx.Lifecycle, db *rtvllog.RetrievalLogDB, m lotus_retrievalmarket.RetrievalProvider, dt lotus_dtypes.ProviderDataTransfer) {
-		rel := rtvllog.NewRetrievalLog(db, duration)
+		rel := rtvllog.NewRetrievalLog(db, duration, dt, stalledDuration)
 
 		relctx, cancel := context.WithCancel(context.Background())
 		type unsubFn func()

--- a/retrievalmarket/rtvllog/db.go
+++ b/retrievalmarket/rtvllog/db.go
@@ -123,6 +123,10 @@ func (d *RetrievalLogDB) List(ctx context.Context, cursor *time.Time, offset int
 	return d.list(ctx, offset, limit, where, whereArgs...)
 }
 
+func (d *RetrievalLogDB) ListLastUpdatedAndOpen(ctx context.Context, lastUpdated time.Time) ([]RetrievalDealState, error) {
+	return d.list(ctx, 0, 0, "UpdatedAt <= ? AND Status != 'DealStatusCompleted' AND Status != 'DealStatusCancelled'", lastUpdated)
+}
+
 func (d *RetrievalLogDB) list(ctx context.Context, offset int, limit int, where string, whereArgs ...interface{}) ([]RetrievalDealState, error) {
 	qry := "SELECT " +
 		"CreatedAt, " +

--- a/retrievalmarket/rtvllog/retrieval_log.go
+++ b/retrievalmarket/rtvllog/retrieval_log.go
@@ -7,25 +7,30 @@ import (
 
 	datatransfer "github.com/filecoin-project/go-data-transfer"
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
+	lotus_dtypes "github.com/filecoin-project/lotus/node/modules/dtypes"
 	logging "github.com/ipfs/go-log/v2"
 )
 
 var log = logging.Logger("rtrvlog")
 
 type RetrievalLog struct {
-	db       *RetrievalLogDB
-	duration time.Duration
-	ctx      context.Context
+	db              *RetrievalLogDB
+	duration        time.Duration
+	dataTransfer    lotus_dtypes.ProviderDataTransfer
+	stalledDuration time.Duration
+	ctx             context.Context
 
 	lastUpdateLk sync.Mutex
 	lastUpdate   map[string]time.Time
 }
 
-func NewRetrievalLog(db *RetrievalLogDB, duration time.Duration) *RetrievalLog {
+func NewRetrievalLog(db *RetrievalLogDB, duration time.Duration, dt lotus_dtypes.ProviderDataTransfer, stalledDuration time.Duration) *RetrievalLog {
 	return &RetrievalLog{
-		db:         db,
-		duration:   duration,
-		lastUpdate: make(map[string]time.Time),
+		db:              db,
+		duration:        duration,
+		dataTransfer:    dt,
+		stalledDuration: stalledDuration,
+		lastUpdate:      make(map[string]time.Time),
 	}
 }
 
@@ -33,6 +38,7 @@ func (r *RetrievalLog) Start(ctx context.Context) {
 	r.ctx = ctx
 	go r.gcUpdateMap(ctx)
 	go r.gcDatabase(ctx)
+	go r.gcRetrievals(ctx)
 }
 
 // Called when there is a retrieval ask query
@@ -221,6 +227,37 @@ func (r *RetrievalLog) gcDatabase(ctx context.Context) {
 				log.Errorw("error trimming retrieval logs", "err", err)
 			} else if count > 0 {
 				log.Infof("Deleted %d retrieval logs older than %s", count, r.duration)
+			}
+		}
+	}
+}
+
+// Periodically cancels stalled retrievals older than 30mins
+func (r *RetrievalLog) gcRetrievals(ctx context.Context) {
+	ticker := time.NewTicker(5 * time.Minute)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case now := <-ticker.C:
+			// Get retrievals last updated
+			rows, err := r.db.ListLastUpdatedAndOpen(ctx, now.Add(-r.stalledDuration))
+
+			if err != nil {
+				log.Errorw("error fetching open, stalled retrievals", "err", err)
+				continue
+			}
+
+			for _, row := range rows {
+				chid := datatransfer.ChannelID{Initiator: row.PeerID, Responder: row.LocalPeerID, ID: row.TransferID}
+				err := r.dataTransfer.CloseDataTransferChannel(ctx, chid)
+				if err != nil {
+					log.Errorw("error canceling retrieval", "dealID", row.DealID, "err", err)
+				} else {
+					log.Infof("Canceled retrieval %s, older than %s", row.DealID, r.stalledDuration)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
As part of debugging https://github.com/filecoin-project/boost/issues/1125 we determined that stalled retrievals were never being cleaned up by the go-fil-markets code. This was originally intended to allow resumption of retrieval, however, there was never a cap put on the duration and retrievals would require manual termination. This behavior doesn't scale.

There is refactoring that is needed for the go-fil-markets retrieval codepaths as a separate effort, but in the interim, this will provide a short term fix for canceling stalled retrieval.

This new job runs every 5 minutes and will cancel all retrievals in the Retrieval Log that have not been updated in the past 30 minutes (configurable). 30 minutes should be a reasonable default for clients to attempt to reconnect and resume transfer if desired.

## Caveats of this approach
I have noted in the config type docs that the RetrievalLog duration must exceed the stalled retrieval duration in order for this to function properly. The reason the RetrievalLog is being used here for pruning is that it is significantly more efficient than querying the go-fil-markets statemachines, as the latter loads everything into memory. Once we have refactored the legacy retrieval code, we can migrate to using a more thorough check for stalled retrieval than the logs db.

## Devnet Testing
I set up my local devnet to prune stalled retrievals older than 5 minutes and executed 100 retrievals and abruptly terminated their connection from the client. After the 5 minute stall window was passed, all deals were executed.

![Screenshot 2023-02-28 at 2 12 54 PM](https://user-images.githubusercontent.com/639834/221873620-8596fd06-bf04-4975-aa5c-b1995f904cd1.png)

![Screenshot 2023-02-28 at 2 20 10 PM](https://user-images.githubusercontent.com/639834/221873639-b075eee8-cade-4af4-9457-022a69311aa7.png)


