### PR TITLE
feat: hook up unpaid gs retrievals to cli

### DIFF
--- a/node/impl/boost.go
+++ b/node/impl/boost.go
@@ -18,6 +18,7 @@ import (
 	"github.com/filecoin-project/boost/indexprovider"
 	"github.com/filecoin-project/boost/markets/storageadapter"
 	"github.com/filecoin-project/boost/node/modules/dtypes"
+	retmarket "github.com/filecoin-project/boost/retrievalmarket/server"
 	"github.com/filecoin-project/boost/storagemarket"
 	"github.com/filecoin-project/boost/storagemarket/sealingpipeline"
 	"github.com/filecoin-project/boost/storagemarket/types"
@@ -70,6 +71,9 @@ type BoostAPI struct {
 	RetrievalProvider retrievalmarket.RetrievalProvider
 	SectorAccessor    retrievalmarket.SectorAccessor
 	DealPublisher     *storageadapter.DealPublisher
+
+	// Graphsync Unpaid Retrieval
+	GraphsyncUnpaidRetrieval *retmarket.GraphsyncUnpaidRetrieval
 
 	// Sealing Pipeline API
 	Sps sealingpipeline.API

--- a/node/impl/boost_legacy.go
+++ b/node/impl/boost_legacy.go
@@ -55,8 +55,11 @@ func (sm *BoostAPI) MarketRestartDataTransfer(ctx context.Context, transferID da
 func (sm *BoostAPI) MarketCancelDataTransfer(ctx context.Context, transferID datatransfer.TransferID, otherPeer peer.ID, isInitiator bool) error {
 	selfPeer := sm.Host.ID()
 
-	// Unpaid retrievals
-	sm.GraphsyncUnpaidRetrieval.CancelTransfer(ctx, transferID, &otherPeer)
+	// Attempt to cancel unpaid first, if that succeeds, we're done
+	err := sm.GraphsyncUnpaidRetrieval.CancelTransfer(ctx, transferID, &otherPeer)
+	if err == nil {
+		return nil
+	}
 
 	// Legacy, paid retrievals
 	if isInitiator {

--- a/retrievalmarket/server/channelstate.go
+++ b/retrievalmarket/server/channelstate.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bytes"
+
 	datatransfer "github.com/filecoin-project/go-data-transfer"
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
 	"github.com/ipfs/go-cid"
@@ -16,6 +17,9 @@ type retrievalState struct {
 	cs   *channelState
 	mkts *retrievalmarket.ProviderDealState
 }
+
+func (r retrievalState) ChannelState() channelState                           { return *r.cs }
+func (r retrievalState) ProviderDealState() retrievalmarket.ProviderDealState { return *r.mkts }
 
 // channelState is immutable channel data plus mutable state
 type channelState struct {

--- a/retrievalmarket/server/gsunpaidretrieval.go
+++ b/retrievalmarket/server/gsunpaidretrieval.go
@@ -159,6 +159,16 @@ func (g *GraphsyncUnpaidRetrieval) CancelTransfer(ctx context.Context, id datatr
 	return nil
 }
 
+func (g *GraphsyncUnpaidRetrieval) List() []retrievalState {
+	values := make([]retrievalState, 0, len(g.activeRetrievals))
+
+	for _, value := range g.activeRetrievals {
+		values = append(values, *value)
+	}
+
+	return values
+}
+
 func (g *GraphsyncUnpaidRetrieval) RegisterIncomingRequestQueuedHook(hook graphsync.OnIncomingRequestQueuedHook) graphsync.UnregisterHookFunc {
 	return g.GraphExchange.RegisterIncomingRequestQueuedHook(func(p peer.ID, request graphsync.RequestData, hookActions graphsync.RequestQueuedHookActions) {
 		interceptRtvl, err := g.interceptRetrieval(p, request)


### PR DESCRIPTION
## Summary
This hooks up the GraphsyncUnpaidRetrieval server to the cli for managing data-transfers.

- `boostd retrieval-deals list` will currently not show GSUnpaidRetrievals that have completed(error or success) as they are no longer tracked. The records only exist in the retrieval log. Deals made with the old code path will continue to show in this list regardless of status.
```
$ boostd retrieval-deals list
Receiver                                              DealID               Payload      State               PricePerByte  BytesSent  Message
12D3KooWQqsi3sKKW6rbxgmH5MAuvvYi6LiCaxTKT7u4GMu3Qq1H  1678278198331351001  ...hgh7h452  DealStatusNew       0             0          
12D3KooWCUyu21tPs3Yzftfb4uzviYmACLyr9pxUVaB8cNGUJBvV  1678278198331388001  ...vhlvr5f2  DealStatusUnsealed  0             5125210    
12D3KooWNJVpqAUKx9bewRzn2rry92RU7Zj5RHfFxAAfcLJX6CY1  1678278198331698001  ...vcfyzzzy  DealStatusUnsealed  0             0          
12D3KooW9tGwFUTi3nWGYCSVoWqdGVzPEgtwFWQTqMkyUfYqwQsL  1678278198331902001  ...hzuuwsi6  DealStatusUnsealed  0             512305     
12D3KooWRo4ikirHQ85fPh7JDC1vRRWAy1wPZtBAjHPZP9zxsLhu  1678278198332135001  ...5x6agfvg  DealStatusUnsealed  0             5125210    

$ boostd retrieval-deals list
Receiver  DealID  Payload  State  PricePerByte  BytesSent  Message
```
- `boostd data-transfers list` works as expected:
```
# In progress unpaid retrievals
$ boostd data-transfers list
Sending Channels

ID                   Status     Sending To   Root Cid     Initiated?  Transferred  Voucher  
1678277603629198001  Ongoing    ...DTfHcPJL  ...hzuuwsi6  N           825.3KiB     null     
1678277603629231001  Ongoing    ...N7fXJBH7  ...5x6agfvg  N           4.888MiB     null     
1678277606304697001  Requested  ...zou5KEku  ...ckt4w6hm  N           0B           null 

Receiving Channels

# Retrieval finished
$ boostd data-transfers list
Sending Channels

Receiving Channels
```
- `boostd data-transfers cancel` successfully terminates a deal

TODO:
- [X] Testing and verification that all cli methods are covered
- [X] `boostd data-transfers cancel` works but is not polite for in progress transfers, this should try to send a graphsync cancel message before outright failing. Using lassie locally, this will cause the lassie retrieval to timeout after the cancel.