### PR TITLE
test: devnet quality of life updates

### DIFF
--- a/docker/devnet/boost/entrypoint.sh
+++ b/docker/devnet/boost/entrypoint.sh
@@ -74,5 +74,4 @@ if [ ! -f $BOOST_PATH/.register.boost ]; then
 fi
 
 echo Starting boost in dev mode...
-exec boostd -vv run
-
+exec boostd -vv run --nosync=true

--- a/docker/devnet/boost/sample/random-deal.sh
+++ b/docker/devnet/boost/sample/random-deal.sh
@@ -8,14 +8,19 @@
 # $ boost init
 # $ lotus send --from=`lotus wallet default` `boost wallet default` 100
 # $ boostx market-add 50
-# $ ./sample/random-deal.sh
+# $ ./sample/random-deal.sh 51200 100
 ###################################################################################
 set -e
 
 ci="\e[3m"
 cn="\e[0m"
 
-FILE=`boostx generate-rand-car -c=512 -l=8 -s=5120000 /app/public/ | awk '{print $NF}'`
+chunks="${1:-51200}"
+links="${2:-100}"
+
+printf "${ci}boostx generate-rand-car -c=$chunks -l=$links -s=5120000 /app/public/ | awk '{print $NF}'\n\n${cn}"
+
+FILE=`boostx generate-rand-car -c=$chunks -l=$links -s=5120000 /app/public/ | awk '{print $NF}'`
 PAYLOAD_CID=$(find "$FILE" | xargs -I{} basename {} | sed 's/\.car//')
 
 COMMP_CID=`boostx commp $FILE 2> /dev/null | grep CID | cut -d: -f2 | xargs`

--- a/docker/monitoring/docker-compose.yaml
+++ b/docker/monitoring/docker-compose.yaml
@@ -43,7 +43,7 @@ services:
     volumes:
       - ./${PROMETHEUS_CONFIG_FILE:-prometheus.yaml}:/etc/prometheus.yaml
     ports:
-      - "9090:9090"
+      - "9190:9090"
     ## Uncomment and modify this section depending on your Filecoin deployment.
     ## Prometheus needs to be able to scrape these targets so that it collects metrics
     ## and have them visualized in Grafana.


### PR DESCRIPTION
## Summary
This adds a few quality of life fixes/updates I've been using locally. Each commit is atomic, so you can take a look at the individual change sets.

* You can now pass `./sample/random-deal.sh` the number of chunks and leaf size when creating a car. I also reduced the default size. This makes it easier to create deals of varying dag depth/width.
* Fixed collision with prometheus and the non monitoring container ports. 9090 is also exposed by Lotus. 
* The boost container will now always run in `--nosync=true` mode. I've been able to run my devnet for multiple days with this set. Since there are no external nodes we need to worry about, we can set it to always true for ease of development.

## Future Considerations
* For the port collision problem of the docker containers we should setup a better approach to minimize the amount of ports we expose to avoid process collision, while making it easy to access the underlying libp2p hosts, etc when we need to for development, such as debugging a local Boost process against the lotus docker containers.