### PR TITLE
chore(ci): update deprecated mac resources

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,7 +121,7 @@ jobs:
   build-macos:
     description: build darwin boost binary
     macos:
-      xcode: "14.2.0"
+      xcode: "12.5.1"
     working_directory: ~/go/src/github.com/filecoin-project/boost
     resource_class: macos.x86.medium.gen2
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,9 +121,9 @@ jobs:
   build-macos:
     description: build darwin boost binary
     macos:
-      xcode: "12.5.1"
+      xcode: "14.2.0"
     working_directory: ~/go/src/github.com/filecoin-project/boost
-    resource_class: large
+    resource_class: macos.x86.medium.gen2
     steps:
       - prepare:
           linux: false


### PR DESCRIPTION
Mac medium and large resources are being deprecated so updating this now, https://discuss.circleci.com/t/macos-resource-deprecation-update/46891. The new large resource is available as an m1, but the runtime cost is 4x the current large, https://circleci.com/product/features/resource-classes/#macos, so moving this back to medium for the time being.

The current go install doesn't work on xcode 14 for some reason I haven't looked into, so postponing updating that for now.