### PR TITLE
removing libp2p-go-eventbus

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -77,7 +77,6 @@ require (
 	github.com/jbenet/go-random v0.0.0-20190219211222-123a90aedc0c
 	github.com/jpillora/backoff v1.0.0
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/libp2p/go-eventbus v0.2.1
 	github.com/libp2p/go-libp2p v0.23.4
 	github.com/libp2p/go-libp2p-gostream v0.5.0
 	github.com/libp2p/go-libp2p-http v0.2.1

--- a/go.sum
+++ b/go.sum
@@ -1067,7 +1067,6 @@ github.com/libp2p/go-conn-security-multistream v0.2.0/go.mod h1:hZN4MjlNetKD3Rq5
 github.com/libp2p/go-conn-security-multistream v0.2.1/go.mod h1:cR1d8gA0Hr59Fj6NhaTpFhJZrjSYuNmhpT2r25zYR70=
 github.com/libp2p/go-conn-security-multistream v0.3.0/go.mod h1:EEP47t4fw/bTelVmEzIDqSe69hO/ip52xBEhZMLWAHM=
 github.com/libp2p/go-eventbus v0.1.0/go.mod h1:vROgu5cs5T7cv7POWlWxBaVLxfSegC5UGQf8A2eEmx4=
-github.com/libp2p/go-eventbus v0.2.1 h1:VanAdErQnpTioN2TowqNcOijf6YwhuODe4pPKSDpxGc=
 github.com/libp2p/go-eventbus v0.2.1/go.mod h1:jc2S4SoEVPP48H9Wpzm5aiGwUCBMfGhVhhBjyhhCJs8=
 github.com/libp2p/go-flow-metrics v0.0.1/go.mod h1:Iv1GH0sG8DtYN3SVJ2eG221wMiNpZxBdp967ls1g+k8=
 github.com/libp2p/go-flow-metrics v0.0.2/go.mod h1:HeoSNUrOJVK1jEpDqVEiUOIXqhbnS27omG0uWU5slZs=

--- a/storagemarket/deal_handler.go
+++ b/storagemarket/deal_handler.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/filecoin-project/boost/storagemarket/types"
 	"github.com/google/uuid"
-	"github.com/libp2p/go-eventbus"
 	"github.com/libp2p/go-libp2p/core/event"
+	"github.com/libp2p/go-libp2p/p2p/host/eventbus"
 	"go.uber.org/atomic"
 )
 

--- a/storagemarket/newdealps.go
+++ b/storagemarket/newdealps.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/filecoin-project/boost/storagemarket/types"
-	"github.com/libp2p/go-eventbus"
 	"github.com/libp2p/go-libp2p/core/event"
+	"github.com/libp2p/go-libp2p/p2p/host/eventbus"
 )
 
 // newDealPS provides a nicer interface to keep track of "new deal" events


### PR DESCRIPTION
## Problem

https://github.com/filecoin-project/boost/issues/1303

github.com/libp2p/go-eventbus is deprecated and should boost should be using github.com/libp2p/go-libp2p/p2p/host/eventbus instead.

## Solution

- [X] updating the packages from `github.com/libp2p/go-eventbus`  to `github.com/libp2p/go-libp2p/p2p/host/eventbus`
- [X] call `go mod tidy` 
- [X] confirmed build worked

# Description

this helps with removing references to `go-libp2p-core` in dependencies:

```
> go mod graph | grep libp2p-core

....
github.com/libp2p/go-eventbus@v0.2.1 github.com/libp2p/go-libp2p-core@v0.5.7
....
```