### PR TITLE
group agent version by binary name

### DIFF
--- a/cmd/boostx/stats_cmd.go
+++ b/cmd/boostx/stats_cmd.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/filecoin-project/boost/retrievalmarket/lp2pimpl"
 	transports_types "github.com/filecoin-project/boost/retrievalmarket/types"
+	"regexp"
 	"sort"
 	"strings"
 	"sync"
@@ -152,6 +153,7 @@ var statsCmd = &cli.Command{
 					if !ok {
 						return fmt.Errorf("AgentVersion for peer %s is not a string: type %T", addrInfo.ID, agentVersionI)
 					}
+					agentVersionShort := shortAgentVersion(agentVersion)
 
 					// Get SP's supported transports
 					var transports *transports_types.QueryResponse
@@ -172,7 +174,7 @@ var statsCmd = &cli.Command{
 						boostNodes++
 						boostQualityAdjPower = big.Add(boostQualityAdjPower, minerToMinerPower[maddr].QualityAdjPower)
 						boostRawBytePower = big.Add(boostRawBytePower, minerToMinerPower[maddr].RawBytePower)
-						agentVersions[agentVersion]++
+						agentVersions[agentVersionShort]++
 						if transports != nil {
 							for _, p := range transports.Protocols {
 								transportProtos[p.Name]++
@@ -180,7 +182,7 @@ var statsCmd = &cli.Command{
 						}
 					} else if contains(protostrs, "/fil/storage/mk/1.1.0") {
 						out += " is running markets"
-						agentVersions[agentVersion]++
+						agentVersions[agentVersionShort]++
 						marketsNodes++
 					} else {
 						out += " is not running markets or boost"
@@ -257,4 +259,10 @@ func contains(sl []string, substr string) bool {
 	}
 
 	return false
+}
+
+var agentVersionRegExp = regexp.MustCompile(`^(.+)\+.+$`)
+
+func shortAgentVersion(av string) string {
+	return agentVersionRegExp.ReplaceAllString(av, "$1")
 }

--- a/cmd/boostx/stats_cmd_test.go
+++ b/cmd/boostx/stats_cmd_test.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestAgentVersion(t *testing.T) {
+	testCases := map[string]string{
+		"lotus-1.20.0+gzbt+git.cddeab21d.dirty": "lotus-1.20.0+gzbt",
+		"boost-1.6.1+git.4931e18":               "boost-1.6.1",
+		"boost-1.6.2-rc1+git.0b5cf47.dirty":     "boost-1.6.2-rc1",
+		"lotus-1.20.0":                          "lotus-1.20.0",
+	}
+	for agentVersion, exp := range testCases {
+		agentVersionShort := shortAgentVersion(agentVersion)
+		require.Equal(t, exp, agentVersionShort)
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/filecoin-project/boost/issues/1361

- [x] Test in prod

```
$ ./boostx stats --sp-query-concurrency=10 --sp-query-max=500
...

Total Boost nodes: 43
Total Boost raw power: 99173234406064128
Total Boost quality adj power: 435450019682222080
Total Lotus Markets nodes: 69
Total SPs with minimum power:  3542
Total Indexer nodes: 96
Agent Versions:
  boost-1.6.1: 3
  boost-1.6.2-rc2: 1
  lotus-1.17.2-dev+mainnet: 4
  ...
  lotus-1.20.6: 1
  lotus-1.21.0-rc2+mainnet: 2
  lotus-lianjing-kwj 1.20.0+mainnet: 1
  venus-marketv2.5.0: 1
  venus-marketv2.6.0: 6
Retrieval Protocol Support:
  bitswap: 3
  http: 2
  libp2p: 43

```