### PR TITLE
feat(ui): display end of peerid instead of front

### DIFF
--- a/react/src/Components.js
+++ b/react/src/Components.js
@@ -28,7 +28,7 @@ export function ShortClientAddress(props) {
 }
 
 export function ShortPeerID(props) {
-    const shortPeerId = props.peerId.substring(0, 8) + '…'
+    const shortPeerId = '…' + props.peerId.slice(-8)
     return <div>{shortPeerId}</div>
 }
 


### PR DESCRIPTION
## Summary
Fixes https://github.com/filecoin-project/boost/issues/1238
Instead of displaying the common characters in a Peer ID, this will display the end of the PeerId. This makes it easier to quickly discern requests from different peers.

You can see in the screenshots below of the exact same data that while the PeerIDs all look the same before, showing the last 8 characters instead of the first 8 clearly shows they're all unique peers.

**Before**
![Screenshot 2023-03-03 at 2 08 34 PM](https://user-images.githubusercontent.com/639834/222730727-eb4358bb-4d42-435b-b199-c0dc7131cc2d.png)

**After**
![Screenshot 2023-03-03 at 2 16 41 PM](https://user-images.githubusercontent.com/639834/222730746-573bc181-2e77-42b5-9866-9fccbfa34652.png)
