### PR TITLE
fix(devnet): update golang and lotus default versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,7 +200,7 @@ docsgen-openrpc-boost: docsgen-openrpc-bin
 
 ## DOCKER IMAGES
 docker_user?=filecoin
-lotus_version?=v1.20.0-rc1
+lotus_version?=v1.21.0-rc2
 ffi_from_source?=0
 build_lotus?=0
 ifeq ($(build_lotus),1)
@@ -226,7 +226,7 @@ $(lotus_src_dir):
 	git clone --depth 1 --branch $(lotus_version) https://github.com/filecoin-project/lotus $@
 update/lotus: $(lotus_src_dir)
 	cd $(lotus_src_dir) && git pull
-.PHONY: update/lotus	
+.PHONY: update/lotus
 
 docker/lotus-all-in-one: info/lotus-all-in-one | $(lotus_src_dir)
 	cd $(lotus_src_dir) && $(docker_build_cmd) -f Dockerfile --target lotus-all-in-one \

--- a/docker/devnet/.env-stable
+++ b/docker/devnet/.env-stable
@@ -1,5 +1,0 @@
-DOCKER_USER=filecoin
-LOTUS_IMAGE=${DOCKER_USER}/lotus-dev:1.17.1-rc2
-LOTUS_MINER_IMAGE=${DOCKER_USER}/lotus-miner-dev:1.17.1-rc2
-BOOST_IMAGE=${DOCKER_USER}/boost-dev:1.3.0-rc1
-BOOST_GUI_IMAGE=${DOCKER_USER}/boost-gui:1.3.0-rc1

--- a/docker/devnet/Dockerfile.source
+++ b/docker/devnet/Dockerfile.source
@@ -13,7 +13,7 @@ COPY gql /src/gql
 RUN npm_config_legacy_peer_deps=yes npm ci --no-audit --prefix react&& \
       npm run --prefix react build
 #########################################################################################
-FROM golang:1.18-bullseye as builder
+FROM golang:1.19-bullseye as builder
 
 RUN apt update && apt install -y \
       build-essential \
@@ -89,7 +89,7 @@ WORKDIR /app
 COPY --from=lotus-test /usr/local/bin/lotus /usr/local/bin/
 COPY --from=lotus-test /usr/local/bin/lotus-miner /usr/local/bin/
 ## Test lotus starts
-RUN lotus -v && lotus-miner -v 
+RUN lotus -v && lotus-miner -v
 #########################################################################################
 FROM runner as boost-dev
 
@@ -103,18 +103,18 @@ LABEL org.opencontainers.image.version=$BUILD_VERSION \
       version=$BUILD_VERSION \
       release=$BUILD_VERSION \
       summary="This image is used to host the boost-dev storage provider" \
-      description="This image is used to host the boost-dev storage provider" 
+      description="This image is used to host the boost-dev storage provider"
 
 ENV BOOST_PATH /var/lib/boost
 VOLUME /var/lib/boost
-EXPOSE 8080  
+EXPOSE 8080
 
 COPY --from=builder /go/src/boostd /usr/local/bin/
 COPY --from=builder /go/src/boost /usr/local/bin/
 COPY --from=builder /go/src/boostx /usr/local/bin/
 COPY docker/devnet/boost/entrypoint.sh /app/
 COPY docker/devnet/boost/sample/* /app/sample/
-RUN boost -v 
+RUN boost -v
 
 ENTRYPOINT ["./entrypoint.sh"]
 #########################################################################################
@@ -130,9 +130,9 @@ LABEL org.opencontainers.image.version=$BUILD_VERSION \
       version=$BUILD_VERSION \
       release=$BUILD_VERSION \
       summary="This image is used to host booster-http-dev" \
-      description="This image is used to host booster-http-dev" 
+      description="This image is used to host booster-http-dev"
 
-EXPOSE 7777  
+EXPOSE 7777
 
 COPY --from=builder /go/src/boostd /usr/local/bin/
 COPY --from=builder /go/src/booster-http /usr/local/bin/
@@ -152,7 +152,7 @@ LABEL org.opencontainers.image.version=$BUILD_VERSION \
       version=$BUILD_VERSION \
       release=$BUILD_VERSION \
       summary="This image is used to host booster-bitswap-dev" \
-      description="This image is used to host booster-bitswap-dev" 
+      description="This image is used to host booster-bitswap-dev"
 
 EXPOSE 8888
 


### PR DESCRIPTION
The devnet build was breaking after https://github.com/filecoin-project/boost/pull/1333, this PR just bumps to golang 1.19 to stay inline with the golang version in boost go.mod.

* Also bump default lotus to latest v1.21 rc
* Removes the unused and outdated .env-stable file for devnet