### PR TITLE
Set user agent from boost build version instead of lotus

### DIFF
--- a/node/builder.go
+++ b/node/builder.go
@@ -105,6 +105,7 @@ var (
 	ConnGaterKey         = special{12} // libp2p option
 	DAGStoreKey          = special{13} // constructor returns multiple values
 	ResourceManagerKey   = special{14} // Libp2p option
+	UserAgentKey         = special{15} // Libp2p option
 )
 
 type invoke int
@@ -227,6 +228,8 @@ var LibP2P = Options(
 	Override(SmuxTransportKey, lotus_lp2p.SmuxTransport()),
 	Override(RelayKey, lotus_lp2p.NoRelay()),
 	Override(SecurityKey, lotus_lp2p.Security(true, false)),
+	Override(DefaultTransportsKey, lp2p.DefaultTransports),
+	Override(UserAgentKey, modules.UserAgent),
 
 	// Host
 	Override(new(lotus_lp2p.RawHost), lotus_lp2p.Host),

--- a/node/modules/lp2p.go
+++ b/node/modules/lp2p.go
@@ -1,0 +1,16 @@
+package modules
+
+import (
+	"github.com/filecoin-project/boost/build"
+	"github.com/filecoin-project/lotus/node/modules/lp2p"
+	"github.com/libp2p/go-libp2p"
+)
+
+func simpleOpt(opt libp2p.Option) func() (opts lp2p.Libp2pOpts, err error) {
+	return func() (opts lp2p.Libp2pOpts, err error) {
+		opts.Opts = append(opts.Opts, opt)
+		return
+	}
+}
+
+var UserAgent = simpleOpt(libp2p.UserAgent("boost-" + build.UserVersion()))


### PR DESCRIPTION
TODO:
- [x] Test on devnet

```
$ boost provider libp2p-info t01000
Provider: t01000
Agent: boost-1.6.1-rc1
...
````