### PR TITLE
Simple graphsync retrieval server

### DIFF
--- a/cmd/lib/api.go
+++ b/cmd/lib/api.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/filecoin-project/boost/api"
 	cliutil "github.com/filecoin-project/boost/cli/util"
@@ -136,6 +137,8 @@ func CreateSectorAccessor(ctx context.Context, storageApiInfo string, fullnodeAp
 
 	// Create the piece provider
 	pp := sealer.NewPieceProvider(storage, storageService, storageService)
-	sa := sectoraccessor.NewSectorAccessor(dtypes.MinerAddress(maddr), storageService, pp, fullnodeApi)
+	const maxCacheSize = 4096
+	newSectorAccessor := sectoraccessor.NewCachingSectorAccessor(maxCacheSize, 5*time.Minute)
+	sa := newSectorAccessor(dtypes.MinerAddress(maddr), storageService, pp, fullnodeApi)
 	return sa, storageCloser, nil
 }

--- a/docker/monitoring/grafana/dashboards/provider-retrievals.json
+++ b/docker/monitoring/grafana/dashboards/provider-retrievals.json
@@ -265,6 +265,514 @@
         "x": 0,
         "y": 9
       },
+      "id": 62,
+      "panels": [],
+      "title": "graphsync",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prom1234"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 10
+      },
+      "id": 69,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prom1234"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "irate(boost_graphsync_request_bytes_sent_count{}[$__rate_interval]) * 15",
+          "instant": false,
+          "legendFormat": "total",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prom1234"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "irate(boost_graphsync_request_bytes_sent_unpaid_count{}[$__rate_interval]) * 15",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "unpaid",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prom1234"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "irate(boost_graphsync_request_bytes_sent_paid_count{}[$__rate_interval]) * 15",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "paid",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Graphsync Bytes Served",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prom1234"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 17
+      },
+      "id": 66,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prom1234"
+          },
+          "editorMode": "code",
+          "expr": "irate(boost_graphsync_request_block_sent_count{}[$__rate_interval]) * 15",
+          "legendFormat": "total",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prom1234"
+          },
+          "editorMode": "code",
+          "expr": "irate(boost_graphsync_request_block_sent_unpaid_count{}[$__rate_interval]) * 15",
+          "hide": false,
+          "legendFormat": "unpaid",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prom1234"
+          },
+          "editorMode": "code",
+          "expr": "irate(boost_graphsync_request_block_sent_paid_count{}[$__rate_interval]) * 15",
+          "hide": false,
+          "legendFormat": "paid",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Graphsync Blocks Sent",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prom1234"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 17
+      },
+      "id": 68,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prom1234"
+          },
+          "editorMode": "code",
+          "expr": "irate(boost_graphsync_request_queued_count{}[$__rate_interval]) * 15",
+          "legendFormat": "queued",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prom1234"
+          },
+          "editorMode": "code",
+          "expr": "irate(boost_graphsync_request_started_count{}[$__rate_interval]) * 15",
+          "hide": false,
+          "legendFormat": "started",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prom1234"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "irate(boost_graphsync_request_completed_count{}[$__rate_interval]) * 15",
+          "hide": false,
+          "legendFormat": "completed",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prom1234"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "irate(boost_graphsync_request_client_cancelled_count{}[$__rate_interval]) * 15",
+          "hide": false,
+          "legendFormat": "client_cancelled",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prom1234"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "irate(boost_graphsync_request_completed_unpaid_success_count{}[$__rate_interval]) * 15",
+          "hide": false,
+          "legendFormat": "completed success",
+          "range": true,
+          "refId": "E"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prom1234"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "irate(boost_graphsync_request_completed_unpaid_fail_count{}[$__rate_interval]) * 15",
+          "hide": false,
+          "legendFormat": "completed failed",
+          "range": true,
+          "refId": "F"
+        }
+      ],
+      "title": "Graphsync Transfers",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prom1234"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 17
+      },
+      "id": 70,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prom1234"
+          },
+          "editorMode": "code",
+          "expr": "irate(boost_graphsync_request_network_error_count{}[$__rate_interval]) * 15",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Graphsync Network Errors",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 25
+      },
       "id": 38,
       "panels": [],
       "title": "booster-bitswap",
@@ -331,7 +839,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 10
+        "y": 26
       },
       "id": 60,
       "options": {
@@ -427,7 +935,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 17
+        "y": 33
       },
       "id": 36,
       "options": {
@@ -521,7 +1029,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 17
+        "y": 33
       },
       "id": 39,
       "options": {
@@ -628,7 +1136,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 17
+        "y": 33
       },
       "id": 46,
       "options": {
@@ -735,7 +1243,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 25
+        "y": 41
       },
       "id": 40,
       "options": {
@@ -829,7 +1337,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 25
+        "y": 41
       },
       "id": 43,
       "options": {
@@ -936,7 +1444,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 25
+        "y": 41
       },
       "id": 48,
       "options": {
@@ -1043,7 +1551,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 33
+        "y": 49
       },
       "id": 41,
       "options": {
@@ -1137,7 +1645,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 33
+        "y": 49
       },
       "id": 42,
       "options": {
@@ -1244,7 +1752,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 33
+        "y": 49
       },
       "id": 47,
       "options": {
@@ -1352,7 +1860,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 41
+        "y": 57
       },
       "id": 45,
       "options": {
@@ -1461,7 +1969,7 @@
         "h": 8,
         "w": 12,
         "x": 8,
-        "y": 41
+        "y": 57
       },
       "id": 59,
       "options": {
@@ -1501,7 +2009,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 49
+        "y": 65
       },
       "id": 30,
       "panels": [],
@@ -1595,7 +2103,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 50
+        "y": 66
       },
       "id": 2,
       "options": {
@@ -1716,7 +2224,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 50
+        "y": 66
       },
       "id": 3,
       "options": {
@@ -1812,7 +2320,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 57
+        "y": 73
       },
       "id": 36,
       "options": {
@@ -1943,7 +2451,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 57
+        "y": 73
       },
       "id": 37,
       "options": {
@@ -2070,7 +2578,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 65
+        "y": 81
       },
       "id": 5,
       "options": {
@@ -2187,7 +2695,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 65
+        "y": 81
       },
       "id": 6,
       "options": {
@@ -2306,7 +2814,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 72
+        "y": 88
       },
       "id": 9,
       "links": [],
@@ -2345,7 +2853,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 80
+        "y": 96
       },
       "id": 39,
       "panels": [],
@@ -2414,7 +2922,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 81
+        "y": 97
       },
       "id": 49,
       "options": {
@@ -2511,7 +3019,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 81
+        "y": 97
       },
       "id": 50,
       "options": {
@@ -2607,7 +3115,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 89
+        "y": 105
       },
       "id": 51,
       "options": {
@@ -2703,7 +3211,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 89
+        "y": 105
       },
       "id": 52,
       "options": {
@@ -2798,7 +3306,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 97
+        "y": 113
       },
       "id": 54,
       "options": {
@@ -2893,7 +3401,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 97
+        "y": 113
       },
       "id": 57,
       "options": {
@@ -2989,7 +3497,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 105
+        "y": 121
       },
       "id": 56,
       "options": {
@@ -3085,7 +3593,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 105
+        "y": 121
       },
       "id": 55,
       "options": {
@@ -3162,6 +3670,6 @@
   "timezone": "",
   "title": "Provider Retrievals",
   "uid": "VG2IXa4Vk",
-  "version": 4,
+  "version": 15,
   "weekStart": ""
 }

