### PR TITLE
fix: correct link for download root block

### DIFF
--- a/react/src/Inspect.js
+++ b/react/src/Inspect.js
@@ -160,7 +160,7 @@ function PieceStatus({pieceCid, pieceStatus, searchQuery}) {
                         <th>Data Root CID</th>
                         <td>
                             <span>{rootCid}</span>
-                            <a className="download" target="_blank" href={"/download/block/"+searchQuery}>
+                            <a className="download" target="_blank" href={"/download/block/"+rootCid}>
                                 Download block
                             </a>
                         </td>


### PR DESCRIPTION
This fixes the rendered HTML to use the correct root cid block, when the root cid is show on the inspect page. Previously whatever the search query was (piece cid, root cid, or payload cid) would be used.

Screenshot of the correct html, you can see the label and cid url match

![Screenshot 2023-04-06 at 12 41 41 PM](https://user-images.githubusercontent.com/639834/230354288-736c0d1a-e0cc-4cbb-a4af-a2e3a45c6919.png)