--- a/go.mod
+++ b/go.mod
@@ -240,7 +240,7 @@ require (
 	github.com/jackpal/go-nat-pmp v1.0.2 // indirect
 	github.com/jbenet/go-temp-err-catcher v0.1.0 // indirect
 	github.com/jbenet/goprocess v0.1.4 // indirect
-	github.com/jellydator/ttlcache/v2 v2.11.1 // indirect
+	github.com/jellydator/ttlcache/v2 v2.11.1
 	github.com/jessevdk/go-flags v1.4.0 // indirect
 	github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901 // indirect
 	github.com/josharian/intern v1.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -202,7 +202,7 @@ require (
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/hako/durafmt v0.0.0-20200710122514-c0fb7b4da026 // indirect
 	github.com/hannahhoward/cbor-gen-for v0.0.0-20200817222906-ea96cece81f1 // indirect
-	github.com/hannahhoward/go-pubsub v0.0.0-20200423002714-8d62886cc36e // indirect
+	github.com/hannahhoward/go-pubsub v0.0.0-20200423002714-8d62886cc36e
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-hclog v0.16.2 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/dustin/go-humanize v1.0.0
 	github.com/etclabscore/go-openrpc-reflect v0.0.36
 	github.com/fatih/color v1.13.0
-	github.com/filecoin-project/dagstore v0.6.0
+	github.com/filecoin-project/dagstore v0.6.1-0.20230307103937-65fd5c933062
 	github.com/filecoin-project/go-address v1.1.0
 	github.com/filecoin-project/go-bitfield v0.2.4
 	github.com/filecoin-project/go-cbor-util v0.0.1

--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	github.com/ipfs/go-cid v0.3.2
 	github.com/ipfs/go-cidutil v0.1.0
 	github.com/ipfs/go-datastore v0.6.0
-	github.com/ipfs/go-graphsync v0.13.3-0.20230308100815-9a03a967f254
+	github.com/ipfs/go-graphsync v0.13.3
 	github.com/ipfs/go-ipfs-blockstore v1.2.0
 	github.com/ipfs/go-ipfs-blocksutil v0.0.1
 	github.com/ipfs/go-ipfs-chunker v0.0.5

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/dustin/go-humanize v1.0.0
 	github.com/etclabscore/go-openrpc-reflect v0.0.36
 	github.com/fatih/color v1.13.0
-	github.com/filecoin-project/dagstore v0.6.1-0.20230307103937-65fd5c933062
+	github.com/filecoin-project/dagstore v0.7.0
 	github.com/filecoin-project/go-address v1.1.0
 	github.com/filecoin-project/go-bitfield v0.2.4
 	github.com/filecoin-project/go-cbor-util v0.0.1

--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	github.com/ipfs/go-cid v0.3.2
 	github.com/ipfs/go-cidutil v0.1.0
 	github.com/ipfs/go-datastore v0.6.0
-	github.com/ipfs/go-graphsync v0.13.2
+	github.com/ipfs/go-graphsync v0.13.3-0.20230308100815-9a03a967f254
 	github.com/ipfs/go-ipfs-blockstore v1.2.0
 	github.com/ipfs/go-ipfs-blocksutil v0.0.1
 	github.com/ipfs/go-ipfs-chunker v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -796,6 +796,8 @@ github.com/ipfs/go-fs-lock v0.0.7 h1:6BR3dajORFrFTkb5EpCUFIAypsoxpGpDSVUdFwzgL9U
 github.com/ipfs/go-fs-lock v0.0.7/go.mod h1:Js8ka+FNYmgQRLrRXzU3CB/+Csr1BwrRilEcvYrHhhc=
 github.com/ipfs/go-graphsync v0.13.3-0.20230308100815-9a03a967f254 h1:edC/SDL7vZJPDZwJitenUpPlxflFaf6+IlzofKSzbwI=
 github.com/ipfs/go-graphsync v0.13.3-0.20230308100815-9a03a967f254/go.mod h1:TO1Y65spARny/t37hkid5xCpQJ6vR7A7VFTEUb0Z6eA=
+github.com/ipfs/go-graphsync v0.13.3 h1:Y8mCjJU0tbb1QlJooIV0YucXbI1oaVMLhZHRWpt31zM=
+github.com/ipfs/go-graphsync v0.13.3/go.mod h1:TO1Y65spARny/t37hkid5xCpQJ6vR7A7VFTEUb0Z6eA=
 github.com/ipfs/go-ipfs-blockstore v0.0.1/go.mod h1:d3WClOmRQKFnJ0Jz/jj/zmksX0ma1gROTlovZKBmN08=
 github.com/ipfs/go-ipfs-blockstore v0.1.0/go.mod h1:5aD0AvHPi7mZc6Ci1WCAhiBQu2IsfTduLl+422H6Rqw=
 github.com/ipfs/go-ipfs-blockstore v0.2.1/go.mod h1:jGesd8EtCM3/zPgx+qr0/feTXGUeRai6adgwC+Q+JvE=

--- a/go.sum
+++ b/go.sum
@@ -333,8 +333,8 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/fatih/color v1.8.0/go.mod h1:3l45GVGkyrnYNl9HoIjnp2NnNWvh6hLAqD8yTfGjnw8=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
-github.com/filecoin-project/dagstore v0.6.0 h1:/ntQJEgCb8QfXqTVRFOCapUYmAvtoaNOtZRxzpJhbgU=
-github.com/filecoin-project/dagstore v0.6.0/go.mod h1:YKn4qXih+/2xQWpfJsaKGOi4POw5vH5grDmfPCCnx8g=
+github.com/filecoin-project/dagstore v0.6.1-0.20230307103937-65fd5c933062 h1:qtSqOJ3hkcWjTn0fAwuJY+4SPU9KLUHjSjCq4AS7F0E=
+github.com/filecoin-project/dagstore v0.6.1-0.20230307103937-65fd5c933062/go.mod h1:YKn4qXih+/2xQWpfJsaKGOi4POw5vH5grDmfPCCnx8g=
 github.com/filecoin-project/go-address v0.0.3/go.mod h1:jr8JxKsYx+lQlQZmF5i2U0Z+cGQ59wMIps/8YW/lDj8=
 github.com/filecoin-project/go-address v0.0.5/go.mod h1:jr8JxKsYx+lQlQZmF5i2U0Z+cGQ59wMIps/8YW/lDj8=
 github.com/filecoin-project/go-address v0.0.6/go.mod h1:7B0/5DA13n6nHkB8bbGx1gWzG/dbTsZ0fgOJVGsM3TE=

--- a/go.sum
+++ b/go.sum
@@ -333,8 +333,8 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/fatih/color v1.8.0/go.mod h1:3l45GVGkyrnYNl9HoIjnp2NnNWvh6hLAqD8yTfGjnw8=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
-github.com/filecoin-project/dagstore v0.6.1-0.20230307103937-65fd5c933062 h1:qtSqOJ3hkcWjTn0fAwuJY+4SPU9KLUHjSjCq4AS7F0E=
-github.com/filecoin-project/dagstore v0.6.1-0.20230307103937-65fd5c933062/go.mod h1:YKn4qXih+/2xQWpfJsaKGOi4POw5vH5grDmfPCCnx8g=
+github.com/filecoin-project/dagstore v0.7.0 h1:IS0R+69za8dguYWeqz/MI+nb7ONpk03tAkxPCBXEKm0=
+github.com/filecoin-project/dagstore v0.7.0/go.mod h1:YKn4qXih+/2xQWpfJsaKGOi4POw5vH5grDmfPCCnx8g=
 github.com/filecoin-project/go-address v0.0.3/go.mod h1:jr8JxKsYx+lQlQZmF5i2U0Z+cGQ59wMIps/8YW/lDj8=
 github.com/filecoin-project/go-address v0.0.5/go.mod h1:jr8JxKsYx+lQlQZmF5i2U0Z+cGQ59wMIps/8YW/lDj8=
 github.com/filecoin-project/go-address v0.0.6/go.mod h1:7B0/5DA13n6nHkB8bbGx1gWzG/dbTsZ0fgOJVGsM3TE=

--- a/go.sum
+++ b/go.sum
@@ -794,8 +794,6 @@ github.com/ipfs/go-filestore v1.2.0/go.mod h1:HLJrCxRXquTeEEpde4lTLMaE/MYJZD7WHL
 github.com/ipfs/go-fs-lock v0.0.6/go.mod h1:OTR+Rj9sHiRubJh3dRhD15Juhd/+w6VPOY28L7zESmM=
 github.com/ipfs/go-fs-lock v0.0.7 h1:6BR3dajORFrFTkb5EpCUFIAypsoxpGpDSVUdFwzgL9U=
 github.com/ipfs/go-fs-lock v0.0.7/go.mod h1:Js8ka+FNYmgQRLrRXzU3CB/+Csr1BwrRilEcvYrHhhc=
-github.com/ipfs/go-graphsync v0.13.3-0.20230308100815-9a03a967f254 h1:edC/SDL7vZJPDZwJitenUpPlxflFaf6+IlzofKSzbwI=
-github.com/ipfs/go-graphsync v0.13.3-0.20230308100815-9a03a967f254/go.mod h1:TO1Y65spARny/t37hkid5xCpQJ6vR7A7VFTEUb0Z6eA=
 github.com/ipfs/go-graphsync v0.13.3 h1:Y8mCjJU0tbb1QlJooIV0YucXbI1oaVMLhZHRWpt31zM=
 github.com/ipfs/go-graphsync v0.13.3/go.mod h1:TO1Y65spARny/t37hkid5xCpQJ6vR7A7VFTEUb0Z6eA=
 github.com/ipfs/go-ipfs-blockstore v0.0.1/go.mod h1:d3WClOmRQKFnJ0Jz/jj/zmksX0ma1gROTlovZKBmN08=

--- a/go.sum
+++ b/go.sum
@@ -794,8 +794,6 @@ github.com/ipfs/go-filestore v1.2.0/go.mod h1:HLJrCxRXquTeEEpde4lTLMaE/MYJZD7WHL
 github.com/ipfs/go-fs-lock v0.0.6/go.mod h1:OTR+Rj9sHiRubJh3dRhD15Juhd/+w6VPOY28L7zESmM=
 github.com/ipfs/go-fs-lock v0.0.7 h1:6BR3dajORFrFTkb5EpCUFIAypsoxpGpDSVUdFwzgL9U=
 github.com/ipfs/go-fs-lock v0.0.7/go.mod h1:Js8ka+FNYmgQRLrRXzU3CB/+Csr1BwrRilEcvYrHhhc=
-github.com/ipfs/go-graphsync v0.13.2 h1:+7IjTrdg3+3iwtPXSkLoxvhaByS3+3b9NStMAowFqkw=
-github.com/ipfs/go-graphsync v0.13.2/go.mod h1:TO1Y65spARny/t37hkid5xCpQJ6vR7A7VFTEUb0Z6eA=
 github.com/ipfs/go-graphsync v0.13.3-0.20230308100815-9a03a967f254 h1:edC/SDL7vZJPDZwJitenUpPlxflFaf6+IlzofKSzbwI=
 github.com/ipfs/go-graphsync v0.13.3-0.20230308100815-9a03a967f254/go.mod h1:TO1Y65spARny/t37hkid5xCpQJ6vR7A7VFTEUb0Z6eA=
 github.com/ipfs/go-ipfs-blockstore v0.0.1/go.mod h1:d3WClOmRQKFnJ0Jz/jj/zmksX0ma1gROTlovZKBmN08=

--- a/go.sum
+++ b/go.sum
@@ -796,6 +796,8 @@ github.com/ipfs/go-fs-lock v0.0.7 h1:6BR3dajORFrFTkb5EpCUFIAypsoxpGpDSVUdFwzgL9U
 github.com/ipfs/go-fs-lock v0.0.7/go.mod h1:Js8ka+FNYmgQRLrRXzU3CB/+Csr1BwrRilEcvYrHhhc=
 github.com/ipfs/go-graphsync v0.13.2 h1:+7IjTrdg3+3iwtPXSkLoxvhaByS3+3b9NStMAowFqkw=
 github.com/ipfs/go-graphsync v0.13.2/go.mod h1:TO1Y65spARny/t37hkid5xCpQJ6vR7A7VFTEUb0Z6eA=
+github.com/ipfs/go-graphsync v0.13.3-0.20230308100815-9a03a967f254 h1:edC/SDL7vZJPDZwJitenUpPlxflFaf6+IlzofKSzbwI=
+github.com/ipfs/go-graphsync v0.13.3-0.20230308100815-9a03a967f254/go.mod h1:TO1Y65spARny/t37hkid5xCpQJ6vR7A7VFTEUb0Z6eA=
 github.com/ipfs/go-ipfs-blockstore v0.0.1/go.mod h1:d3WClOmRQKFnJ0Jz/jj/zmksX0ma1gROTlovZKBmN08=
 github.com/ipfs/go-ipfs-blockstore v0.1.0/go.mod h1:5aD0AvHPi7mZc6Ci1WCAhiBQu2IsfTduLl+422H6Rqw=
 github.com/ipfs/go-ipfs-blockstore v0.2.1/go.mod h1:jGesd8EtCM3/zPgx+qr0/feTXGUeRai6adgwC+Q+JvE=

--- a/gql/resolver_rtvllog.go
+++ b/gql/resolver_rtvllog.go
@@ -128,12 +128,12 @@ type retrievalStateListResolver struct {
 }
 
 type retLogArgs struct {
-	PeerID string
-	DealID gqltypes.Uint64
+	PeerID     string
+	TransferID gqltypes.Uint64
 }
 
 func (r *resolver) RetrievalLog(ctx context.Context, args retLogArgs) (*retrievalStateResolver, error) {
-	st, err := r.retDB.Get(ctx, args.PeerID, uint64(args.DealID))
+	st, err := r.retDB.Get(ctx, args.PeerID, uint64(args.TransferID))
 	if err != nil {
 		return nil, err
 	}

--- a/gql/resolver_rtvllog.go
+++ b/gql/resolver_rtvllog.go
@@ -2,8 +2,6 @@ package gql
 
 import (
 	"context"
-	"time"
-
 	gqltypes "github.com/filecoin-project/boost/gql/types"
 	"github.com/filecoin-project/boost/retrievalmarket/rtvllog"
 	"github.com/graph-gophers/graphql-go"
@@ -12,6 +10,10 @@ import (
 type retrievalStateResolver struct {
 	rtvllog.RetrievalDealState
 	db *rtvllog.RetrievalLogDB
+}
+
+func (r *retrievalStateResolver) RowID() gqltypes.Uint64 {
+	return gqltypes.Uint64(r.RetrievalDealState.RowID)
 }
 
 func (r *retrievalStateResolver) CreatedAt() graphql.Time {
@@ -140,7 +142,7 @@ func (r *resolver) RetrievalLog(ctx context.Context, args retLogArgs) (*retrieva
 }
 
 type retrievalStatesArgs struct {
-	Cursor *gqltypes.BigInt // CreatedAt in milli-seconds
+	Cursor *gqltypes.Uint64 // database row id
 	Offset graphql.NullInt
 	Limit  graphql.NullInt
 }
@@ -158,11 +160,10 @@ func (r *resolver) RetrievalLogs(ctx context.Context, args retrievalStatesArgs) 
 
 	// Fetch one extra row so that we can check if there are more rows
 	// beyond the limit
-	var cursor *time.Time
+	var cursor *uint64
 	if args.Cursor != nil {
-		val := (*args.Cursor).Int64()
-		asTime := time.Unix(val/1000, (val%1000)*1e6)
-		cursor = &asTime
+		cursorptr := uint64(*args.Cursor)
+		cursor = &cursorptr
 	}
 	rows, err := r.retDB.List(ctx, cursor, offset, limit+1)
 	if err != nil {

--- a/gql/schema.graphql
+++ b/gql/schema.graphql
@@ -431,7 +431,7 @@ type RootQuery {
   proposalLogsCount: ProposalLogsCount!
 
   """Get individual retrieval log"""
-  retrievalLog(peerID: String!, dealID: Uint64!): RetrievalState
+  retrievalLog(peerID: String!, transferID: Uint64!): RetrievalState
 
   """Get retrieval logs"""
   retrievalLogs(cursor: Uint64, offset: Int, limit: Int): RetrievalStateList!

--- a/gql/schema.graphql
+++ b/gql/schema.graphql
@@ -218,6 +218,7 @@ type MarketEvent {
 }
 
 type RetrievalState {
+  RowID: Uint64!
   CreatedAt: Time!
   UpdatedAt: Time!
   PeerID: String!
@@ -433,7 +434,7 @@ type RootQuery {
   retrievalLog(peerID: String!, dealID: Uint64!): RetrievalState
 
   """Get retrieval logs"""
-  retrievalLogs(cursor: BigInt, offset: Int, limit: Int): RetrievalStateList!
+  retrievalLogs(cursor: Uint64, offset: Int, limit: Int): RetrievalStateList!
 
   """Get the number of retrieval logs"""
   retrievalLogsCount: RetrievalStatesCount!

--- a/markets/sectoraccessor/cachingsa.go
+++ b/markets/sectoraccessor/cachingsa.go
@@ -1,0 +1,69 @@
+package sectoraccessor
+
+import (
+	"context"
+	"fmt"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/lotus/api/v1api"
+	"github.com/filecoin-project/lotus/markets/dagstore"
+	"github.com/filecoin-project/lotus/node/modules/dtypes"
+	"github.com/filecoin-project/lotus/storage/sealer"
+	"github.com/filecoin-project/lotus/storage/sectorblocks"
+	"github.com/jellydator/ttlcache/v2"
+	"sync"
+	"time"
+)
+
+// sync.Mutex uses 8 bytes of memory
+// 16 * 1024 * 8 bytes = 128k memory used
+const stripedLockSize = 16 * 1024
+
+// CachingSectorAccessor caches calls to isUnsealed
+type CachingSectorAccessor struct {
+	dagstore.SectorAccessor
+	cache       *ttlcache.Cache
+	stripedLock [stripedLockSize]sync.Mutex
+}
+
+func (c *CachingSectorAccessor) IsUnsealed(ctx context.Context, sectorID abi.SectorNumber, offset abi.UnpaddedPieceSize, length abi.UnpaddedPieceSize) (bool, error) {
+	// Check the cache for this sector
+	cacheKey := fmt.Sprintf("%d", sectorID)
+	val, err := c.cache.Get(cacheKey)
+	if err == nil {
+		return val.(bool), nil
+	}
+
+	// Cache miss:
+	// IsUnsealed is an expensive operation, so wait for any other threads
+	// that are calling IsUnsealed for the same sector to complete
+	stripedLockIndex := sectorID % stripedLockSize
+	c.stripedLock[stripedLockIndex].Lock()
+	defer c.stripedLock[stripedLockIndex].Unlock()
+
+	// Check if any other threads updated the cache while this thread waited
+	// for the lock
+	val, err = c.cache.Get(cacheKey)
+	if err == nil {
+		return val.(bool), nil
+	}
+
+	// Nothing in the cache, so make the call to IsUnsealed
+	isUnsealed, err := c.SectorAccessor.IsUnsealed(ctx, sectorID, offset, length)
+	if err == nil {
+		// Save the results in the cache
+		_ = c.cache.Set(cacheKey, isUnsealed)
+	}
+	return isUnsealed, err
+}
+
+type SectorAccessorConstructor func(maddr dtypes.MinerAddress, secb sectorblocks.SectorBuilder, pp sealer.PieceProvider, full v1api.FullNode) dagstore.SectorAccessor
+
+func NewCachingSectorAccessor(maxCacheSize int, cacheExpire time.Duration) SectorAccessorConstructor {
+	return func(maddr dtypes.MinerAddress, secb sectorblocks.SectorBuilder, pp sealer.PieceProvider, full v1api.FullNode) dagstore.SectorAccessor {
+		sa := NewSectorAccessor(maddr, secb, pp, full)
+		cache := ttlcache.NewCache()
+		_ = cache.SetTTL(cacheExpire)
+		cache.SetCacheSizeLimit(maxCacheSize)
+		return &CachingSectorAccessor{SectorAccessor: sa, cache: cache}
+	}
+}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -140,6 +140,31 @@ var (
 	BitswapRblsHasSuccessResponseCount     = stats.Int64("bitswap/rbls_has_success_response_count", "Counter of successful RemoteBlockstore Has responses", stats.UnitDimensionless)
 	BitswapRblsHasFailResponseCount        = stats.Int64("bitswap/rbls_has_fail_response_count", "Counter of failed RemoteBlockstore Has responses", stats.UnitDimensionless)
 	BitswapRblsBytesSentCount              = stats.Int64("bitswap/rbls_bytes_sent_count", "Counter of the number of bytes sent by bitswap since startup", stats.UnitBytes)
+
+	// graphsync
+	GraphsyncRequestQueuedCount                 = stats.Int64("graphsync/request_queued_count", "Counter of Graphsync requests queued", stats.UnitDimensionless)
+	GraphsyncRequestQueuedPaidCount             = stats.Int64("graphsync/request_queued_paid_count", "Counter of Graphsync paid requests queued", stats.UnitDimensionless)
+	GraphsyncRequestQueuedUnpaidCount           = stats.Int64("graphsync/request_queued_unpaid_count", "Counter of Graphsync unpaid requests queued", stats.UnitDimensionless)
+	GraphsyncRequestStartedCount                = stats.Int64("graphsync/request_started_count", "Counter of Graphsync requests started", stats.UnitDimensionless)
+	GraphsyncRequestStartedPaidCount            = stats.Int64("graphsync/request_started_paid_count", "Counter of Graphsync paid requests started", stats.UnitDimensionless)
+	GraphsyncRequestStartedUnpaidCount          = stats.Int64("graphsync/request_started_unpaid_count", "Counter of Graphsync unpaid requests started", stats.UnitDimensionless)
+	GraphsyncRequestStartedUnpaidSuccessCount   = stats.Int64("graphsync/request_started_unpaid_success_count", "Counter of Graphsync successful unpaid requests started", stats.UnitDimensionless)
+	GraphsyncRequestStartedUnpaidFailCount      = stats.Int64("graphsync/request_started_unpaid_fail_count", "Counter of Graphsync failed unpaid requests started", stats.UnitDimensionless)
+	GraphsyncRequestCompletedCount              = stats.Int64("graphsync/request_completed_count", "Counter of Graphsync requests completed", stats.UnitDimensionless)
+	GraphsyncRequestCompletedPaidCount          = stats.Int64("graphsync/request_completed_paid_count", "Counter of Graphsync paid requests completed", stats.UnitDimensionless)
+	GraphsyncRequestCompletedUnpaidCount        = stats.Int64("graphsync/request_completed_unpaid_count", "Counter of Graphsync unpaid requests completed", stats.UnitDimensionless)
+	GraphsyncRequestCompletedUnpaidSuccessCount = stats.Int64("graphsync/request_completed_unpaid_success_count", "Counter of Graphsync successful unpaid requests completed", stats.UnitDimensionless)
+	GraphsyncRequestCompletedUnpaidFailCount    = stats.Int64("graphsync/request_completed_unpaid_fail_count", "Counter of Graphsync failed unpaid requests completed", stats.UnitDimensionless)
+	GraphsyncRequestClientCancelledCount        = stats.Int64("graphsync/request_client_cancelled_count", "Counter of Graphsync requests cancelled", stats.UnitDimensionless)
+	GraphsyncRequestClientCancelledPaidCount    = stats.Int64("graphsync/request_client_cancelled_paid_count", "Counter of Graphsync paid requests cancelled", stats.UnitDimensionless)
+	GraphsyncRequestClientCancelledUnpaidCount  = stats.Int64("graphsync/request_client_cancelled_unpaid_count", "Counter of Graphsync unpaid requests cancelled", stats.UnitDimensionless)
+	GraphsyncRequestBlockSentCount              = stats.Int64("graphsync/request_block_sent_count", "Counter of Graphsync blocks sent", stats.UnitDimensionless)
+	GraphsyncRequestBlockSentPaidCount          = stats.Int64("graphsync/request_block_sent_paid_count", "Counter of Graphsync paid blocks sent", stats.UnitDimensionless)
+	GraphsyncRequestBlockSentUnpaidCount        = stats.Int64("graphsync/request_block_sent_unpaid_count", "Counter of Graphsync unpaid blocks sent", stats.UnitDimensionless)
+	GraphsyncRequestBytesSentCount              = stats.Int64("graphsync/request_bytes_sent_count", "Counter of Graphsync paid bytes sent", stats.UnitBytes)
+	GraphsyncRequestBytesSentPaidCount          = stats.Int64("graphsync/request_bytes_sent_paid_count", "Counter of Graphsync paid bytes sent", stats.UnitBytes)
+	GraphsyncRequestBytesSentUnpaidCount        = stats.Int64("graphsync/request_bytes_sent_unpaid_count", "Counter of Graphsync unpaid bytes sent", stats.UnitBytes)
+	GraphsyncRequestNetworkErrorCount           = stats.Int64("graphsync/request_network_error_count", "Counter of Graphsync network errors", stats.UnitDimensionless)
 )
 
 var (
@@ -233,6 +258,100 @@ var (
 	BitswapRblsBytesSentCountView = &view.View{
 		Measure:     BitswapRblsBytesSentCount,
 		Aggregation: view.Sum(),
+	}
+
+	// graphsync
+	GraphsyncRequestQueuedCountView = &view.View{
+		Measure:     GraphsyncRequestQueuedCount,
+		Aggregation: view.Count(),
+	}
+	GraphsyncRequestQueuedPaidCountView = &view.View{
+		Measure:     GraphsyncRequestQueuedPaidCount,
+		Aggregation: view.Count(),
+	}
+	GraphsyncRequestQueuedUnpaidCountView = &view.View{
+		Measure:     GraphsyncRequestQueuedUnpaidCount,
+		Aggregation: view.Count(),
+	}
+	GraphsyncRequestStartedCountView = &view.View{
+		Measure:     GraphsyncRequestStartedCount,
+		Aggregation: view.Count(),
+	}
+	GraphsyncRequestStartedPaidCountView = &view.View{
+		Measure:     GraphsyncRequestStartedPaidCount,
+		Aggregation: view.Count(),
+	}
+	GraphsyncRequestStartedUnpaidCountView = &view.View{
+		Measure:     GraphsyncRequestStartedUnpaidCount,
+		Aggregation: view.Count(),
+	}
+	GraphsyncRequestStartedUnpaidSuccessCountView = &view.View{
+		Measure:     GraphsyncRequestStartedUnpaidSuccessCount,
+		Aggregation: view.Count(),
+	}
+	GraphsyncRequestStartedUnpaidFailCountView = &view.View{
+		Measure:     GraphsyncRequestStartedUnpaidFailCount,
+		Aggregation: view.Count(),
+	}
+	GraphsyncRequestCompletedCountView = &view.View{
+		Measure:     GraphsyncRequestCompletedCount,
+		Aggregation: view.Count(),
+	}
+	GraphsyncRequestCompletedPaidCountView = &view.View{
+		Measure:     GraphsyncRequestCompletedPaidCount,
+		Aggregation: view.Count(),
+	}
+	GraphsyncRequestCompletedUnpaidCountView = &view.View{
+		Measure:     GraphsyncRequestCompletedUnpaidCount,
+		Aggregation: view.Count(),
+	}
+	GraphsyncRequestCompletedUnpaidSuccessCountView = &view.View{
+		Measure:     GraphsyncRequestCompletedUnpaidSuccessCount,
+		Aggregation: view.Count(),
+	}
+	GraphsyncRequestCompletedUnpaidFailCountView = &view.View{
+		Measure:     GraphsyncRequestCompletedUnpaidFailCount,
+		Aggregation: view.Count(),
+	}
+	GraphsyncRequestClientCancelledCountView = &view.View{
+		Measure:     GraphsyncRequestClientCancelledCount,
+		Aggregation: view.Count(),
+	}
+	GraphsyncRequestClientCancelledPaidCountView = &view.View{
+		Measure:     GraphsyncRequestClientCancelledPaidCount,
+		Aggregation: view.Count(),
+	}
+	GraphsyncRequestClientCancelledUnpaidCountView = &view.View{
+		Measure:     GraphsyncRequestClientCancelledUnpaidCount,
+		Aggregation: view.Count(),
+	}
+	GraphsyncRequestBlockSentCountView = &view.View{
+		Measure:     GraphsyncRequestBlockSentCount,
+		Aggregation: view.Count(),
+	}
+	GraphsyncRequestPaidBlockSentCountView = &view.View{
+		Measure:     GraphsyncRequestBlockSentPaidCount,
+		Aggregation: view.Count(),
+	}
+	GraphsyncRequestUnpaidBlockSentCountView = &view.View{
+		Measure:     GraphsyncRequestBlockSentUnpaidCount,
+		Aggregation: view.Count(),
+	}
+	GraphsyncRequestBytesSentCountView = &view.View{
+		Measure:     GraphsyncRequestBytesSentCount,
+		Aggregation: view.Sum(),
+	}
+	GraphsyncRequestPaidBytesSentCountView = &view.View{
+		Measure:     GraphsyncRequestBytesSentPaidCount,
+		Aggregation: view.Sum(),
+	}
+	GraphsyncRequestUnpaidBytesSentCountView = &view.View{
+		Measure:     GraphsyncRequestBytesSentUnpaidCount,
+		Aggregation: view.Sum(),
+	}
+	GraphsyncRequestNetworkErrorCountView = &view.View{
+		Measure:     GraphsyncRequestNetworkErrorCount,
+		Aggregation: view.Count(),
 	}
 
 	InfoView = &view.View{
@@ -527,6 +646,29 @@ var DefaultViews = func() []*view.View {
 		BitswapRblsHasSuccessResponseCountView,
 		BitswapRblsHasFailResponseCountView,
 		BitswapRblsBytesSentCountView,
+		GraphsyncRequestQueuedCountView,
+		GraphsyncRequestQueuedPaidCountView,
+		GraphsyncRequestQueuedUnpaidCountView,
+		GraphsyncRequestStartedCountView,
+		GraphsyncRequestStartedPaidCountView,
+		GraphsyncRequestStartedUnpaidCountView,
+		GraphsyncRequestStartedUnpaidSuccessCountView,
+		GraphsyncRequestStartedUnpaidFailCountView,
+		GraphsyncRequestCompletedCountView,
+		GraphsyncRequestCompletedPaidCountView,
+		GraphsyncRequestCompletedUnpaidCountView,
+		GraphsyncRequestCompletedUnpaidSuccessCountView,
+		GraphsyncRequestCompletedUnpaidFailCountView,
+		GraphsyncRequestClientCancelledCountView,
+		GraphsyncRequestClientCancelledPaidCountView,
+		GraphsyncRequestClientCancelledUnpaidCountView,
+		GraphsyncRequestBlockSentCountView,
+		GraphsyncRequestPaidBlockSentCountView,
+		GraphsyncRequestUnpaidBlockSentCountView,
+		GraphsyncRequestBytesSentCountView,
+		GraphsyncRequestPaidBytesSentCountView,
+		GraphsyncRequestUnpaidBytesSentCountView,
+		GraphsyncRequestNetworkErrorCountView,
 		lotusmetrics.DagStorePRBytesDiscardedView,
 		lotusmetrics.DagStorePRBytesRequestedView,
 		lotusmetrics.DagStorePRDiscardCountView,

--- a/node/builder.go
+++ b/node/builder.go
@@ -145,6 +145,7 @@ const (
 	HandleDealsKey
 	HandleCreateRetrievalTablesKey
 	HandleSetShardSelector
+	HandleSetRetrievalAskGetter
 	HandleRetrievalEventsKey
 	HandleRetrievalKey
 	HandleRetrievalTransportsKey
@@ -510,6 +511,8 @@ func ConfigBoost(cfg *config.Boost) Option {
 
 		// Lotus Markets
 		Override(new(lotus_dtypes.ProviderTransferNetwork), modules.NewProviderTransferNetwork),
+		Override(new(*modules.ProxyAskGetter), modules.NewAskGetter),
+		Override(new(server.AskGetter), From(new(*modules.ProxyAskGetter))),
 		Override(new(*server.GraphsyncUnpaidRetrieval), modules.Graphsync(cfg.LotusDealmaking.SimultaneousTransfersForStorage, cfg.LotusDealmaking.SimultaneousTransfersForStoragePerClient, cfg.LotusDealmaking.SimultaneousTransfersForRetrieval)),
 		Override(new(lotus_dtypes.StagingGraphsync), From(new(*server.GraphsyncUnpaidRetrieval))),
 		Override(new(lotus_dtypes.ProviderPieceStore), lotus_modules.NewProviderPieceStore),
@@ -539,6 +542,7 @@ func ConfigBoost(cfg *config.Boost) Option {
 		Override(new(retrievalmarket.RetrievalProviderNode), retrievaladapter.NewRetrievalProviderNode),
 		Override(new(rmnet.RetrievalMarketNetwork), lotus_modules.RetrievalNetwork),
 		Override(new(retrievalmarket.RetrievalProvider), lotus_modules.RetrievalProvider),
+		Override(HandleSetRetrievalAskGetter, modules.SetAskGetter),
 		Override(HandleRetrievalEventsKey, modules.HandleRetrievalGraphsyncUpdates(time.Duration(cfg.Dealmaking.RetrievalLogDuration), time.Duration(cfg.Dealmaking.StalledRetrievalTimeout))),
 		Override(HandleRetrievalKey, lotus_modules.HandleRetrieval),
 		Override(new(*lp2pimpl.TransportsListener), modules.NewTransportsListener(cfg)),

--- a/node/builder.go
+++ b/node/builder.go
@@ -16,7 +16,6 @@ import (
 	lotus_dealfilter "github.com/filecoin-project/boost/markets/dealfilter"
 	"github.com/filecoin-project/boost/markets/idxprov"
 	"github.com/filecoin-project/boost/markets/retrievaladapter"
-	"github.com/filecoin-project/boost/markets/sectoraccessor"
 	lotus_storageadapter "github.com/filecoin-project/boost/markets/storageadapter"
 	"github.com/filecoin-project/boost/node/config"
 	"github.com/filecoin-project/boost/node/impl"
@@ -534,7 +533,7 @@ func ConfigBoost(cfg *config.Boost) Option {
 		Override(HandleSetShardSelector, modules.SetShardSelectorFunc),
 
 		// Lotus Markets (retrieval)
-		Override(new(mdagstore.SectorAccessor), sectoraccessor.NewSectorAccessor),
+		Override(new(mdagstore.SectorAccessor), modules.NewSectorAccessor(cfg)),
 		Override(new(retrievalmarket.SectorAccessor), From(new(mdagstore.SectorAccessor))),
 		Override(new(retrievalmarket.RetrievalProviderNode), retrievaladapter.NewRetrievalProviderNode),
 		Override(new(rmnet.RetrievalMarketNetwork), lotus_modules.RetrievalNetwork),

--- a/node/builder.go
+++ b/node/builder.go
@@ -549,7 +549,6 @@ func ConfigBoost(cfg *config.Boost) Option {
 		Override(new(provider.Interface), modules.IndexProvider(cfg.IndexProvider)),
 
 		// Lotus Markets (storage)
-		Override(new(lotus_dtypes.ProviderTransferNetwork), lotus_modules.NewProviderTransferNetwork),
 		Override(new(lotus_dtypes.ProviderTransport), lotus_modules.NewProviderTransport),
 		Override(new(lotus_dtypes.ProviderDataTransfer), modules.NewProviderDataTransfer),
 		Override(new(*storedask.StoredAsk), lotus_modules.NewStorageAsk),

--- a/node/builder.go
+++ b/node/builder.go
@@ -509,6 +509,7 @@ func ConfigBoost(cfg *config.Boost) Option {
 		})),
 
 		// Lotus Markets
+		Override(new(lotus_dtypes.ProviderTransferNetwork), modules.NewProviderTransferNetwork),
 		Override(new(*server.GraphsyncUnpaidRetrieval), modules.Graphsync(cfg.LotusDealmaking.SimultaneousTransfersForStorage, cfg.LotusDealmaking.SimultaneousTransfersForStoragePerClient, cfg.LotusDealmaking.SimultaneousTransfersForRetrieval)),
 		Override(new(lotus_dtypes.StagingGraphsync), From(new(*server.GraphsyncUnpaidRetrieval))),
 		Override(new(lotus_dtypes.ProviderPieceStore), lotus_modules.NewProviderPieceStore),

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -111,6 +111,8 @@ func DefaultBoost() *Boost {
 			BlockstoreCacheMaxShards: 20, // Match default simultaneous retrievals
 			BlockstoreCacheExpiry:    Duration(30 * time.Second),
 
+			IsUnsealedCacheExpiry: Duration(5 * time.Minute),
+
 			MaxTransferDuration: Duration(24 * 3600 * time.Second),
 
 			RemoteCommp:             false,

--- a/node/config/doc_gen.go
+++ b/node/config/doc_gen.go
@@ -295,6 +295,12 @@ Lower this limit if boostd memory is too high during retrievals`,
 			Comment: `How long a blockstore shard should be cached before expiring without use`,
 		},
 		{
+			Name: "IsUnsealedCacheExpiry",
+			Type: "Duration",
+
+			Comment: `How long to cache calls to check whether a sector is unsealed`,
+		},
+		{
 			Name: "MaxTransferDuration",
 			Type: "Duration",
 

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -197,6 +197,9 @@ type DealmakingConfig struct {
 	// How long a blockstore shard should be cached before expiring without use
 	BlockstoreCacheExpiry Duration
 
+	// How long to cache calls to check whether a sector is unsealed
+	IsUnsealedCacheExpiry Duration
+
 	// The maximum amount of time a transfer can take before it fails
 	MaxTransferDuration Duration
 

--- a/node/impl/boost.go
+++ b/node/impl/boost.go
@@ -18,6 +18,7 @@ import (
 	"github.com/filecoin-project/boost/indexprovider"
 	"github.com/filecoin-project/boost/markets/storageadapter"
 	"github.com/filecoin-project/boost/node/modules/dtypes"
+	retmarket "github.com/filecoin-project/boost/retrievalmarket/server"
 	"github.com/filecoin-project/boost/storagemarket"
 	"github.com/filecoin-project/boost/storagemarket/sealingpipeline"
 	"github.com/filecoin-project/boost/storagemarket/types"
@@ -70,6 +71,9 @@ type BoostAPI struct {
 	RetrievalProvider retrievalmarket.RetrievalProvider
 	SectorAccessor    retrievalmarket.SectorAccessor
 	DealPublisher     *storageadapter.DealPublisher
+
+	// Graphsync Unpaid Retrieval
+	GraphsyncUnpaidRetrieval *retmarket.GraphsyncUnpaidRetrieval
 
 	// Sealing Pipeline API
 	Sps sealingpipeline.API

--- a/node/impl/boost_legacy.go
+++ b/node/impl/boost_legacy.go
@@ -28,9 +28,17 @@ func (sm *BoostAPI) MarketListDataTransfers(ctx context.Context) ([]lapi.DataTra
 		return nil, err
 	}
 
-	apiChannels := make([]lapi.DataTransferChannel, 0, len(inProgressChannels))
+	unpaidRetrievals := sm.GraphsyncUnpaidRetrieval.List()
+
+	// Get legacy, paid retrievals
+	apiChannels := make([]lapi.DataTransferChannel, 0, len(inProgressChannels)+len(unpaidRetrievals))
 	for _, channelState := range inProgressChannels {
 		apiChannels = append(apiChannels, lapi.NewDataTransferChannel(sm.Host.ID(), channelState))
+	}
+
+	// Include unpaid retrievals
+	for _, ur := range unpaidRetrievals {
+		apiChannels = append(apiChannels, lapi.NewDataTransferChannel(sm.Host.ID(), ur.ChannelState()))
 	}
 
 	return apiChannels, nil
@@ -46,6 +54,14 @@ func (sm *BoostAPI) MarketRestartDataTransfer(ctx context.Context, transferID da
 
 func (sm *BoostAPI) MarketCancelDataTransfer(ctx context.Context, transferID datatransfer.TransferID, otherPeer peer.ID, isInitiator bool) error {
 	selfPeer := sm.Host.ID()
+
+	// Attempt to cancel unpaid first, if that succeeds, we're done
+	err := sm.GraphsyncUnpaidRetrieval.CancelTransfer(ctx, transferID, &otherPeer)
+	if err == nil {
+		return nil
+	}
+
+	// Legacy, paid retrievals
 	if isInitiator {
 		return sm.DataTransfer.CloseDataTransferChannel(ctx, datatransfer.ChannelID{Initiator: selfPeer, Responder: otherPeer, ID: transferID})
 	}
@@ -72,8 +88,10 @@ func (sm *BoostAPI) MarketDataTransferUpdates(ctx context.Context) (<-chan lapi.
 }
 
 func (sm *BoostAPI) MarketListRetrievalDeals(ctx context.Context) ([]retrievalmarket.ProviderDealState, error) {
-	var out []retrievalmarket.ProviderDealState
 	deals := sm.RetrievalProvider.ListDeals()
+	unpaidRetrievals := sm.GraphsyncUnpaidRetrieval.List()
+
+	out := make([]retrievalmarket.ProviderDealState, 0, len(deals)+len(unpaidRetrievals))
 
 	for _, deal := range deals {
 		if deal.ChannelID != nil {
@@ -82,6 +100,10 @@ func (sm *BoostAPI) MarketListRetrievalDeals(ctx context.Context) ([]retrievalma
 			}
 		}
 		out = append(out, deal)
+	}
+
+	for _, ur := range unpaidRetrievals {
+		out = append(out, ur.ProviderDealState())
 	}
 
 	return out, nil

--- a/node/modules/graphsync.go
+++ b/node/modules/graphsync.go
@@ -15,8 +15,8 @@ import (
 )
 
 // Graphsync creates a graphsync instance used to serve retrievals.
-func Graphsync(parallelTransfersForStorage uint64, parallelTransfersForStoragePerPeer uint64, parallelTransfersForRetrieval uint64) func(mctx lotus_helpers.MetricsCtx, lc fx.Lifecycle, ibs dtypes.IndexBackedBlockstore, h host.Host, net lotus_dtypes.ProviderTransferNetwork, dealDecider lotus_dtypes.RetrievalDealFilter, dagStore stores.DAGStoreWrapper, pstore lotus_dtypes.ProviderPieceStore, sa retrievalmarket.SectorAccessor) (*server.GraphsyncUnpaidRetrieval, error) {
-	return func(mctx lotus_helpers.MetricsCtx, lc fx.Lifecycle, ibs dtypes.IndexBackedBlockstore, h host.Host, net lotus_dtypes.ProviderTransferNetwork, dealDecider lotus_dtypes.RetrievalDealFilter, dagStore stores.DAGStoreWrapper, pstore lotus_dtypes.ProviderPieceStore, sa retrievalmarket.SectorAccessor) (*server.GraphsyncUnpaidRetrieval, error) {
+func Graphsync(parallelTransfersForStorage uint64, parallelTransfersForStoragePerPeer uint64, parallelTransfersForRetrieval uint64) func(mctx lotus_helpers.MetricsCtx, lc fx.Lifecycle, ibs dtypes.IndexBackedBlockstore, h host.Host, net lotus_dtypes.ProviderTransferNetwork, dealDecider lotus_dtypes.RetrievalDealFilter, dagStore stores.DAGStoreWrapper, pstore lotus_dtypes.ProviderPieceStore, sa retrievalmarket.SectorAccessor, askStore retrievalmarket.AskStore) (*server.GraphsyncUnpaidRetrieval, error) {
+	return func(mctx lotus_helpers.MetricsCtx, lc fx.Lifecycle, ibs dtypes.IndexBackedBlockstore, h host.Host, net lotus_dtypes.ProviderTransferNetwork, dealDecider lotus_dtypes.RetrievalDealFilter, dagStore stores.DAGStoreWrapper, pstore lotus_dtypes.ProviderPieceStore, sa retrievalmarket.SectorAccessor, askStore retrievalmarket.AskStore) (*server.GraphsyncUnpaidRetrieval, error) {
 		// Create a Graphsync instance
 		mkgs := lotus_modules.StagingGraphsync(parallelTransfersForStorage, parallelTransfersForStoragePerPeer, parallelTransfersForRetrieval)
 		gs := mkgs(mctx, lc, ibs, h)
@@ -27,6 +27,7 @@ func Graphsync(parallelTransfersForStorage uint64, parallelTransfersForStoragePe
 			DagStore:       dagStore,
 			PieceStore:     pstore,
 			SectorAccessor: sa,
+			AskStore:       askStore,
 		}
 		gsupr, err := server.NewGraphsyncUnpaidRetrieval(h.ID(), gs, net, vdeps)
 

--- a/node/modules/graphsync.go
+++ b/node/modules/graphsync.go
@@ -6,35 +6,56 @@ import (
 	"github.com/filecoin-project/boost/retrievalmarket/server"
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
 	retrievalimpl "github.com/filecoin-project/go-fil-markets/retrievalmarket/impl"
-	"github.com/filecoin-project/go-fil-markets/retrievalmarket/impl/askstore"
 	"github.com/filecoin-project/go-fil-markets/stores"
+	"github.com/filecoin-project/go-state-types/abi"
 	lotus_modules "github.com/filecoin-project/lotus/node/modules"
 	lotus_dtypes "github.com/filecoin-project/lotus/node/modules/dtypes"
 	lotus_helpers "github.com/filecoin-project/lotus/node/modules/helpers"
-	"github.com/ipfs/go-datastore"
-	"github.com/ipfs/go-datastore/namespace"
 	"github.com/libp2p/go-libp2p/core/host"
 	"go.uber.org/fx"
 )
 
+// ProxyAskGetter is used to avoid circular dependencies:
+// RetrievalProvider depends on Graphsync, which depends on RetrievalProvider's
+// GetAsk method.
+// We create an AskGetter that returns zero-priced asks by default.
+// Then we set the AskGetter to the RetrievalProvider after it's been created.
+type ProxyAskGetter struct {
+	server.AskGetter
+}
+
+func (ag *ProxyAskGetter) GetAsk() *retrievalmarket.Ask {
+	if ag.AskGetter == nil {
+		return &retrievalmarket.Ask{
+			PricePerByte: abi.NewTokenAmount(0),
+			UnsealPrice:  abi.NewTokenAmount(0),
+		}
+	}
+	return ag.AskGetter.GetAsk()
+}
+
+func NewAskGetter() *ProxyAskGetter {
+	return &ProxyAskGetter{}
+}
+
+func SetAskGetter(proxy *ProxyAskGetter, rp retrievalmarket.RetrievalProvider) {
+	proxy.AskGetter = rp
+}
+
 // Graphsync creates a graphsync instance used to serve retrievals.
-func Graphsync(parallelTransfersForStorage uint64, parallelTransfersForStoragePerPeer uint64, parallelTransfersForRetrieval uint64) func(mctx lotus_helpers.MetricsCtx, lc fx.Lifecycle, ibs dtypes.IndexBackedBlockstore, h host.Host, net lotus_dtypes.ProviderTransferNetwork, dealDecider lotus_dtypes.RetrievalDealFilter, dagStore stores.DAGStoreWrapper, pstore lotus_dtypes.ProviderPieceStore, sa retrievalmarket.SectorAccessor, ds lotus_dtypes.MetadataDS) (*server.GraphsyncUnpaidRetrieval, error) {
-	return func(mctx lotus_helpers.MetricsCtx, lc fx.Lifecycle, ibs dtypes.IndexBackedBlockstore, h host.Host, net lotus_dtypes.ProviderTransferNetwork, dealDecider lotus_dtypes.RetrievalDealFilter, dagStore stores.DAGStoreWrapper, pstore lotus_dtypes.ProviderPieceStore, sa retrievalmarket.SectorAccessor, ds lotus_dtypes.MetadataDS) (*server.GraphsyncUnpaidRetrieval, error) {
+func Graphsync(parallelTransfersForStorage uint64, parallelTransfersForStoragePerPeer uint64, parallelTransfersForRetrieval uint64) func(mctx lotus_helpers.MetricsCtx, lc fx.Lifecycle, ibs dtypes.IndexBackedBlockstore, h host.Host, net lotus_dtypes.ProviderTransferNetwork, dealDecider lotus_dtypes.RetrievalDealFilter, dagStore stores.DAGStoreWrapper, pstore lotus_dtypes.ProviderPieceStore, sa retrievalmarket.SectorAccessor, askGetter server.AskGetter) (*server.GraphsyncUnpaidRetrieval, error) {
+	return func(mctx lotus_helpers.MetricsCtx, lc fx.Lifecycle, ibs dtypes.IndexBackedBlockstore, h host.Host, net lotus_dtypes.ProviderTransferNetwork, dealDecider lotus_dtypes.RetrievalDealFilter, dagStore stores.DAGStoreWrapper, pstore lotus_dtypes.ProviderPieceStore, sa retrievalmarket.SectorAccessor, askGetter server.AskGetter) (*server.GraphsyncUnpaidRetrieval, error) {
 		// Create a Graphsync instance
 		mkgs := lotus_modules.StagingGraphsync(parallelTransfersForStorage, parallelTransfersForStoragePerPeer, parallelTransfersForRetrieval)
 		gs := mkgs(mctx, lc, ibs, h)
 
 		// Wrap the Graphsync instance with a handler for unpaid retrieval requests
-		askStore, err := askstore.NewAskStore(namespace.Wrap(ds, datastore.NewKey("retrieval-ask")), datastore.NewKey("latest"))
-		if err != nil {
-			return nil, err
-		}
 		vdeps := server.ValidationDeps{
 			DealDecider:    retrievalimpl.DealDecider(dealDecider),
 			DagStore:       dagStore,
 			PieceStore:     pstore,
 			SectorAccessor: sa,
-			AskStore:       askStore,
+			AskStore:       askGetter,
 		}
 		gsupr, err := server.NewGraphsyncUnpaidRetrieval(h.ID(), gs, net, vdeps)
 

--- a/node/modules/retrieval.go
+++ b/node/modules/retrieval.go
@@ -156,10 +156,13 @@ func HandleRetrievalGraphsyncUpdates(duration time.Duration, stalledDuration tim
 				unsubs = append(unsubs, unsubFn(m.SubscribeToQueryEvents(rel.OnQueryEvent)))
 				unsubs = append(unsubs, unsubFn(m.SubscribeToValidationEvents(rel.OnValidationEvent)))
 				unsubs = append(unsubs, unsubFn(dt.SubscribeToEvents(rel.OnDataTransferEvent)))
-				unsubs = append(unsubs, unsubFn(gsur.SubscribeToEvents(rel.OnDataTransferEvent)))
-				// TODO: fire market event so that these transfers show up in retrievals list
-				//unsubs = append(unsubs, unsubFn(gsur.SubscribeToEvents(func(event datatransfer.Event, channelState datatransfer.ChannelState) {
-				//	log.Infow("dt event", "event", datatransfer.Events[event.Code], "msg", event.Message, "state", channelState.Message())
+				unsubs = append(unsubs, unsubFn(gsur.SubscribeToDataTransferEvents(rel.OnDataTransferEvent)))
+				unsubs = append(unsubs, unsubFn(gsur.SubscribeToMarketsEvents(rel.OnRetrievalEvent)))
+				//unsubs = append(unsubs, unsubFn(gsur.SubscribeToDataTransferEvents(func(event datatransfer.Event, channelState datatransfer.ChannelState) {
+				//	log.Infow("dt event", "event", datatransfer.Events[event.Code], "msg", event.Message, "state", datatransfer.Statuses[channelState.Status()])
+				//})))
+				//unsubs = append(unsubs, unsubFn(gsur.SubscribeToMarketsEvents(func(event lotus_retrievalmarket.ProviderEvent, state lotus_retrievalmarket.ProviderDealState) {
+				//	log.Infow("mt event", "event", lotus_retrievalmarket.ProviderEvents[event], "msg", state.Message, "state", state.Status.String())
 				//})))
 				rel.Start(relctx)
 				return nil

--- a/node/modules/retrieval.go
+++ b/node/modules/retrieval.go
@@ -158,13 +158,6 @@ func HandleRetrievalGraphsyncUpdates(duration time.Duration, stalledDuration tim
 				unsubs = append(unsubs, unsubFn(dt.SubscribeToEvents(rel.OnDataTransferEvent)))
 				unsubs = append(unsubs, unsubFn(gsur.SubscribeToDataTransferEvents(rel.OnDataTransferEvent)))
 				unsubs = append(unsubs, unsubFn(gsur.SubscribeToMarketsEvents(rel.OnRetrievalEvent)))
-				unsubs = append(unsubs, unsubFn(gsur.SubscribeToValidationEvents(rel.OnValidationEvent)))
-				//unsubs = append(unsubs, unsubFn(gsur.SubscribeToDataTransferEvents(func(event datatransfer.Event, channelState datatransfer.ChannelState) {
-				//	log.Infow("dt event", "event", datatransfer.Events[event.Code], "msg", event.Message, "state", datatransfer.Statuses[channelState.Status()])
-				//})))
-				//unsubs = append(unsubs, unsubFn(gsur.SubscribeToMarketsEvents(func(event lotus_retrievalmarket.ProviderEvent, state lotus_retrievalmarket.ProviderDealState) {
-				//	log.Infow("mt event", "event", lotus_retrievalmarket.ProviderEvents[event], "msg", state.Message, "state", state.Status.String())
-				//})))
 				rel.Start(relctx)
 				return nil
 			},

--- a/node/modules/retrieval.go
+++ b/node/modules/retrieval.go
@@ -145,7 +145,7 @@ func NewRetrievalLogDB(db *RetrievalSqlDB) *rtvllog.RetrievalLogDB {
 // Write graphsync retrieval updates to the database
 func HandleRetrievalGraphsyncUpdates(duration time.Duration, stalledDuration time.Duration) func(lc fx.Lifecycle, db *rtvllog.RetrievalLogDB, m lotus_retrievalmarket.RetrievalProvider, dt lotus_dtypes.ProviderDataTransfer, gsur *server.GraphsyncUnpaidRetrieval) {
 	return func(lc fx.Lifecycle, db *rtvllog.RetrievalLogDB, m lotus_retrievalmarket.RetrievalProvider, dt lotus_dtypes.ProviderDataTransfer, gsur *server.GraphsyncUnpaidRetrieval) {
-		rel := rtvllog.NewRetrievalLog(db, duration, dt, stalledDuration)
+		rel := rtvllog.NewRetrievalLog(db, duration, dt, stalledDuration, gsur)
 
 		relctx, cancel := context.WithCancel(context.Background())
 		type unsubFn func()

--- a/node/modules/retrieval.go
+++ b/node/modules/retrieval.go
@@ -158,6 +158,7 @@ func HandleRetrievalGraphsyncUpdates(duration time.Duration, stalledDuration tim
 				unsubs = append(unsubs, unsubFn(dt.SubscribeToEvents(rel.OnDataTransferEvent)))
 				unsubs = append(unsubs, unsubFn(gsur.SubscribeToDataTransferEvents(rel.OnDataTransferEvent)))
 				unsubs = append(unsubs, unsubFn(gsur.SubscribeToMarketsEvents(rel.OnRetrievalEvent)))
+				unsubs = append(unsubs, unsubFn(gsur.SubscribeToValidationEvents(rel.OnValidationEvent)))
 				//unsubs = append(unsubs, unsubFn(gsur.SubscribeToDataTransferEvents(func(event datatransfer.Event, channelState datatransfer.ChannelState) {
 				//	log.Infow("dt event", "event", datatransfer.Events[event.Code], "msg", event.Message, "state", datatransfer.Statuses[channelState.Status()])
 				//})))

--- a/node/modules/storageminer.go
+++ b/node/modules/storageminer.go
@@ -651,7 +651,8 @@ func NewIndexBackedBlockstore(cfg *config.Boost) func(lc fx.Lifecycle, dagst dag
 			},
 		})
 
-		rbs, err := indexbs.NewIndexBackedBlockstore(ctx, dagst, ss.Proxy, cfg.Dealmaking.BlockstoreCacheMaxShards, time.Duration(cfg.Dealmaking.BlockstoreCacheExpiry))
+		ibsds := brm.NewIndexBackedBlockstoreDagstore(dagst)
+		rbs, err := indexbs.NewIndexBackedBlockstore(ctx, ibsds, ss.Proxy, cfg.Dealmaking.BlockstoreCacheMaxShards, time.Duration(cfg.Dealmaking.BlockstoreCacheExpiry))
 		if err != nil {
 			return nil, fmt.Errorf("failed to create index backed blockstore: %w", err)
 		}

--- a/node/modules/storageminer.go
+++ b/node/modules/storageminer.go
@@ -14,6 +14,7 @@ import (
 	"github.com/filecoin-project/boost/gql"
 	"github.com/filecoin-project/boost/indexprovider"
 	"github.com/filecoin-project/boost/markets/idxprov"
+	"github.com/filecoin-project/boost/markets/sectoraccessor"
 	"github.com/filecoin-project/boost/markets/storageadapter"
 	"github.com/filecoin-project/boost/node/config"
 	"github.com/filecoin-project/boost/node/modules/dtypes"
@@ -580,6 +581,14 @@ func NewGraphqlServer(cfg *config.Boost) func(lc fx.Lifecycle, r repo.LockedRepo
 
 		return server
 	}
+}
+
+// Use a caching sector accessor
+func NewSectorAccessor(cfg *config.Boost) sectoraccessor.SectorAccessorConstructor {
+	// The cache just holds booleans, so there's no harm in using a big number
+	// for cache size
+	const maxCacheSize = 4096
+	return sectoraccessor.NewCachingSectorAccessor(maxCacheSize, time.Duration(cfg.Dealmaking.IsUnsealedCacheExpiry))
 }
 
 // ShardSelector helps to resolve a circular dependency:

--- a/node/modules/storageminer.go
+++ b/node/modules/storageminer.go
@@ -32,6 +32,7 @@ import (
 	"github.com/filecoin-project/dagstore/indexbs"
 	"github.com/filecoin-project/dagstore/shard"
 	"github.com/filecoin-project/go-address"
+	dtnet "github.com/filecoin-project/go-data-transfer/network"
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
 	lotus_storagemarket "github.com/filecoin-project/go-fil-markets/storagemarket"
 	storageimpl "github.com/filecoin-project/go-fil-markets/storagemarket/impl"
@@ -673,4 +674,10 @@ func NewTracing(cfg *config.Boost) func(lc fx.Lifecycle) (*tracing.Tracing, erro
 
 		return &tracing.Tracing{}, nil
 	}
+}
+
+// NewProviderTransferNetwork sets up the libp2p protocol networking for data transfer
+func NewProviderTransferNetwork(h host.Host) lotus_dtypes.ProviderTransferNetwork {
+	// Leave it up to the client to reconnect
+	return dtnet.NewFromLibp2pHost(h, dtnet.RetryParameters(0, 0, 0, 0))
 }

--- a/react/src/App.js
+++ b/react/src/App.js
@@ -43,7 +43,7 @@ function App(props) {
                                         <Route path="/proposal-logs/from/:cursor/page/:pageNum" element={<ProposalLogsPage />} />
                                         <Route path="/retrieval-logs" element={<RetrievalLogsPage />} />
                                         <Route path="/retrieval-logs/from/:cursor/page/:pageNum" element={<RetrievalLogsPage />} />
-                                        <Route path="/retrieval-logs/:peerID/:dealID" element={<RetrievalLogDetail />} />
+                                        <Route path="/retrieval-logs/:peerID/:transferID" element={<RetrievalLogDetail />} />
                                         <Route path="/storage-space" element={<StorageSpacePage />} />
                                         <Route path="/sealing-pipeline" element={<SealingPipelinePage />} />
                                         <Route path="/funds" element={<FundsPage />} />

--- a/react/src/RetrievalLogDetail.js
+++ b/react/src/RetrievalLogDetail.js
@@ -31,8 +31,8 @@ export function RetrievalLogDetail(props) {
         msgEl.textContent = msg
     }
 
-    function dealIDToClipboard() {
-        navigator.clipboard.writeText(retrieval.DealID+'')
+    function transferIDToClipboard() {
+        navigator.clipboard.writeText(retrieval.TransferID+'')
         const el = document.body.querySelector('.content .title .copy')
         addClassFor(el, 'copied', 500)
         showPopup("Copied " + retrieval.DealID + " to clipboard")
@@ -42,7 +42,7 @@ export function RetrievalLogDetail(props) {
         pollInterval: 1000,
         variables: {
             peerID: params.peerID,
-            dealID: params.dealID,
+            transferID: params.transferID,
         },
         fetchPolicy: 'network-only',
     })
@@ -67,7 +67,7 @@ export function RetrievalLogDetail(props) {
         evtRowData.push({evt: evt, prev: prev})
     }
 
-    return <div className="retrieval-log-detail modal" id={retrieval.PeerID + '/' + retrieval.DealID}>
+    return <div className="retrieval-log-detail modal" id={retrieval.PeerID + '/' + retrieval.TransferID}>
         <div className="content">
             <div className="close" onClick={() => navigate(-1)}>
                 <img className="icon" alt="" src={closeImg} />
@@ -76,8 +76,8 @@ export function RetrievalLogDetail(props) {
                 <div className="message"></div>
             </div>
             <div className="title">
-                <span>Retrieval {retrieval.DealID + ''}</span>
-                <span className="copy" onClick={dealIDToClipboard} title="Copy deal uuid to clipboard"></span>
+                <span>Retrieval {retrieval.TransferID + ''}</span>
+                <span className="copy" onClick={transferIDToClipboard} title="Copy transfer ID to clipboard"></span>
             </div>
             <table className="retrieval-fields">
                 <tbody>
@@ -94,7 +94,11 @@ export function RetrievalLogDetail(props) {
                     <td>{retrieval.PeerID}</td>
                 </tr>
                 <tr>
-                    <th>Deal ID</th>
+                    <th>Transfer ID</th>
+                    <td>{retrieval.TransferID+''}</td>
+                </tr>
+                <tr>
+                    <th>Retrieval Deal ID</th>
                     <td>{retrieval.DealID+''}</td>
                 </tr>
                 <tr>

--- a/react/src/RetrievalLogDetail.js
+++ b/react/src/RetrievalLogDetail.js
@@ -190,7 +190,7 @@ function RetrievalEvent(props) {
             <td className="at">{moment(evt.CreatedAt).format(dateFormat)}</td>
             <td className="since-last">{sinceLast}</td>
             <td className={"event " + evt.EventType}>
-                {evt.EventType == 'data-transfer' ? 'DT:' : null}
+                {evt.EventType === 'data-transfer' ? 'DT:' : null}
                 {getEventName(evt.Name)}
             </td>
             <td className="status">{getDealStatus(evt.Status)}</td>

--- a/react/src/RetrievalLogs.css
+++ b/react/src/RetrievalLogs.css
@@ -32,7 +32,7 @@
     min-width: 8em;
 }
 
-.retrieval-logs td.deal-id {
+.retrieval-logs td.transfer-id {
     min-width: 7em;
 }
 

--- a/react/src/RetrievalLogs.js
+++ b/react/src/RetrievalLogs.js
@@ -68,14 +68,14 @@ function RetrievalLogsContent(props) {
     var res = data.retrievalLogs
     var logs = res.logs
     if (pageNum === 1) {
-        logs.sort((a, b) => b.CreatedAt.getTime() - a.CreatedAt.getTime())
+        logs.sort((a, b) => Number(b.RowID - a.RowID))
         logs = logs.slice(0, rowsPerPage)
     }
     const totalCount = res.totalCount
 
     var cursor = params.cursor
     if (pageNum === 1 && logs.length) {
-        cursor = logs[0].CreatedAt
+        cursor = Number(logs[0].RowID)
     }
 
     var toggleTimestampFormat = () => saveTimestampFormat(!timestampFormat)
@@ -105,7 +105,7 @@ function RetrievalLogsContent(props) {
 
             {logs.map(row => (
                 <TableRow
-                    key={row.CreatedAt}
+                    key={row.RowID}
                     row={row}
                     timestampFormat={timestampFormat}
                     toggleTimestampFormat={toggleTimestampFormat}
@@ -150,12 +150,12 @@ function TableRow(props) {
     const dealIDToClipboard = () => fieldToClipboard(row.DealID, copyPeerId)
 
     var status = getDealStatus(row.DTStatus)
-    if (row.DTStatus != status && row.DTStatus != '') {
+    if (row.DTStatus !== status && row.DTStatus !== '') {
         status += ": " + row.DTStatus
     }
     var msg = row.Message
-    if (row.DTMessage != '') {
-        if (msg != '') {
+    if (row.DTMessage !== '') {
+        if (msg !== '') {
             msg += ' - '
         }
         msg += row.DTMessage

--- a/react/src/RetrievalLogs.js
+++ b/react/src/RetrievalLogs.js
@@ -96,7 +96,7 @@ function RetrievalLogsContent(props) {
             <tr>
                 <th onClick={toggleTimestampFormat} className="start">Start</th>
                 <th>Peer ID</th>
-                <th>Deal ID</th>
+                <th>Transfer ID</th>
                 <th>Payload CID</th>
                 <th>Sent</th>
                 <th>Status</th>
@@ -146,8 +146,8 @@ function TableRow(props) {
 
     const copyPeerId = "copy-"+row.CreatedAt+row.PeerID
     const peerIDToClipboard = () => fieldToClipboard(row.PeerID, copyPeerId)
-    const copyDealId = "copy-"+row.CreatedAt+row.DealID
-    const dealIDToClipboard = () => fieldToClipboard(row.DealID, copyPeerId)
+    const copyTransferId = "copy-"+row.CreatedAt+row.TransferID
+    const transferIDToClipboard = () => fieldToClipboard(row.TransferID, copyTransferId)
 
     var status = getDealStatus(row.DTStatus)
     if (row.DTStatus !== status && row.DTStatus !== '') {
@@ -169,10 +169,10 @@ function TableRow(props) {
                 <span id={copyPeerId} className="copy" onClick={peerIDToClipboard} title="Copy peer ID to clipboard"></span>
                 <ShortPeerID peerId={row.PeerID} />
             </td>
-            <td className="deal-id">
-                <span id={copyDealId} className="copy" onClick={dealIDToClipboard} title="Copy deal ID to clipboard"></span>
-                <Link to={basePath+'/'+row.PeerID+'/'+row.DealID}>
-                    {'…'+(row.DealID+'').slice(-8)}
+            <td className="transfer-id">
+                <span id={copyTransferId} className="copy" onClick={transferIDToClipboard} title="Copy transfer ID to clipboard"></span>
+                <Link to={basePath+'/'+row.PeerID+'/'+row.TransferID}>
+                    {'…'+(row.TransferID+'').slice(-8)}
                 </Link>
             </td>
             <td className="payload-cid">

--- a/react/src/gql.js
+++ b/react/src/gql.js
@@ -256,9 +256,10 @@ const RetrievalLogQuery = gql`
 `;
 
 const RetrievalLogsListQuery = gql`
-    query AppRetrievalLogsListQuery($cursor: BigInt, $offset: Int, $limit: Int) {
+    query AppRetrievalLogsListQuery($cursor: Uint64, $offset: Int, $limit: Int) {
         retrievalLogs(cursor: $cursor, offset: $offset, limit: $limit) {
             logs {
+                RowID
                 CreatedAt
                 UpdatedAt
                 PeerID

--- a/react/src/gql.js
+++ b/react/src/gql.js
@@ -222,8 +222,8 @@ const ProposalLogsCountQuery = gql`
 `;
 
 const RetrievalLogQuery = gql`
-    query AppRetrievalLogQuery($peerID: String!, $dealID: Uint64!) {
-        retrievalLog(peerID: $peerID, dealID: $dealID) {
+    query AppRetrievalLogQuery($peerID: String!, $transferID: Uint64!) {
+        retrievalLog(peerID: $peerID, transferID: $transferID) {
             CreatedAt
             UpdatedAt
             PeerID

--- a/retrievalmarket/lib/idxciddagstore.go
+++ b/retrievalmarket/lib/idxciddagstore.go
@@ -1,0 +1,71 @@
+package lib
+
+import (
+	"context"
+	"fmt"
+	"github.com/filecoin-project/boost/retrievalmarket/server"
+	"github.com/filecoin-project/dagstore"
+	"github.com/filecoin-project/dagstore/indexbs"
+	"github.com/filecoin-project/dagstore/shard"
+	"github.com/ipfs/go-cid"
+)
+
+// IndexBackedBlockstoreDagstore implements the dagstore interface needed
+// by the IndexBackedBlockstore.
+// The implementation of ShardsContainingCid handles identity cids.
+type IndexBackedBlockstoreDagstore struct {
+	dagstore.Interface
+}
+
+var _ dagstore.Interface = (*IndexBackedBlockstoreDagstore)(nil)
+
+func NewIndexBackedBlockstoreDagstore(ds dagstore.Interface) indexbs.IdxBstoreDagstore {
+	return &IndexBackedBlockstoreDagstore{Interface: ds}
+}
+
+// ShardsContainingCid checks the dagstore for shards containing the given cid.
+// If there are no shards with that cid, it checks if the shard is an identity
+// cid, and gets the shards containing the identity cid's child cids.
+// This is for the case where the identity cid was not stored in the original
+// CAR file's index (but the identity cid's child cids are in the index).
+func (i *IndexBackedBlockstoreDagstore) ShardsContainingCid(ctx context.Context, c cid.Cid) ([]shard.Key, error) {
+	shards, err := i.Interface.ShardsContainingMultihash(ctx, c.Hash())
+	if err == nil {
+		return shards, nil
+	}
+
+	var idErr error
+	piecesWithTargetBlock, idErr := server.GetCommonPiecesFromIdentityCidLinks(func(c cid.Cid) ([]cid.Cid, error) {
+		return i.piecesContainingBlock(ctx, c)
+	}, c)
+	if idErr != nil {
+		return nil, fmt.Errorf("getting common pieces for cid %s: %w", c, idErr)
+	}
+	if len(piecesWithTargetBlock) == 0 {
+		// No pieces found for cid: return the original error from the call to
+		// ShardsContainingMultihash above
+		return nil, fmt.Errorf("getting pieces for cid %s: %w", c, err)
+	}
+
+	shards = make([]shard.Key, 0, len(piecesWithTargetBlock))
+	for _, pcid := range piecesWithTargetBlock {
+		shards = append(shards, shard.KeyFromCID(pcid))
+	}
+	return shards, nil
+}
+
+func (i *IndexBackedBlockstoreDagstore) piecesContainingBlock(ctx context.Context, c cid.Cid) ([]cid.Cid, error) {
+	shards, err := i.Interface.ShardsContainingMultihash(ctx, c.Hash())
+	if err != nil {
+		return nil, fmt.Errorf("finding shards containing child cid %s: %w", c, err)
+	}
+	pcids := make([]cid.Cid, 0, len(shards))
+	for _, s := range shards {
+		pcid, err := cid.Parse(s.String())
+		if err != nil {
+			return nil, fmt.Errorf("parsing shard into cid: %w", err)
+		}
+		pcids = append(pcids, pcid)
+	}
+	return pcids, nil
+}

--- a/retrievalmarket/rtvllog/db.go
+++ b/retrievalmarket/rtvllog/db.go
@@ -124,7 +124,13 @@ func (d *RetrievalLogDB) List(ctx context.Context, cursor *time.Time, offset int
 }
 
 func (d *RetrievalLogDB) ListLastUpdatedAndOpen(ctx context.Context, lastUpdated time.Time) ([]RetrievalDealState, error) {
-	return d.list(ctx, 0, 0, "UpdatedAt <= ? AND Status != 'DealStatusCompleted' AND Status != 'DealStatusCancelled'", lastUpdated)
+	where := "UpdatedAt <= ?" +
+		"AND Status != 'DealStatusCompleted'" +
+		"AND Status != 'DealStatusCancelled'" +
+		"AND Status != 'DealStatusErrored'" +
+		"AND Status != 'DealStatusRejected'"
+
+	return d.list(ctx, 0, 0, where, lastUpdated)
 }
 
 func (d *RetrievalLogDB) list(ctx context.Context, offset int, limit int, where string, whereArgs ...interface{}) ([]RetrievalDealState, error) {

--- a/retrievalmarket/rtvllog/retrieval_log.go
+++ b/retrievalmarket/rtvllog/retrieval_log.go
@@ -241,7 +241,7 @@ func (r *RetrievalLog) gcDatabase(ctx context.Context) {
 
 // Periodically cancels stalled retrievals older than 30mins
 func (r *RetrievalLog) gcRetrievals(ctx context.Context) {
-	ticker := time.NewTicker(1 * time.Minute)
+	ticker := time.NewTicker(5 * time.Minute)
 	defer ticker.Stop()
 
 	for {

--- a/retrievalmarket/server/channelstate.go
+++ b/retrievalmarket/server/channelstate.go
@@ -1,0 +1,168 @@
+package server
+
+import (
+	"bytes"
+	datatransfer "github.com/filecoin-project/go-data-transfer"
+	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
+	"github.com/ipfs/go-cid"
+	"github.com/ipld/go-ipld-prime"
+	"github.com/ipld/go-ipld-prime/codec/dagcbor"
+	basicnode "github.com/ipld/go-ipld-prime/node/basic"
+	"github.com/libp2p/go-libp2p/core/peer"
+	cbg "github.com/whyrusleeping/cbor-gen"
+)
+
+// channelState is immutable channel data plus mutable state
+type channelState struct {
+	// peerId of the manager peer
+	selfPeer peer.ID
+	// an identifier for this channel shared by request and responder, set by requester through protocol
+	transferID datatransfer.TransferID
+	// an identifier for this markets protocol data transfer
+	marketsID retrievalmarket.DealID
+	// base CID for the piece being transferred
+	baseCid cid.Cid
+	// portion of Piece to return, specified by an IPLD selector
+	selector *cbg.Deferred
+	// the party that is sending the data (not who initiated the request)
+	sender peer.ID
+	// the party that is receiving the data (not who initiated the request)
+	recipient peer.ID
+	// expected amount of data to be transferred
+	totalSize uint64
+	// current status of this deal
+	status datatransfer.Status
+	// isPull indicates if this is a push or pull request
+	isPull bool
+	// total bytes read from this node and queued for sending (0 if receiver)
+	queued uint64
+	// total bytes sent from this node (0 if receiver)
+	sent uint64
+	// total bytes received by this node (0 if sender)
+	received uint64
+	// number of blocks that have been received, including blocks that are
+	// present in more than one place in the DAG
+	receivedBlocksTotal int64
+	// Number of blocks that have been queued, including blocks that are
+	// present in more than one place in the DAG
+	queuedBlocksTotal int64
+	// Number of blocks that have been sent, including blocks that are
+	// present in more than one place in the DAG
+	sentBlocksTotal int64
+	// more informative status on a channel
+	message string
+}
+
+// EmptyChannelState is the zero value for channel state, meaning not present
+var EmptyChannelState = channelState{}
+
+// Status is the current status of this channel
+func (c channelState) Status() datatransfer.Status { return c.status }
+
+// Received returns the number of bytes received
+func (c channelState) Queued() uint64 { return c.queued }
+
+// Sent returns the number of bytes sent
+func (c channelState) Sent() uint64 { return c.sent }
+
+// Received returns the number of bytes received
+func (c channelState) Received() uint64 { return c.received }
+
+// TransferID returns the transfer id for this channel
+func (c channelState) TransferID() datatransfer.TransferID { return c.transferID }
+
+// BaseCID returns the CID that is at the root of this data transfer
+func (c channelState) BaseCID() cid.Cid { return c.baseCid }
+
+// Selector returns the IPLD selector for this data transfer (represented as
+// an IPLD node)
+func (c channelState) Selector() ipld.Node {
+	builder := basicnode.Prototype.Any.NewBuilder()
+	reader := bytes.NewReader(c.selector.Raw)
+	err := dagcbor.Decode(builder, reader)
+	if err != nil {
+		log.Error(err)
+	}
+	return builder.Build()
+}
+
+// Voucher returns the voucher for this data transfer
+func (c channelState) Voucher() datatransfer.Voucher {
+	return nil
+}
+
+// ReceivedCidsTotal returns the number of (non-unique) cids received so far
+// on the channel - note that a block can exist in more than one place in the DAG
+func (c channelState) ReceivedCidsTotal() int64 {
+	return c.receivedBlocksTotal
+}
+
+// QueuedCidsTotal returns the number of (non-unique) cids queued so far
+// on the channel - note that a block can exist in more than one place in the DAG
+func (c channelState) QueuedCidsTotal() int64 {
+	return c.queuedBlocksTotal
+}
+
+// SentCidsTotal returns the number of (non-unique) cids sent so far
+// on the channel - note that a block can exist in more than one place in the DAG
+func (c channelState) SentCidsTotal() int64 {
+	return c.sentBlocksTotal
+}
+
+// Sender returns the peer id for the node that is sending data
+func (c channelState) Sender() peer.ID { return c.sender }
+
+// Recipient returns the peer id for the node that is receiving data
+func (c channelState) Recipient() peer.ID { return c.recipient }
+
+// TotalSize returns the total size for the data being transferred
+func (c channelState) TotalSize() uint64 { return c.totalSize }
+
+// IsPull returns whether this is a pull request based on who initiated it
+func (c channelState) IsPull() bool {
+	return c.isPull
+}
+
+func (c channelState) ChannelID() datatransfer.ChannelID {
+	if c.isPull {
+		return datatransfer.ChannelID{ID: c.transferID, Initiator: c.recipient, Responder: c.sender}
+	}
+	return datatransfer.ChannelID{ID: c.transferID, Initiator: c.sender, Responder: c.recipient}
+}
+
+func (c channelState) Message() string {
+	return c.message
+}
+
+func (c channelState) Vouchers() []datatransfer.Voucher {
+	return nil
+}
+
+func (c channelState) LastVoucher() datatransfer.Voucher {
+	return nil
+}
+
+func (c channelState) LastVoucherResult() datatransfer.VoucherResult {
+	return nil
+}
+
+func (c channelState) VoucherResults() []datatransfer.VoucherResult {
+	return nil
+}
+
+func (c channelState) SelfPeer() peer.ID {
+	return c.selfPeer
+}
+
+func (c channelState) OtherPeer() peer.ID {
+	if c.sender == c.selfPeer {
+		return c.recipient
+	}
+	return c.sender
+}
+
+func (c channelState) Stages() *datatransfer.ChannelStages {
+	return nil
+}
+
+var _ datatransfer.ChannelState = channelState{}

--- a/retrievalmarket/server/channelstate.go
+++ b/retrievalmarket/server/channelstate.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bytes"
+
 	datatransfer "github.com/filecoin-project/go-data-transfer"
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
 	"github.com/ipfs/go-cid"
@@ -16,6 +17,9 @@ type retrievalState struct {
 	cs   *channelState
 	mkts *retrievalmarket.ProviderDealState
 }
+
+func (r retrievalState) ChannelState() channelState                           { return *r.cs }
+func (r retrievalState) ProviderDealState() retrievalmarket.ProviderDealState { return *r.mkts }
 
 // channelState is immutable channel data plus mutable state
 type channelState struct {

--- a/retrievalmarket/server/channelstate.go
+++ b/retrievalmarket/server/channelstate.go
@@ -12,14 +12,17 @@ import (
 	cbg "github.com/whyrusleeping/cbor-gen"
 )
 
+type retrievalState struct {
+	cs   *channelState
+	mkts *retrievalmarket.ProviderDealState
+}
+
 // channelState is immutable channel data plus mutable state
 type channelState struct {
 	// peerId of the manager peer
 	selfPeer peer.ID
 	// an identifier for this channel shared by request and responder, set by requester through protocol
 	transferID datatransfer.TransferID
-	// an identifier for this markets protocol data transfer
-	marketsID retrievalmarket.DealID
 	// base CID for the piece being transferred
 	baseCid cid.Cid
 	// portion of Piece to return, specified by an IPLD selector

--- a/retrievalmarket/server/events.go
+++ b/retrievalmarket/server/events.go
@@ -3,12 +3,13 @@ package server
 import (
 	"errors"
 	datatransfer "github.com/filecoin-project/go-data-transfer"
+	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
 	"github.com/hannahhoward/go-pubsub"
 	"time"
 )
 
-func (g *GraphsyncUnpaidRetrieval) SubscribeToEvents(subscriber datatransfer.Subscriber) datatransfer.Unsubscribe {
-	return datatransfer.Unsubscribe(g.pubSub.Subscribe(subscriber))
+func (g *GraphsyncUnpaidRetrieval) SubscribeToDataTransferEvents(subscriber datatransfer.Subscriber) datatransfer.Unsubscribe {
+	return datatransfer.Unsubscribe(g.pubSubDT.Subscribe(subscriber))
 }
 
 type dtEvent struct {
@@ -16,19 +17,19 @@ type dtEvent struct {
 	state datatransfer.ChannelState
 }
 
-func (g *GraphsyncUnpaidRetrieval) publish(evtCode datatransfer.EventCode, msg string, chst datatransfer.ChannelState) {
+func (g *GraphsyncUnpaidRetrieval) publishDTEvent(evtCode datatransfer.EventCode, msg string, chst datatransfer.ChannelState) {
 	evt := datatransfer.Event{
 		Code:      evtCode,
 		Message:   msg,
 		Timestamp: time.Now(),
 	}
-	err := g.pubSub.Publish(dtEvent{evt, chst})
+	err := g.pubSubDT.Publish(dtEvent{evt, chst})
 	if err != nil {
 		log.Warnf("err publishing DT event: %s", err.Error())
 	}
 }
 
-func eventDispatcher(evt pubsub.Event, subscriberFn pubsub.SubscriberFn) error {
+func eventDispatcherDT(evt pubsub.Event, subscriberFn pubsub.SubscriberFn) error {
 	ie, ok := evt.(dtEvent)
 	if !ok {
 		return errors.New("wrong type of event")
@@ -36,6 +37,35 @@ func eventDispatcher(evt pubsub.Event, subscriberFn pubsub.SubscriberFn) error {
 	cb, ok := subscriberFn.(datatransfer.Subscriber)
 	if !ok {
 		return errors.New("wrong type of subscriber function")
+	}
+	cb(ie.evt, ie.state)
+	return nil
+}
+
+func (g *GraphsyncUnpaidRetrieval) SubscribeToMarketsEvents(subscriber retrievalmarket.ProviderSubscriber) retrievalmarket.Unsubscribe {
+	return retrievalmarket.Unsubscribe(g.pubSubMkts.Subscribe(subscriber))
+}
+
+type mktsEvent struct {
+	evt   retrievalmarket.ProviderEvent
+	state retrievalmarket.ProviderDealState
+}
+
+func (g *GraphsyncUnpaidRetrieval) publishMktsEvent(evt retrievalmarket.ProviderEvent, state retrievalmarket.ProviderDealState) {
+	err := g.pubSubMkts.Publish(mktsEvent{evt: evt, state: state})
+	if err != nil {
+		log.Warnf("err publishing markets event: %s", err.Error())
+	}
+}
+
+func eventDispatcherMkts(evt pubsub.Event, subscriberFn pubsub.SubscriberFn) error {
+	ie, ok := evt.(mktsEvent)
+	if !ok {
+		return errors.New("wrong type of event")
+	}
+	cb, ok := subscriberFn.(retrievalmarket.ProviderSubscriber)
+	if !ok {
+		return errors.New("wrong type of event")
 	}
 	cb(ie.evt, ie.state)
 	return nil

--- a/retrievalmarket/server/events.go
+++ b/retrievalmarket/server/events.go
@@ -1,0 +1,42 @@
+package server
+
+import (
+	"errors"
+	datatransfer "github.com/filecoin-project/go-data-transfer"
+	"github.com/hannahhoward/go-pubsub"
+	"time"
+)
+
+func (g *GraphsyncUnpaidRetrieval) SubscribeToEvents(subscriber datatransfer.Subscriber) datatransfer.Unsubscribe {
+	return datatransfer.Unsubscribe(g.pubSub.Subscribe(subscriber))
+}
+
+type dtEvent struct {
+	evt   datatransfer.Event
+	state datatransfer.ChannelState
+}
+
+func (g *GraphsyncUnpaidRetrieval) publish(evtCode datatransfer.EventCode, msg string, chst datatransfer.ChannelState) {
+	evt := datatransfer.Event{
+		Code:      evtCode,
+		Message:   msg,
+		Timestamp: time.Now(),
+	}
+	err := g.pubSub.Publish(dtEvent{evt, chst})
+	if err != nil {
+		log.Warnf("err publishing DT event: %s", err.Error())
+	}
+}
+
+func eventDispatcher(evt pubsub.Event, subscriberFn pubsub.SubscriberFn) error {
+	ie, ok := evt.(dtEvent)
+	if !ok {
+		return errors.New("wrong type of event")
+	}
+	cb, ok := subscriberFn.(datatransfer.Subscriber)
+	if !ok {
+		return errors.New("wrong type of subscriber function")
+	}
+	cb(ie.evt, ie.state)
+	return nil
+}

--- a/retrievalmarket/server/gsunpaidretrieval.go
+++ b/retrievalmarket/server/gsunpaidretrieval.go
@@ -283,6 +283,10 @@ func (g *GraphsyncUnpaidRetrieval) RegisterIncomingRequestHook(hook graphsync.On
 			return
 		}
 
+		dtOpenMsg := "unpaid"
+		if msg.IsRestart() {
+			dtOpenMsg += " (restart)"
+		}
 		g.publishDTEvent(datatransfer.Open, "unpaid", state.cs)
 		g.publishMktsEvent(retrievalmarket.ProviderEventOpen, *state.mkts)
 

--- a/retrievalmarket/server/gsunpaidretrieval.go
+++ b/retrievalmarket/server/gsunpaidretrieval.go
@@ -66,12 +66,16 @@ var defaultExtensions = []graphsync.ExtensionName{
 	extension.ExtensionDataTransfer1_1,
 }
 
+type AskGetter interface {
+	GetAsk() *retrievalmarket.Ask
+}
+
 type ValidationDeps struct {
 	DealDecider    retrievalimpl.DealDecider
 	DagStore       stores.DAGStoreWrapper
 	PieceStore     piecestore.PieceStore
 	SectorAccessor retrievalmarket.SectorAccessor
-	AskStore       retrievalmarket.AskStore
+	AskStore       AskGetter
 }
 
 func NewGraphsyncUnpaidRetrieval(peerID peer.ID, gs graphsync.GraphExchange, dtnet network.DataTransferNetwork, vdeps ValidationDeps) (*GraphsyncUnpaidRetrieval, error) {

--- a/retrievalmarket/server/gsunpaidretrieval.go
+++ b/retrievalmarket/server/gsunpaidretrieval.go
@@ -136,8 +136,10 @@ func (g *GraphsyncUnpaidRetrieval) CancelTransfer(ctx context.Context, id datatr
 
 	// If peer is set we can cancel more efficiently
 	if p != nil {
-		state := g.activeRetrievals[reqId{p: *p, id: id}]
-		g.failTransfer(state, errors.New("transfer cancelled by provider"))
+		state, ok := g.activeRetrievals[reqId{p: *p, id: id}]
+		if ok {
+			g.failTransfer(state, errors.New("transfer cancelled by provider"))
+		}
 		return nil
 	}
 

--- a/retrievalmarket/server/gsunpaidretrieval.go
+++ b/retrievalmarket/server/gsunpaidretrieval.go
@@ -287,7 +287,7 @@ func (g *GraphsyncUnpaidRetrieval) RegisterIncomingRequestHook(hook graphsync.On
 		if msg.IsRestart() {
 			dtOpenMsg += " (restart)"
 		}
-		g.publishDTEvent(datatransfer.Open, "unpaid", state.cs)
+		g.publishDTEvent(datatransfer.Open, dtOpenMsg, state.cs)
 		g.publishMktsEvent(retrievalmarket.ProviderEventOpen, *state.mkts)
 
 		err := func() error {

--- a/retrievalmarket/server/gsunpaidretrieval.go
+++ b/retrievalmarket/server/gsunpaidretrieval.go
@@ -461,7 +461,15 @@ func (g *GraphsyncUnpaidRetrieval) RegisterNetworkErrorListener(listener graphsy
 			return
 		}
 
-		// Consider network errors as fatal, clients can resume if they wish
+		// Consider network errors as fatal, clients can sent a new request if they wish
+
+		// Cancel the graphsync retrieval
+		cancelErr := g.GraphExchange.Cancel(g.ctx, request.ID())
+		if cancelErr != nil {
+			log.Errorf("cancelling graphsync response after network error: %w", cancelErr)
+		}
+
+		// Fail the transfer
 		g.failTransfer(state, err)
 	})
 }

--- a/retrievalmarket/server/gsunpaidretrieval.go
+++ b/retrievalmarket/server/gsunpaidretrieval.go
@@ -132,31 +132,42 @@ func (g *GraphsyncUnpaidRetrieval) untrackTransfer(p peer.ID, id datatransfer.Tr
 }
 
 func (g *GraphsyncUnpaidRetrieval) CancelTransfer(ctx context.Context, id datatransfer.TransferID, p *peer.ID) error {
-	didCancel := false
-
-	// If peer is set we can cancel more efficiently
+	var state *retrievalState
 	if p != nil {
-		state, ok := g.activeRetrievals[reqId{p: *p, id: id}]
-		if ok {
-			g.failTransfer(state, errors.New("transfer cancelled by provider"))
-		}
-		return nil
+		state = g.activeRetrievals[reqId{p: *p, id: id}]
 	}
 
-	// Peer was not given so we need to iterate over active retrievals
-	for _, state := range g.activeRetrievals {
-		if state.cs.transferID == id {
-			didCancel = true
-			g.failTransfer(state, errors.New("transfer cancelled by provider"))
-			// Dont break, transferID might not be unique, so we have to keep iterating
+	if state == nil {
+		for _, st := range g.activeRetrievals {
+			if st.cs.transferID == id {
+				state = st
+				break
+			}
 		}
 	}
 
-	if !didCancel {
+	if state == nil {
 		return fmt.Errorf("no transfer with id %d", id)
 	}
 
+	err := g.dtnet.SendMessage(ctx, state.cs.recipient, message.CancelResponse(state.cs.transferID))
+	g.failTransfer(state, errors.New("transfer cancelled by provider"))
+
+	if err != nil {
+		return fmt.Errorf("cancelling request for transfer %d: %w", id, err)
+	}
+
 	return nil
+}
+
+func (g *GraphsyncUnpaidRetrieval) List() []retrievalState {
+	values := make([]retrievalState, 0, len(g.activeRetrievals))
+
+	for _, value := range g.activeRetrievals {
+		values = append(values, *value)
+	}
+
+	return values
 }
 
 func (g *GraphsyncUnpaidRetrieval) RegisterIncomingRequestQueuedHook(hook graphsync.OnIncomingRequestQueuedHook) graphsync.UnregisterHookFunc {

--- a/retrievalmarket/server/gsunpaidretrieval_test.go
+++ b/retrievalmarket/server/gsunpaidretrieval_test.go
@@ -142,7 +142,8 @@ func runRequestTest(t *testing.T, tc testCase) {
 	if tc.ask != nil {
 		ask = tc.ask
 	}
-	askStore.SetAsk(ask)
+	err = askStore.SetAsk(ask)
+	require.NoError(t, err)
 
 	sectorAccessor := testnodes.NewTestSectorAccessor()
 	if !tc.noUnsealedCopy {

--- a/retrievalmarket/server/gsunpaidretrieval_test.go
+++ b/retrievalmarket/server/gsunpaidretrieval_test.go
@@ -1,0 +1,300 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	boosttu "github.com/filecoin-project/boost/testutil"
+	"github.com/filecoin-project/go-address"
+	datatransfer "github.com/filecoin-project/go-data-transfer"
+	dtimpl "github.com/filecoin-project/go-data-transfer/impl"
+	"github.com/filecoin-project/go-data-transfer/testutil"
+	dtgstransport "github.com/filecoin-project/go-data-transfer/transport/graphsync"
+	"github.com/filecoin-project/go-fil-markets/piecestore"
+	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
+	retrievalimpl "github.com/filecoin-project/go-fil-markets/retrievalmarket/impl"
+	"github.com/filecoin-project/go-fil-markets/retrievalmarket/impl/testnodes"
+	rmnet "github.com/filecoin-project/go-fil-markets/retrievalmarket/network"
+	tut "github.com/filecoin-project/go-fil-markets/shared_testutil"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-datastore"
+	"github.com/ipfs/go-datastore/namespace"
+	"github.com/ipfs/go-graphsync"
+	graphsyncimpl "github.com/ipfs/go-graphsync/impl"
+	"github.com/ipfs/go-graphsync/network"
+	"github.com/ipfs/go-graphsync/storeutil"
+	logging "github.com/ipfs/go-log/v2"
+	carv2 "github.com/ipld/go-car/v2"
+	"github.com/ipld/go-car/v2/blockstore"
+	selectorparse "github.com/ipld/go-ipld-prime/traversal/selector/parse"
+	"github.com/stretchr/testify/require"
+	"io"
+	"os"
+	"testing"
+	"time"
+)
+
+var tlog = logging.Logger("testgs")
+
+type testCase struct {
+	name          string
+	reqMissingCid bool
+	watch         func(client retrievalmarket.RetrievalClient, gsupr *GraphsyncUnpaidRetrieval)
+	expectErr     bool
+	expectCancel  bool
+}
+
+var providerCancelled = errors.New("provider cancelled")
+var clientCancelled = errors.New("client cancelled")
+
+func TestGS(t *testing.T) {
+	//_ = logging.SetLogLevel("testgs", "debug")
+	_ = logging.SetLogLevel("testgs", "info")
+	//_ = logging.SetLogLevel("dt-impl", "debug")
+
+	testCases := []testCase{{
+		name: "happy path",
+	}, {
+		name:          "request missing payload cid",
+		reqMissingCid: true,
+		expectErr:     true,
+	}, {
+		name: "cancel request after sending 2 blocks",
+		watch: func(client retrievalmarket.RetrievalClient, gsupr *GraphsyncUnpaidRetrieval) {
+			count := 0
+			gsupr.outgoingBlockHook = func(state *retrievalState) {
+				count++
+				if count == 2 {
+					tlog.Debug("cancelling client deal")
+					err := client.CancelDeal(state.mkts.ID)
+					require.NoError(t, err)
+				}
+				if count == 10 {
+					tlog.Warn("sending last block but client cancel hasn't arrived yet")
+				}
+			}
+		},
+		expectCancel: true,
+	}}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			runRequestTest(t, tc)
+		})
+	}
+}
+
+func runRequestTest(t *testing.T, tc testCase) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Create a CAR file and set up mocks
+	testData := tut.NewLibp2pTestData(ctx, t)
+	carRootCid, carData := createCarV1(t)
+	sectorID := abi.SectorNumber(1)
+	offset := abi.PaddedPieceSize(0)
+	pieceInfo := piecestore.PieceInfo{
+		PieceCID: tut.GenerateCids(1)[0],
+		Deals: []piecestore.DealInfo{
+			{
+				DealID:   abi.DealID(1),
+				SectorID: sectorID,
+				Offset:   offset,
+				Length:   abi.UnpaddedPieceSize(len(carData)).Padded(),
+			},
+		},
+	}
+
+	pieceStore := tut.NewTestPieceStore()
+	sectorAccessor := testnodes.NewTestSectorAccessor()
+	sectorAccessor.ExpectUnseal(sectorID, offset.Unpadded(), abi.UnpaddedPieceSize(len(carData)), carData)
+	dagstoreWrapper := tut.NewMockDagStoreWrapper(pieceStore, sectorAccessor)
+	vdeps := ValidationDeps{
+		DagStore:       dagstoreWrapper,
+		PieceStore:     pieceStore,
+		SectorAccessor: sectorAccessor,
+	}
+
+	expectedPiece := pieceInfo.PieceCID
+	pieceStore.ExpectPiece(expectedPiece, pieceInfo)
+	pieceStore.ExpectCID(carRootCid, piecestore.CIDInfo{
+		PieceBlockLocations: []piecestore.PieceBlockLocation{
+			{
+				PieceCID: expectedPiece,
+			},
+		},
+	})
+	dagstoreWrapper.AddBlockToPieceIndex(carRootCid, expectedPiece)
+
+	// Create a blockstore over the CAR file blocks
+	carDataBuff := bytes.NewReader(carData)
+	carDataBs, err := blockstore.NewReadOnly(carDataBuff, nil, carv2.ZeroLengthSectionAsEOF(true), blockstore.UseWholeCIDs(true))
+	require.NoError(t, err)
+
+	// Wrap graphsync with the graphsync unpaid retrieval interceptor
+	linkSystem2 := storeutil.LinkSystemForBlockstore(carDataBs)
+	gs2 := graphsyncimpl.New(ctx, network.NewFromLibp2pHost(testData.Host2), linkSystem2)
+	gsupr, err := NewGraphsyncUnpaidRetrieval(testData.Host2.ID(), gs2, testData.DTNet2, vdeps)
+	require.NoError(t, err)
+
+	// Create the retrieval provider with the graphsync unpaid retrieval interceptor
+	paymentAddress := address.TestAddress2
+	provider := createRetrievalProvider(ctx, t, testData, pieceStore, sectorAccessor, dagstoreWrapper, gsupr, paymentAddress)
+
+	gsupr.SubscribeToDataTransferEvents(func(event datatransfer.Event, channelState datatransfer.ChannelState) {
+		tlog.Debugf("prov dt: %s %s / %s", datatransfer.Events[event.Code], event.Message, datatransfer.Statuses[channelState.Status()])
+	})
+	gsupr.Start(ctx)
+	tut.StartAndWaitForReady(ctx, t, provider)
+
+	// Create a retrieval client
+	retrievalPeer := retrievalmarket.RetrievalPeer{
+		Address: paymentAddress,
+		ID:      testData.Host2.ID(),
+	}
+	retrievalClientNode := testnodes.NewTestRetrievalClientNode(testnodes.TestRetrievalClientNodeParams{})
+	retrievalClientNode.ExpectKnownAddresses(retrievalPeer, nil)
+	client := createRetrievalClient(ctx, t, testData, retrievalClientNode)
+	tut.StartAndWaitForReady(ctx, t, client)
+
+	if tc.watch != nil {
+		tc.watch(client, gsupr)
+	}
+
+	// Watch for provider completion
+	providerResChan := make(chan error)
+	gsupr.SubscribeToMarketsEvents(func(event retrievalmarket.ProviderEvent, state retrievalmarket.ProviderDealState) {
+		tlog.Debugf("prov mkt: %s %s %s", retrievalmarket.ProviderEvents[event], state.Status.String(), state.Message)
+		switch event {
+		case retrievalmarket.ProviderEventComplete:
+			providerResChan <- nil
+		case retrievalmarket.ProviderEventCancelComplete:
+			providerResChan <- providerCancelled
+		case retrievalmarket.ProviderEventDataTransferError:
+			providerResChan <- errors.New(state.Message)
+		}
+	})
+
+	// Watch for client completion
+	clientResChan := make(chan error)
+	client.SubscribeToEvents(func(event retrievalmarket.ClientEvent, state retrievalmarket.ClientDealState) {
+		tlog.Debugf("clnt mkt: %s %s %s", event.String(), state.Status.String(), state.Message)
+		switch event {
+		case retrievalmarket.ClientEventComplete:
+			clientResChan <- nil
+		case retrievalmarket.ClientEventCancelComplete:
+			clientResChan <- clientCancelled
+		case retrievalmarket.ClientEventDataTransferError:
+			clientResChan <- errors.New(state.Message)
+		}
+	})
+
+	// Retrieve the data
+	tlog.Infof("Retrieve cid %s from peer %s", carRootCid, retrievalPeer.ID)
+	sel := selectorparse.CommonSelector_ExploreAllRecursively
+	params, err := retrievalmarket.NewParamsV1(abi.NewTokenAmount(0), 0, 0, sel, nil, abi.NewTokenAmount(0))
+	require.NoError(t, err)
+	if tc.reqMissingCid {
+		carRootCid, err = cid.Parse("bafkqaaa")
+		require.NoError(t, err)
+	}
+	_, err = client.Retrieve(ctx, 1, carRootCid, params, abi.NewTokenAmount(0), retrievalPeer, address.TestAddress, address.TestAddress2)
+	require.NoError(t, err)
+
+	// Wait for provider completion
+	err = waitFor(ctx, t, providerResChan)
+	if tc.expectErr || tc.expectCancel {
+		require.Error(t, err)
+		if tc.expectCancel {
+			require.EqualError(t, err, providerCancelled.Error())
+		}
+	} else {
+		require.NoError(t, err)
+	}
+
+	// Wait for client completion
+	err = waitFor(ctx, t, clientResChan)
+	if tc.expectErr || tc.expectCancel {
+		require.Error(t, err)
+		if tc.expectCancel {
+			require.EqualError(t, err, clientCancelled.Error())
+		}
+	} else {
+		require.NoError(t, err)
+	}
+}
+
+func createRetrievalProvider(ctx context.Context, t *testing.T, testData *tut.Libp2pTestData, pieceStore *tut.TestPieceStore, sectorAccessor *testnodes.TestSectorAccessor, dagstoreWrapper *tut.MockDagStoreWrapper, gs graphsync.GraphExchange, paymentAddress address.Address) retrievalmarket.RetrievalProvider {
+	nw2 := rmnet.NewFromLibp2pHost(testData.Host2, rmnet.RetryParameters(0, 0, 0, 0))
+	dtTransport2 := dtgstransport.NewTransport(testData.Host2.ID(), gs)
+	dt2, err := dtimpl.NewDataTransfer(testData.DTStore2, testData.DTNet2, dtTransport2)
+	require.NoError(t, err)
+	testutil.StartAndWaitForReady(ctx, t, dt2)
+	providerDs := namespace.Wrap(testData.Ds2, datastore.NewKey("/retrievals/provider"))
+	priceFunc := func(ctx context.Context, dealPricingParams retrievalmarket.PricingInput) (retrievalmarket.Ask, error) {
+		return retrievalmarket.Ask{
+			UnsealPrice:  abi.NewTokenAmount(0),
+			PricePerByte: abi.NewTokenAmount(0),
+		}, nil
+	}
+	providerNode := testnodes.NewTestRetrievalProviderNode()
+	provider, err := retrievalimpl.NewProvider(
+		paymentAddress, providerNode, sectorAccessor, nw2, pieceStore, dagstoreWrapper, dt2, providerDs,
+		priceFunc)
+	require.NoError(t, err)
+	return provider
+}
+
+func createRetrievalClient(ctx context.Context, t *testing.T, testData *tut.Libp2pTestData, retrievalClientNode *testnodes.TestRetrievalClientNode) retrievalmarket.RetrievalClient {
+	nw1 := rmnet.NewFromLibp2pHost(testData.Host1, rmnet.RetryParameters(0, 0, 0, 0))
+	gs1 := graphsyncimpl.New(ctx, network.NewFromLibp2pHost(testData.Host1), testData.LinkSystem1)
+	dtTransport1 := dtgstransport.NewTransport(testData.Host1.ID(), gs1)
+	dt1, err := dtimpl.NewDataTransfer(testData.DTStore1, testData.DTNet1, dtTransport1)
+	require.NoError(t, err)
+	testutil.StartAndWaitForReady(ctx, t, dt1)
+	require.NoError(t, err)
+	clientDs := namespace.Wrap(testData.Ds1, datastore.NewKey("/retrievals/client"))
+	ba := tut.NewTestRetrievalBlockstoreAccessor()
+	client, err := retrievalimpl.NewClient(nw1, dt1, retrievalClientNode, &tut.TestPeerResolver{}, clientDs, ba)
+	require.NoError(t, err)
+	return client
+}
+
+func createCarV1(t *testing.T) (cid.Cid, []byte) {
+	rf, err := boosttu.CreateRandomFile(t.TempDir(), int(time.Now().Unix()), 2*1024*1024)
+	require.NoError(t, err)
+
+	// carv1
+	caropts := []carv2.Option{
+		blockstore.WriteAsCarV1(true),
+	}
+
+	root, cn, err := boosttu.CreateDenseCARWith(t.TempDir(), rf, 128*1024, 1024, caropts)
+	require.NoError(t, err)
+
+	file, err := os.Open(cn)
+	require.NoError(t, err)
+	defer file.Close()
+
+	reader, err := carv2.NewReader(file)
+	require.NoError(t, err)
+
+	v1Reader, err := reader.DataReader()
+	require.NoError(t, err)
+
+	bz, err := io.ReadAll(v1Reader)
+	require.NoError(t, err)
+
+	return root, bz
+}
+
+func waitFor(ctx context.Context, t *testing.T, resChan chan error) error {
+	var err error
+	select {
+	case <-ctx.Done():
+		require.Fail(t, "test timed out")
+	case err = <-resChan:
+	}
+	return err
+}

--- a/retrievalmarket/server/provider_pieces.go
+++ b/retrievalmarket/server/provider_pieces.go
@@ -1,0 +1,221 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"github.com/filecoin-project/go-fil-markets/piecestore"
+	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
+	"github.com/filecoin-project/go-fil-markets/stores"
+	"github.com/ipfs/go-cid"
+	"github.com/ipld/go-ipld-prime"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/ipld/go-ipld-prime/traversal"
+	"github.com/multiformats/go-multihash"
+)
+
+// This code is copied directly from
+// https://github.com/filecoin-project/go-fil-markets/blob/955fd43fad7da2e68539c257f0c8199a6b0c2a4d/retrievalmarket/impl/provider_pieces.go#L1
+// TODO: Create a PR against go-fil-markets to make these methods public,
+// so that we can import them from go-fil-markets instead of copying the code here.
+
+// MaxIdentityCIDBytes is the largest identity CID as a PayloadCID that we are
+// willing to decode
+const MaxIdentityCIDBytes = 2 << 10
+
+// MaxIdentityCIDLinks is the maximum number of links contained within an
+// identity CID that we are willing to check for matching pieces
+const MaxIdentityCIDLinks = 32
+
+// GetAllPieceInfoForPayload returns all of the pieces containing the requested Payload CID.
+// If the Payload CID is an identity CID, then we use getCommonPiecesFromIdentityCidLinks to find
+// pieces containing all of the links within that identity CID.
+// Note that it is possible to receive a non-nil error as well as a non-zero length PieceInfo slice
+// as a return from this function. In that case, there was at least one error encountered querying
+// the piece store.
+func GetAllPieceInfoForPayload(dagStore stores.DAGStoreWrapper, pieceStore piecestore.PieceStore, payloadCID cid.Cid) ([]piecestore.PieceInfo, error) {
+	// Get all pieces that contain the target block
+	piecesWithTargetBlock, err := dagStore.GetPiecesContainingBlock(payloadCID)
+	if err != nil {
+		// this payloadCID may be an identity CID that's in the root of a CAR but
+		// not recorded in the index
+		var idErr error
+		piecesWithTargetBlock, idErr = GetCommonPiecesFromIdentityCidLinks(dagStore, payloadCID)
+		if idErr != nil {
+			return []piecestore.PieceInfo{}, idErr
+		}
+		if len(piecesWithTargetBlock) == 0 {
+			return []piecestore.PieceInfo{}, fmt.Errorf("getting pieces for cid %s: %w", payloadCID, err)
+		}
+	}
+
+	pieces := make([]piecestore.PieceInfo, 0)
+	var lastErr error
+	for _, pieceWithTargetBlock := range piecesWithTargetBlock {
+		// Get the deals for the piece
+		pieceInfo, err := pieceStore.GetPieceInfo(pieceWithTargetBlock)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		pieces = append(pieces, pieceInfo)
+	}
+
+	return pieces, lastErr
+}
+
+// GetCommonPiecesFromIdentityCidLinks will inspect a payloadCID and if it has an identity multihash,
+// will determine which pieces contain all of the links within the decoded identity multihash block
+func GetCommonPiecesFromIdentityCidLinks(dagStore stores.DAGStoreWrapper, payloadCID cid.Cid) ([]cid.Cid, error) {
+	links, err := linksFromIdentityCid(payloadCID)
+	if err != nil || len(links) == 0 {
+		return links, err
+	}
+
+	pieces := make([]cid.Cid, 0)
+	// for each link, query the dagstore for pieces that contain it
+	for i, link := range links {
+		piecesWithThisCid, err := dagStore.GetPiecesContainingBlock(link)
+		if err != nil {
+			return nil, fmt.Errorf("getting pieces for identity CID sub-link %s: %w", link, err)
+		}
+		if len(piecesWithThisCid) == 0 {
+			return nil, fmt.Errorf("no pieces for identity CID sub-link %s", link)
+		}
+		if i == 0 {
+			pieces = append(pieces, piecesWithThisCid...)
+		} else {
+			// after the first, find the intersection between these pieces and the previous ones
+			intersection := make([]cid.Cid, 0)
+			for _, cj := range piecesWithThisCid {
+				for _, ck := range pieces {
+					if cj.Equals(ck) {
+						intersection = append(intersection, cj)
+						break
+					}
+				}
+			}
+			pieces = intersection
+		}
+		if len(pieces) == 0 {
+			break
+		}
+	}
+
+	return pieces, nil
+}
+
+// linksFromIdentityCid will extract zero or more CIDs contained within a valid identity CID.
+// If the CID is not an identity CID, an empty list is returned. If the CID is an identity CID and
+// cannot be decoded, an error is returned.
+func linksFromIdentityCid(identityCid cid.Cid) ([]cid.Cid, error) {
+	if identityCid.Prefix().MhType != multihash.IDENTITY {
+		return []cid.Cid{}, nil
+	}
+
+	if len(identityCid.Hash()) > MaxIdentityCIDBytes {
+		return nil, fmt.Errorf("refusing to decode too-long identity CID (%d bytes)", len(identityCid.Hash()))
+	}
+
+	// decode the identity multihash, if possible (i.e. it's valid and we have the right codec loaded)
+	decoder, err := cidlink.DefaultLinkSystem().DecoderChooser(cidlink.Link{Cid: identityCid})
+	if err != nil {
+		return nil, fmt.Errorf("choosing decoder for identity CID %s: %w", identityCid, err)
+	}
+	mh, err := multihash.Decode(identityCid.Hash())
+	if err != nil {
+		return nil, fmt.Errorf("decoding identity CID multihash %s: %w", identityCid, err)
+	}
+	node, err := ipld.Decode(mh.Digest, decoder)
+	if err != nil {
+		return nil, fmt.Errorf("decoding identity CID %s: %w", identityCid, err)
+	}
+	links, err := traversal.SelectLinks(node)
+	if err != nil {
+		return nil, fmt.Errorf("collecting links from identity CID %s: %w", identityCid, err)
+	}
+
+	// convert from Link to Cid, handle nested identity CIDs, and dedupe
+	resultCids := make([]cid.Cid, 0)
+	for _, link_ := range links {
+		cids := []cid.Cid{link_.(cidlink.Link).Cid}
+		if cids[0].Prefix().MhType == multihash.IDENTITY {
+			// nested, recurse
+			// (just because you can, it doesn't mean you should, nested identity CIDs are an extra layer of silly)
+			cids, err = linksFromIdentityCid(cids[0])
+			if err != nil {
+				return nil, err
+			}
+		}
+		for _, c := range cids {
+			// dedupe
+			var found bool
+			for _, rc := range resultCids {
+				if rc.Equals(c) {
+					found = true
+				}
+			}
+			if !found {
+				resultCids = append(resultCids, c)
+			}
+		}
+	}
+
+	if len(resultCids) > MaxIdentityCIDLinks {
+		return nil, fmt.Errorf("refusing to process identity CID with too many links (%d)", len(resultCids))
+	}
+
+	return resultCids, err
+}
+
+func PieceInUnsealedSector(ctx context.Context, sa retrievalmarket.SectorAccessor, pieceInfo piecestore.PieceInfo) bool {
+	for _, di := range pieceInfo.Deals {
+		isUnsealed, err := sa.IsUnsealed(ctx, di.SectorID, di.Offset.Unpadded(), di.Length.Unpadded())
+		if err != nil {
+			log.Errorf("failed to find out if sector %d is unsealed, err=%s", di.SectorID, err)
+			continue
+		}
+		if isUnsealed {
+			return true
+		}
+	}
+
+	return false
+}
+
+// GetBestPieceInfoMatch will take a list of pieces, and an optional PieceCID from a client, and
+// will find the best piece to use for a retrieval. If a specific PieceCID is provided and that
+// piece is included in the list of pieces, that is used. Otherwise the first unsealed piece is used
+// and if there are no unsealed pieces, the first sealed piece is used.
+// Failure to find a matching piece will result in a piecestore.PieceInfoUndefined being returned.
+func GetBestPieceInfoMatch(ctx context.Context, sa retrievalmarket.SectorAccessor, pieces []piecestore.PieceInfo, clientPieceCID cid.Cid) (piecestore.PieceInfo, bool) {
+	sealedPieceInfo := -1
+	// For each piece that contains the target block
+	for ii, pieceInfo := range pieces {
+		if clientPieceCID.Defined() {
+			// If client wants to retrieve the payload from a specific piece, just return that piece.
+			if pieceInfo.PieceCID.Equals(clientPieceCID) {
+				return pieceInfo, PieceInUnsealedSector(ctx, sa, pieceInfo)
+			}
+		} else {
+			// If client doesn't have a preference for a particular piece, prefer the first piece for
+			// which an unsealed sector exists.
+			if PieceInUnsealedSector(ctx, sa, pieceInfo) {
+				// The piece is in an unsealed sector, so just return it
+				return pieceInfo, true
+			}
+
+			if sealedPieceInfo == -1 {
+				// The piece is not in an unsealed sector, so save it but keep checking other pieces to see
+				// if there is one that is in an unsealed sector, otherwise use the first found sealed piece
+				sealedPieceInfo = ii
+			}
+		}
+	}
+
+	// Found a piece containing the target block, piece is in a sealed sector
+	if sealedPieceInfo > -1 {
+		return pieces[sealedPieceInfo], false
+	}
+
+	return piecestore.PieceInfoUndefined, false
+}

--- a/retrievalmarket/server/validation.go
+++ b/retrievalmarket/server/validation.go
@@ -51,7 +51,7 @@ func (rv *requestValidator) validatePullRequest(isRestart bool, receiver peer.ID
 		legacyProtocol = true
 	}
 	response, err := rv.validatePull(receiver, proposal, legacyProtocol, baseCid, selector)
-	rv.psub.Publish(retrievalmarket.ProviderValidationEvent{
+	_ = rv.psub.Publish(retrievalmarket.ProviderValidationEvent{
 		IsRestart: isRestart,
 		Receiver:  receiver,
 		Proposal:  proposal,

--- a/retrievalmarket/server/validation.go
+++ b/retrievalmarket/server/validation.go
@@ -1,0 +1,61 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"github.com/filecoin-project/go-fil-markets/piecestore"
+	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
+	"github.com/filecoin-project/go-fil-markets/retrievalmarket/impl/requestvalidation"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/ipfs/go-cid"
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+// An implementation of ValidationEnvironment for unpaid retrieval
+type validationEnv struct {
+	ctx context.Context
+	ValidationDeps
+}
+
+var _ requestvalidation.ValidationEnvironment = (*validationEnv)(nil)
+
+func (v *validationEnv) GetAsk(ctx context.Context, payloadCid cid.Cid, pieceCid *cid.Cid, piece piecestore.PieceInfo, isUnsealed bool, client peer.ID) (retrievalmarket.Ask, error) {
+	return retrievalmarket.Ask{
+		PricePerByte:            abi.NewTokenAmount(0),
+		UnsealPrice:             abi.NewTokenAmount(0),
+		PaymentInterval:         0,
+		PaymentIntervalIncrease: 0,
+	}, nil
+}
+
+func (v *validationEnv) CheckDealParams(ask retrievalmarket.Ask, pricePerByte abi.TokenAmount, paymentInterval uint64, paymentIntervalIncrease uint64, unsealPrice abi.TokenAmount) error {
+	return nil
+}
+
+func (v *validationEnv) RunDealDecisioningLogic(ctx context.Context, state retrievalmarket.ProviderDealState) (bool, string, error) {
+	if v.DealDecider == nil {
+		return true, "", nil
+	}
+	return v.DealDecider(ctx, state)
+}
+
+func (v *validationEnv) BeginTracking(pds retrievalmarket.ProviderDealState) error {
+	return nil
+}
+
+func (v *validationEnv) GetPiece(payloadCid cid.Cid, pieceCID *cid.Cid) (piecestore.PieceInfo, bool, error) {
+	inPieceCid := cid.Undef
+	if pieceCID != nil {
+		inPieceCid = *pieceCID
+	}
+
+	pieces, piecesErr := GetAllPieceInfoForPayload(v.DagStore, v.PieceStore, payloadCid)
+	pieceInfo, isUnsealed := GetBestPieceInfoMatch(v.ctx, v.SectorAccessor, pieces, inPieceCid)
+	if pieceInfo.Defined() {
+		return pieceInfo, isUnsealed, nil
+	}
+	if piecesErr != nil {
+		return piecestore.PieceInfoUndefined, false, piecesErr
+	}
+	return piecestore.PieceInfoUndefined, false, fmt.Errorf("unknown pieceCID %s", pieceCID.String())
+}


### PR DESCRIPTION
Implement a retrieval server for graphsync retrievals that intercepts incoming requests and
- handles them if they're for unpaid retrievals
- passes them on to the existing go-fil-markets implementation if they're for paid retrievals

## Todo
- [x] Boost should not attempt to dial back a client when it disconnects - currently it does a backoff retry
- [x] Update data-transfer cancel methods (including retrieval log stalled timeout job) to attempt the cancel on the unpaid retrieval path, and then the legacy path
- [x] Show the list of active retrievals in `boostd data-transfers list`
- [x] Ensure that `boostd data-transfers cancel` cancels retrievals in the new code path
- [x] Update graphsync version to an official tag