### PR TITLE
fix: make devnet work for lid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,14 @@
 /boost
 /boostx
 /boostd
+/boostd-data
 /devnet
 /booster-http
 /booster-bitswap
 /docgen-md
 /docgen-openrpc
 extern/filecoin-ffi/rust/target
+extern/boostd-data/boostd-data
 **/*.a
 **/*.pc
 /**/*/.DS_STORE

--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,12 @@ boost: $(BUILD_DEPS)
 .PHONY: boost
 BINS+=boost boostx boostd
 
+boostd-data:
+	$(MAKE) -C ./extern/boostd-data
+	install -C ./extern/boostd-data/boostd-data ./boostd-data
+.PHONY: boostd-data
+BINS+=boostd-data
+
 booster-http: $(BUILD_DEPS)
 	rm -f booster-http
 	$(GOCC) build $(GOFLAGS) -o booster-http ./cmd/booster-http
@@ -141,6 +147,7 @@ install-boost:
 	install -C ./boost /usr/local/bin/boost
 	install -C ./boostd /usr/local/bin/boostd
 	install -C ./boostx /usr/local/bin/boostx
+	install -C ./extern/boostd-data /usr/local/bin/boostd-data
 
 install-devnet:
 	install -C ./devnet /usr/local/bin/devnet

--- a/docker/devnet/Dockerfile.source
+++ b/docker/devnet/Dockerfile.source
@@ -72,7 +72,7 @@ COPY --from=react-builder /src/react/build /go/src/react/build
 
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
-      make debug booster-http booster-bitswap
+      make debug boostd-data booster-http booster-bitswap
 #########################################################################################
 FROM ubuntu:20.04 as runner
 
@@ -112,6 +112,7 @@ EXPOSE 8080
 COPY --from=builder /go/src/boostd /usr/local/bin/
 COPY --from=builder /go/src/boost /usr/local/bin/
 COPY --from=builder /go/src/boostx /usr/local/bin/
+COPY --from=builder /go/src/boostd-data /usr/local/bin/
 COPY docker/devnet/boost/entrypoint.sh /app/
 COPY docker/devnet/boost/sample/* /app/sample/
 RUN boost -v

--- a/docker/devnet/boost/entrypoint.sh
+++ b/docker/devnet/boost/entrypoint.sh
@@ -73,5 +73,10 @@ if [ ! -f $BOOST_PATH/.register.boost ]; then
 	echo Super. DONE! Boostd is now configured and will be started soon
 fi
 
-echo Starting boost in dev mode...
-exec boostd -vv run --nosync=true
+## Override config options
+echo Updating config values
+sed -i 's|ServiceApiInfo = ""|ServiceApiInfo = "http://localhost:8042"|g' $BOOST_PATH/config.toml
+
+echo Starting LID service and boost in dev mode...
+trap 'kill %1' SIGINT
+exec boostd-data run leveldb --addr=0.0.0.0:8042 & boostd -vv run --nosync=true

--- a/docker/devnet/booster-bitswap/entrypoint.sh
+++ b/docker/devnet/booster-bitswap/entrypoint.sh
@@ -3,11 +3,10 @@ set -e
 
 export FULLNODE_API_INFO=`lotus auth api-info --perm=admin | cut -f2 -d=`
 export MINER_API_INFO=`lotus-miner auth api-info --perm=admin | cut -f2 -d=`
-export BOOST_API_INFO=`boostd auth api-info --perm=admin | cut -f2 -d=`
 
 echo $FULLNODE_API_INFO
 echo $MINER_API_INFO
-echo $BOOST_API_INFO
+echo $LID_API_INFO
 echo $BOOSTER_BITSWAP_REPO
 
 if [ ! -f $BOOSTER_BITSWAP_REPO/.init.booster-bitswap ]; then
@@ -21,4 +20,4 @@ fi
 
 echo Starting booster-bitswap...
 export GOLOG_LOG_LEVEL=remote-blockstore=debug,booster=debug,engine=debug,bitswap-server=debug
-exec booster-bitswap --vv run --api-boost=$BOOST_API_INFO --tracing --engine-blockstore-worker-count=64 --engine-task-worker-count=64 --max-outstanding-bytes-per-peer=8388608 --target-message-size=524288 --task-worker-count=64
+exec booster-bitswap --vv run --api-lid=$LID_API_INFO --api-fullnode=$FULLNODE_API_INFO --api-storage=$MINER_API_INFO --tracing --engine-blockstore-worker-count=64 --engine-task-worker-count=64 --max-outstanding-bytes-per-peer=8388608 --target-message-size=524288 --task-worker-count=64

--- a/docker/devnet/booster-http/entrypoint.sh
+++ b/docker/devnet/booster-http/entrypoint.sh
@@ -3,11 +3,10 @@ set -e
 
 export FULLNODE_API_INFO=`lotus auth api-info --perm=admin | cut -f2 -d=`
 export MINER_API_INFO=`lotus-miner auth api-info --perm=admin | cut -f2 -d=`
-export BOOST_API_INFO=`boostd auth api-info --perm=admin | cut -f2 -d=`
 
 echo $FULLNODE_API_INFO
 echo $MINER_API_INFO
-echo $BOOST_API_INFO
+echo $LID_API_INFO
 
 echo Starting booster-http...
-exec booster-http run --api-boost=$BOOST_API_INFO --api-fullnode=$FULLNODE_API_INFO --api-storage=$MINER_API_INFO --tracing
+exec booster-http run --serve-files=true --api-lid=$LID_API_INFO  --api-fullnode=$FULLNODE_API_INFO --api-storage=$MINER_API_INFO --tracing

--- a/docker/devnet/docker-compose.yaml
+++ b/docker/devnet/docker-compose.yaml
@@ -78,6 +78,7 @@ services:
       - "7777:7777"
     environment:
       - BOOST_PATH=/var/lib/boost
+      - LID_API_INFO=http://boost:8042
       - LOTUS_PATH=/var/lib/lotus
       - LOTUS_MINER_PATH=/var/lib/lotus-miner
     restart: unless-stopped
@@ -98,6 +99,7 @@ services:
     environment:
       - BOOSTER_BITSWAP_REPO=/var/lib/booster-bitswap
       - BOOST_PATH=/var/lib/boost
+      - LID_API_INFO=http://boost:8042
       - LOTUS_PATH=/var/lib/lotus
       - LOTUS_MINER_PATH=/var/lib/lotus-miner
     restart: unless-stopped

--- a/extern/boostd-data/cmd/run.go
+++ b/extern/boostd-data/cmd/run.go
@@ -3,13 +3,14 @@ package main
 import (
 	"context"
 	"fmt"
+	"net/http"
+
 	"github.com/filecoin-project/boostd-data/couchbase"
 	"github.com/filecoin-project/boostd-data/shared/cliutil"
 	"github.com/filecoin-project/boostd-data/shared/tracing"
 	"github.com/filecoin-project/boostd-data/svc"
 	"github.com/mitchellh/go-homedir"
 	"github.com/urfave/cli/v2"
-	"net/http"
 )
 
 var runCmd = &cli.Command{
@@ -21,10 +22,10 @@ var runCmd = &cli.Command{
 }
 
 var runFlags = []cli.Flag{
-	&cli.UintFlag{
-		Name:  "port",
-		Usage: "the port the boostd-data listens on",
-		Value: 8042,
+	&cli.StringFlag{
+		Name:  "addr",
+		Usage: "the address the boostd-data listens on",
+		Value: "localhost:8042",
 	},
 	&cli.BoolFlag{
 		Name:  "pprof",
@@ -130,14 +131,14 @@ func runAction(cctx *cli.Context, dbType string, store *svc.Service) error {
 	}
 
 	// Start the server
-	port := cctx.Int("port")
-	err = store.Start(ctx, port)
+	addr := cctx.String("addr")
+	err = store.Start(ctx, addr)
 	if err != nil {
 		return fmt.Errorf("starting %s store: %w", dbType, err)
 	}
 
-	log.Infof("Started boostd-data %s service on port %d",
-		dbType, port)
+	log.Infof("Started boostd-data %s service on address %s",
+		dbType, addr)
 
 	// Monitor for shutdown.
 	<-ctx.Done()

--- a/extern/boostd-data/couchbase/db.go
+++ b/extern/boostd-data/couchbase/db.go
@@ -478,7 +478,7 @@ func (db *DB) GetPieceCidToMetadata(ctx context.Context, pieceCid cid.Cid) (Couc
 // GetOffsetSize gets the offset and size of the multihash in the given piece.
 // Note that recordCount is needed in order to determine which shard the multihash is in.
 func (db *DB) GetOffsetSize(ctx context.Context, pieceCid cid.Cid, hash multihash.Multihash, recordCount int) (*model.OffsetSize, error) {
-	ctx, span := tracing.Tracer.Start(ctx, "db.get_offset_size")
+	_, span := tracing.Tracer.Start(ctx, "db.get_offset_size")
 	defer span.End()
 
 	// Get the prefix for the shard that the multihash is in
@@ -1161,7 +1161,7 @@ func (db *DB) RemoveDealForPiece(ctx context.Context, dealId string, pieceCid ci
 		// Remove Metadata if removed deal was last one
 		if len(metadata.Deals) == 0 {
 			if err := db.RemovePieceMetadata(ctx, pieceCid); err != nil {
-				fmt.Errorf("Failed to remove the Metadata after removing the last deal: %w", err)
+				return fmt.Errorf("failed to remove the Metadata after removing the last deal: %w", err)
 			}
 			return nil
 		}

--- a/extern/boostd-data/couchbase/service.go
+++ b/extern/boostd-data/couchbase/service.go
@@ -46,11 +46,11 @@ func (s *Store) Start(ctx context.Context) error {
 func (s *Store) AddDealForPiece(ctx context.Context, pieceCid cid.Cid, dealInfo model.DealInfo) error {
 	log.Debugw("handle.add-deal-for-piece", "piece-cid", pieceCid)
 
-	ctx, span := tracing.Tracer.Start(context.Background(), "store.add_deal_for_piece")
+	ctx, span := tracing.Tracer.Start(ctx, "store.add_deal_for_piece")
 	defer span.End()
 
 	defer func(now time.Time) {
-		log.Debugw("handled.add-deal-for-piece", "took", fmt.Sprintf("%s", time.Since(now)))
+		log.Debugw("handled.add-deal-for-piece", "took", time.Since(now))
 	}(time.Now())
 
 	return s.db.AddDealForPiece(ctx, pieceCid, dealInfo)
@@ -59,11 +59,11 @@ func (s *Store) AddDealForPiece(ctx context.Context, pieceCid cid.Cid, dealInfo 
 func (s *Store) SetCarSize(ctx context.Context, pieceCid cid.Cid, size uint64) error {
 	log.Debugw("handle.set-car-size", "piece-cid", pieceCid, "size", size)
 
-	ctx, span := tracing.Tracer.Start(context.Background(), "store.set-car-size")
+	ctx, span := tracing.Tracer.Start(ctx, "store.set-car-size")
 	defer span.End()
 
 	defer func(now time.Time) {
-		log.Debugw("handled.set-car-size", "took", fmt.Sprintf("%s", time.Since(now)))
+		log.Debugw("handled.set-car-size", "took", time.Since(now))
 	}(time.Now())
 
 	err := s.db.SetCarSize(ctx, pieceCid, size)
@@ -77,7 +77,7 @@ func (s *Store) MarkIndexErrored(ctx context.Context, pieceCid cid.Cid, idxErr s
 	defer span.End()
 
 	defer func(now time.Time) {
-		log.Debugw("handled.mark-piece-index-errored", "took", fmt.Sprintf("%s", time.Since(now)))
+		log.Debugw("handled.mark-piece-index-errored", "took", time.Since(now))
 	}(time.Now())
 
 	err := s.db.MarkIndexErrored(ctx, pieceCid, errors.New(idxErr))
@@ -95,7 +95,7 @@ func (s *Store) GetOffsetSize(ctx context.Context, pieceCid cid.Cid, hash mh.Mul
 	defer span.End()
 
 	defer func(now time.Time) {
-		log.Debugw("handled.get-offset-size", "took", fmt.Sprintf("%s", time.Since(now)))
+		log.Debugw("handled.get-offset-size", "took", time.Since(now))
 	}(time.Now())
 
 	md, err := s.db.GetPieceCidToMetadata(ctx, pieceCid)
@@ -115,7 +115,7 @@ func (s *Store) GetPieceMetadata(ctx context.Context, pieceCid cid.Cid) (model.M
 	defer span.End()
 
 	defer func(now time.Time) {
-		log.Debugw("handled.get-piece-metadata", "took", fmt.Sprintf("%s", time.Since(now)))
+		log.Debugw("handled.get-piece-metadata", "took", time.Since(now))
 	}(time.Now())
 
 	md, err := s.db.GetPieceCidToMetadata(ctx, pieceCid)
@@ -134,7 +134,7 @@ func (s *Store) GetPieceDeals(ctx context.Context, pieceCid cid.Cid) ([]model.De
 	defer span.End()
 
 	defer func(now time.Time) {
-		log.Debugw("handled.get-piece-deals", "took", fmt.Sprintf("%s", time.Since(now)))
+		log.Debugw("handled.get-piece-deals", "took", time.Since(now))
 	}(time.Now())
 
 	md, err := s.db.GetPieceCidToMetadata(ctx, pieceCid)
@@ -154,7 +154,7 @@ func (s *Store) PiecesContainingMultihash(ctx context.Context, m mh.Multihash) (
 	defer span.End()
 
 	defer func(now time.Time) {
-		log.Debugw("handled.pieces-containing-mh", "took", fmt.Sprintf("%s", time.Since(now)))
+		log.Debugw("handled.pieces-containing-mh", "took", time.Since(now))
 	}(time.Now())
 
 	pcids, err := s.db.GetPieceCidsByMultihash(ctx, m)
@@ -168,7 +168,7 @@ func (s *Store) GetIndex(ctx context.Context, pieceCid cid.Cid) ([]model.Record,
 	defer span.End()
 
 	defer func(now time.Time) {
-		log.Debugw("handled.get-index", "took", fmt.Sprintf("%s", time.Since(now)))
+		log.Debugw("handled.get-index", "took", time.Since(now))
 	}(time.Now())
 
 	md, err := s.db.GetPieceCidToMetadata(ctx, pieceCid)
@@ -203,7 +203,7 @@ func (s *Store) IsCompleteIndex(ctx context.Context, pieceCid cid.Cid) (bool, er
 	defer span.End()
 
 	defer func(now time.Time) {
-		log.Debugw("handled.is-complete-index", "took", fmt.Sprintf("%s", time.Since(now)))
+		log.Debugw("handled.is-complete-index", "took", time.Since(now))
 	}(time.Now())
 
 	md, err := s.db.GetPieceCidToMetadata(ctx, pieceCid)
@@ -255,7 +255,7 @@ func (s *Store) IndexedAt(ctx context.Context, pieceCid cid.Cid) (time.Time, err
 	defer span.End()
 
 	defer func(now time.Time) {
-		log.Debugw("handled.indexed-at", "took", fmt.Sprintf("%s", time.Since(now)))
+		log.Debugw("handled.indexed-at", "took", time.Since(now))
 	}(time.Now())
 
 	md, err := s.db.GetPieceCidToMetadata(ctx, pieceCid)
@@ -273,7 +273,7 @@ func (s *Store) ListPieces(ctx context.Context) ([]cid.Cid, error) {
 	defer span.End()
 
 	defer func(now time.Time) {
-		log.Debugw("handled.list-pieces", "took", fmt.Sprintf("%s", time.Since(now)))
+		log.Debugw("handled.list-pieces", "took", time.Since(now))
 	}(time.Now())
 
 	return s.db.ListPieces(ctx)

--- a/extern/boostd-data/couchbase/service.go
+++ b/extern/boostd-data/couchbase/service.go
@@ -50,7 +50,7 @@ func (s *Store) AddDealForPiece(ctx context.Context, pieceCid cid.Cid, dealInfo 
 	defer span.End()
 
 	defer func(now time.Time) {
-		log.Debugw("handled.add-deal-for-piece", "took", time.Since(now))
+		log.Debugw("handled.add-deal-for-piece", "took", time.Since(now).String())
 	}(time.Now())
 
 	return s.db.AddDealForPiece(ctx, pieceCid, dealInfo)
@@ -63,7 +63,7 @@ func (s *Store) SetCarSize(ctx context.Context, pieceCid cid.Cid, size uint64) e
 	defer span.End()
 
 	defer func(now time.Time) {
-		log.Debugw("handled.set-car-size", "took", time.Since(now))
+		log.Debugw("handled.set-car-size", "took", time.Since(now).String())
 	}(time.Now())
 
 	err := s.db.SetCarSize(ctx, pieceCid, size)
@@ -77,7 +77,7 @@ func (s *Store) MarkIndexErrored(ctx context.Context, pieceCid cid.Cid, idxErr s
 	defer span.End()
 
 	defer func(now time.Time) {
-		log.Debugw("handled.mark-piece-index-errored", "took", time.Since(now))
+		log.Debugw("handled.mark-piece-index-errored", "took", time.Since(now).String())
 	}(time.Now())
 
 	err := s.db.MarkIndexErrored(ctx, pieceCid, errors.New(idxErr))
@@ -95,7 +95,7 @@ func (s *Store) GetOffsetSize(ctx context.Context, pieceCid cid.Cid, hash mh.Mul
 	defer span.End()
 
 	defer func(now time.Time) {
-		log.Debugw("handled.get-offset-size", "took", time.Since(now))
+		log.Debugw("handled.get-offset-size", "took", time.Since(now).String())
 	}(time.Now())
 
 	md, err := s.db.GetPieceCidToMetadata(ctx, pieceCid)
@@ -115,7 +115,7 @@ func (s *Store) GetPieceMetadata(ctx context.Context, pieceCid cid.Cid) (model.M
 	defer span.End()
 
 	defer func(now time.Time) {
-		log.Debugw("handled.get-piece-metadata", "took", time.Since(now))
+		log.Debugw("handled.get-piece-metadata", "took", time.Since(now).String())
 	}(time.Now())
 
 	md, err := s.db.GetPieceCidToMetadata(ctx, pieceCid)
@@ -134,7 +134,7 @@ func (s *Store) GetPieceDeals(ctx context.Context, pieceCid cid.Cid) ([]model.De
 	defer span.End()
 
 	defer func(now time.Time) {
-		log.Debugw("handled.get-piece-deals", "took", time.Since(now))
+		log.Debugw("handled.get-piece-deals", "took", time.Since(now).String())
 	}(time.Now())
 
 	md, err := s.db.GetPieceCidToMetadata(ctx, pieceCid)
@@ -154,7 +154,7 @@ func (s *Store) PiecesContainingMultihash(ctx context.Context, m mh.Multihash) (
 	defer span.End()
 
 	defer func(now time.Time) {
-		log.Debugw("handled.pieces-containing-mh", "took", time.Since(now))
+		log.Debugw("handled.pieces-containing-mh", "took", time.Since(now).String())
 	}(time.Now())
 
 	pcids, err := s.db.GetPieceCidsByMultihash(ctx, m)
@@ -168,7 +168,7 @@ func (s *Store) GetIndex(ctx context.Context, pieceCid cid.Cid) ([]model.Record,
 	defer span.End()
 
 	defer func(now time.Time) {
-		log.Debugw("handled.get-index", "took", time.Since(now))
+		log.Debugw("handled.get-index", "took", time.Since(now).String())
 	}(time.Now())
 
 	md, err := s.db.GetPieceCidToMetadata(ctx, pieceCid)
@@ -203,7 +203,7 @@ func (s *Store) IsCompleteIndex(ctx context.Context, pieceCid cid.Cid) (bool, er
 	defer span.End()
 
 	defer func(now time.Time) {
-		log.Debugw("handled.is-complete-index", "took", time.Since(now))
+		log.Debugw("handled.is-complete-index", "took", time.Since(now).String())
 	}(time.Now())
 
 	md, err := s.db.GetPieceCidToMetadata(ctx, pieceCid)
@@ -255,7 +255,7 @@ func (s *Store) IndexedAt(ctx context.Context, pieceCid cid.Cid) (time.Time, err
 	defer span.End()
 
 	defer func(now time.Time) {
-		log.Debugw("handled.indexed-at", "took", time.Since(now))
+		log.Debugw("handled.indexed-at", "took", time.Since(now).String())
 	}(time.Now())
 
 	md, err := s.db.GetPieceCidToMetadata(ctx, pieceCid)
@@ -273,7 +273,7 @@ func (s *Store) ListPieces(ctx context.Context) ([]cid.Cid, error) {
 	defer span.End()
 
 	defer func(now time.Time) {
-		log.Debugw("handled.list-pieces", "took", time.Since(now))
+		log.Debugw("handled.list-pieces", "took", time.Since(now).String())
 	}(time.Now())
 
 	return s.db.ListPieces(ctx)

--- a/extern/boostd-data/ldb/db.go
+++ b/extern/boostd-data/ldb/db.go
@@ -321,7 +321,7 @@ func (db *DB) MarkIndexErrored(ctx context.Context, pieceCid cid.Cid, sourceErr 
 		return nil
 	}
 
-	md.Error = err.Error()
+	md.Error = sourceErr.Error()
 	md.ErrorType = fmt.Sprintf("%T", sourceErr)
 
 	return db.SetPieceCidToMetadata(ctx, pieceCid, md)

--- a/extern/boostd-data/ldb/db.go
+++ b/extern/boostd-data/ldb/db.go
@@ -307,7 +307,7 @@ func (db *DB) SetCarSize(ctx context.Context, pieceCid cid.Cid, size uint64) err
 	return db.SetPieceCidToMetadata(ctx, pieceCid, md)
 }
 
-func (db *DB) MarkIndexErrored(ctx context.Context, pieceCid cid.Cid, err error) error {
+func (db *DB) MarkIndexErrored(ctx context.Context, pieceCid cid.Cid, sourceErr error) error {
 	ctx, span := tracing.Tracer.Start(ctx, "db.mark_piece_index_errored")
 	defer span.End()
 
@@ -322,7 +322,7 @@ func (db *DB) MarkIndexErrored(ctx context.Context, pieceCid cid.Cid, err error)
 	}
 
 	md.Error = err.Error()
-	md.ErrorType = fmt.Sprintf("%T", err)
+	md.ErrorType = fmt.Sprintf("%T", sourceErr)
 
 	return db.SetPieceCidToMetadata(ctx, pieceCid, md)
 }
@@ -360,7 +360,7 @@ func (db *DB) AllRecords(ctx context.Context, cursor uint64) ([]model.Record, er
 		kcid := cid.NewCidV1(cid.Raw, m)
 
 		offset, n := binary.Uvarint(r.Value)
-		size, n := binary.Uvarint(r.Value[n:])
+		size, _ := binary.Uvarint(r.Value[n:])
 
 		records = append(records, model.Record{
 			Cid: kcid,
@@ -401,7 +401,7 @@ func (db *DB) GetOffsetSize(ctx context.Context, cursorPrefix string, m multihas
 	}
 
 	offset, n := binary.Uvarint(b)
-	size, n := binary.Uvarint(b[n:])
+	size, _ := binary.Uvarint(b[n:])
 	return &model.OffsetSize{
 		Offset: offset,
 		Size:   size,

--- a/extern/boostd-data/ldb/service.go
+++ b/extern/boostd-data/ldb/service.go
@@ -12,7 +12,6 @@ import (
 	"github.com/filecoin-project/boostd-data/shared/tracing"
 	"github.com/filecoin-project/boostd-data/svc/types"
 	"github.com/ipfs/go-cid"
-	"github.com/ipfs/go-datastore"
 	ds "github.com/ipfs/go-datastore"
 	logging "github.com/ipfs/go-log/v2"
 	carindex "github.com/ipld/go-car/v2/index"
@@ -87,7 +86,7 @@ func (s *Store) AddDealForPiece(ctx context.Context, pieceCid cid.Cid, dealInfo 
 	defer span.End()
 
 	defer func(now time.Time) {
-		log.Debugw("handled.add-deal-for-piece", "took", fmt.Sprintf("%s", time.Since(now)))
+		log.Debugw("handled.add-deal-for-piece", "took", time.Since(now))
 	}(time.Now())
 
 	s.Lock()
@@ -125,11 +124,11 @@ func (s *Store) AddDealForPiece(ctx context.Context, pieceCid cid.Cid, dealInfo 
 func (s *Store) SetCarSize(ctx context.Context, pieceCid cid.Cid, size uint64) error {
 	log.Debugw("handle.set-car-size", "piece-cid", pieceCid, "size", size)
 
-	ctx, span := tracing.Tracer.Start(context.Background(), "store.set-car-size")
+	ctx, span := tracing.Tracer.Start(ctx, "store.set-car-size")
 	defer span.End()
 
 	defer func(now time.Time) {
-		log.Debugw("handled.set-car-size", "took", fmt.Sprintf("%s", time.Since(now)))
+		log.Debugw("handled.set-car-size", "took", time.Since(now))
 	}(time.Now())
 
 	s.Lock()
@@ -146,7 +145,7 @@ func (s *Store) MarkIndexErrored(ctx context.Context, pieceCid cid.Cid, idxErr s
 	defer span.End()
 
 	defer func(now time.Time) {
-		log.Debugw("handled.mark-piece-index-errored", "took", fmt.Sprintf("%s", time.Since(now)))
+		log.Debugw("handled.mark-piece-index-errored", "took", time.Since(now))
 	}(time.Now())
 
 	s.Lock()
@@ -167,7 +166,7 @@ func (s *Store) GetOffsetSize(ctx context.Context, pieceCid cid.Cid, hash mh.Mul
 	defer span.End()
 
 	defer func(now time.Time) {
-		log.Debugw("handled.get-offset-size", "took", fmt.Sprintf("%s", time.Since(now)))
+		log.Debugw("handled.get-offset-size", "took", time.Since(now))
 	}(time.Now())
 
 	s.Lock()
@@ -188,7 +187,7 @@ func (s *Store) GetPieceMetadata(ctx context.Context, pieceCid cid.Cid) (model.M
 	defer span.End()
 
 	defer func(now time.Time) {
-		log.Debugw("handled.get-piece-metadata", "took", fmt.Sprintf("%s", time.Since(now)))
+		log.Debugw("handled.get-piece-metadata", "took", time.Since(now))
 	}(time.Now())
 
 	md, err := s.db.GetPieceCidToMetadata(ctx, pieceCid)
@@ -207,7 +206,7 @@ func (s *Store) GetPieceDeals(ctx context.Context, pieceCid cid.Cid) ([]model.De
 	defer span.End()
 
 	defer func(now time.Time) {
-		log.Debugw("handled.get-piece-deals", "took", fmt.Sprintf("%s", time.Since(now)))
+		log.Debugw("handled.get-piece-deals", "took", time.Since(now))
 	}(time.Now())
 
 	s.Lock()
@@ -230,7 +229,7 @@ func (s *Store) PiecesContainingMultihash(ctx context.Context, m mh.Multihash) (
 	defer span.End()
 
 	defer func(now time.Time) {
-		log.Debugw("handled.pieces-containing-mh", "took", fmt.Sprintf("%s", time.Since(now)))
+		log.Debugw("handled.pieces-containing-mh", "took", time.Since(now))
 	}(time.Now())
 
 	s.Lock()
@@ -247,7 +246,7 @@ func (s *Store) GetIndex(ctx context.Context, pieceCid cid.Cid) ([]model.Record,
 	defer span.End()
 
 	defer func(now time.Time) {
-		log.Warnw("handled.get-index", "took", fmt.Sprintf("%s", time.Since(now)))
+		log.Warnw("handled.get-index", "took", time.Since(now))
 	}(time.Now())
 
 	s.Lock()
@@ -284,7 +283,7 @@ func (s *Store) IsCompleteIndex(ctx context.Context, pieceCid cid.Cid) (bool, er
 	defer span.End()
 
 	defer func(now time.Time) {
-		log.Debugw("handled.is-complete-index", "took", fmt.Sprintf("%s", time.Since(now)))
+		log.Debugw("handled.is-complete-index", "took", time.Since(now))
 	}(time.Now())
 
 	md, err := s.db.GetPieceCidToMetadata(ctx, pieceCid)
@@ -302,7 +301,7 @@ func (s *Store) AddIndex(ctx context.Context, pieceCid cid.Cid, records []model.
 	defer span.End()
 
 	defer func(now time.Time) {
-		log.Debugw("handled.add-index", "took", fmt.Sprintf("%s", time.Since(now)))
+		log.Debugw("handled.add-index", "took", time.Since(now))
 	}(time.Now())
 
 	s.Lock()
@@ -363,7 +362,7 @@ func (s *Store) AddIndex(ctx context.Context, pieceCid cid.Cid, records []model.
 		return err
 	}
 
-	err = s.db.Sync(ctx, datastore.NewKey(fmt.Sprintf("%d", cursor)))
+	err = s.db.Sync(ctx, ds.NewKey(fmt.Sprintf("%d", cursor)))
 	if err != nil {
 		return err
 	}
@@ -378,7 +377,7 @@ func (s *Store) IndexedAt(ctx context.Context, pieceCid cid.Cid) (time.Time, err
 	defer span.End()
 
 	defer func(now time.Time) {
-		log.Debugw("handled.indexed-at", "took", fmt.Sprintf("%s", time.Since(now)))
+		log.Debugw("handled.indexed-at", "took", time.Since(now))
 	}(time.Now())
 
 	s.Lock()
@@ -399,7 +398,7 @@ func (s *Store) ListPieces(ctx context.Context) ([]cid.Cid, error) {
 	defer span.End()
 
 	defer func(now time.Time) {
-		log.Debugw("handled.list-pieces", "took", fmt.Sprintf("%s", time.Since(now)))
+		log.Debugw("handled.list-pieces", "took", time.Since(now))
 	}(time.Now())
 
 	return s.db.ListPieces(ctx)
@@ -410,7 +409,7 @@ func (s *Store) NextPiecesToCheck(ctx context.Context) ([]cid.Cid, error) {
 	defer span.End()
 
 	defer func(now time.Time) {
-		log.Debugw("handled.next-pieces-to-check", "took", fmt.Sprintf("%s", time.Since(now)))
+		log.Debugw("handled.next-pieces-to-check", "took", time.Since(now))
 	}(time.Now())
 
 	return s.db.NextPiecesToCheck(ctx)
@@ -423,7 +422,7 @@ func (s *Store) FlagPiece(ctx context.Context, pieceCid cid.Cid) error {
 	defer span.End()
 
 	defer func(now time.Time) {
-		log.Debugw("handled.flag-piece", "took", fmt.Sprintf("%s", time.Since(now)))
+		log.Debugw("handled.flag-piece", "took", time.Since(now))
 	}(time.Now())
 
 	s.Lock()
@@ -459,7 +458,7 @@ func (s *Store) UnflagPiece(ctx context.Context, pieceCid cid.Cid) error {
 	defer span.End()
 
 	defer func(now time.Time) {
-		log.Debugw("handled.unflag-piece", "took", fmt.Sprintf("%s", time.Since(now)))
+		log.Debugw("handled.unflag-piece", "took", time.Since(now))
 	}(time.Now())
 
 	s.Lock()
@@ -479,7 +478,7 @@ func (s *Store) FlaggedPiecesList(ctx context.Context, cursor *time.Time, offset
 	defer span.End()
 
 	defer func(now time.Time) {
-		log.Debugw("handled.flagged-pieces-list", "took", fmt.Sprintf("%s", time.Since(now)))
+		log.Debugw("handled.flagged-pieces-list", "took", time.Since(now))
 	}(time.Now())
 
 	return s.db.ListFlaggedPieces(ctx)
@@ -492,7 +491,7 @@ func (s *Store) FlaggedPiecesCount(ctx context.Context) (int, error) {
 	defer span.End()
 
 	defer func(now time.Time) {
-		log.Debugw("handled.flagged-pieces-count", "took", fmt.Sprintf("%s", time.Since(now)))
+		log.Debugw("handled.flagged-pieces-count", "took", time.Since(now))
 	}(time.Now())
 
 	return s.db.FlaggedPiecesCount(ctx)
@@ -551,7 +550,7 @@ func (s *Store) RemoveDealForPiece(ctx context.Context, pieceCid cid.Cid, dealUu
 	if len(md.Deals) == 0 {
 		// Remove Metadata if removed deal was last one
 		if err := s.db.RemovePieceMetadata(ctx, pieceCid); err != nil {
-			return fmt.Errorf("Failed to remove the Metadata after removing the last deal: %w", err)
+			return fmt.Errorf("failed to remove the Metadata after removing the last deal: %w", err)
 		}
 		return nil
 	}
@@ -614,5 +613,5 @@ func (s *Store) RemoveIndexes(ctx context.Context, pieceCid cid.Cid) error {
 
 	err = s.db.SetPieceCidToMetadata(ctx, pieceCid, md)
 
-	return nil
+	return err
 }

--- a/extern/boostd-data/ldb/service.go
+++ b/extern/boostd-data/ldb/service.go
@@ -86,7 +86,7 @@ func (s *Store) AddDealForPiece(ctx context.Context, pieceCid cid.Cid, dealInfo 
 	defer span.End()
 
 	defer func(now time.Time) {
-		log.Debugw("handled.add-deal-for-piece", "took", time.Since(now))
+		log.Debugw("handled.add-deal-for-piece", "took", time.Since(now).String())
 	}(time.Now())
 
 	s.Lock()
@@ -128,7 +128,7 @@ func (s *Store) SetCarSize(ctx context.Context, pieceCid cid.Cid, size uint64) e
 	defer span.End()
 
 	defer func(now time.Time) {
-		log.Debugw("handled.set-car-size", "took", time.Since(now))
+		log.Debugw("handled.set-car-size", "took", time.Since(now).String())
 	}(time.Now())
 
 	s.Lock()
@@ -145,7 +145,7 @@ func (s *Store) MarkIndexErrored(ctx context.Context, pieceCid cid.Cid, idxErr s
 	defer span.End()
 
 	defer func(now time.Time) {
-		log.Debugw("handled.mark-piece-index-errored", "took", time.Since(now))
+		log.Debugw("handled.mark-piece-index-errored", "took", time.Since(now).String())
 	}(time.Now())
 
 	s.Lock()
@@ -166,7 +166,7 @@ func (s *Store) GetOffsetSize(ctx context.Context, pieceCid cid.Cid, hash mh.Mul
 	defer span.End()
 
 	defer func(now time.Time) {
-		log.Debugw("handled.get-offset-size", "took", time.Since(now))
+		log.Debugw("handled.get-offset-size", "took", time.Since(now).String())
 	}(time.Now())
 
 	s.Lock()
@@ -187,7 +187,7 @@ func (s *Store) GetPieceMetadata(ctx context.Context, pieceCid cid.Cid) (model.M
 	defer span.End()
 
 	defer func(now time.Time) {
-		log.Debugw("handled.get-piece-metadata", "took", time.Since(now))
+		log.Debugw("handled.get-piece-metadata", "took", time.Since(now).String())
 	}(time.Now())
 
 	md, err := s.db.GetPieceCidToMetadata(ctx, pieceCid)
@@ -206,7 +206,7 @@ func (s *Store) GetPieceDeals(ctx context.Context, pieceCid cid.Cid) ([]model.De
 	defer span.End()
 
 	defer func(now time.Time) {
-		log.Debugw("handled.get-piece-deals", "took", time.Since(now))
+		log.Debugw("handled.get-piece-deals", "took", time.Since(now).String())
 	}(time.Now())
 
 	s.Lock()
@@ -229,7 +229,7 @@ func (s *Store) PiecesContainingMultihash(ctx context.Context, m mh.Multihash) (
 	defer span.End()
 
 	defer func(now time.Time) {
-		log.Debugw("handled.pieces-containing-mh", "took", time.Since(now))
+		log.Debugw("handled.pieces-containing-mh", "took", time.Since(now).String())
 	}(time.Now())
 
 	s.Lock()
@@ -246,7 +246,7 @@ func (s *Store) GetIndex(ctx context.Context, pieceCid cid.Cid) ([]model.Record,
 	defer span.End()
 
 	defer func(now time.Time) {
-		log.Warnw("handled.get-index", "took", time.Since(now))
+		log.Warnw("handled.get-index", "took", time.Since(now).String())
 	}(time.Now())
 
 	s.Lock()
@@ -283,7 +283,7 @@ func (s *Store) IsCompleteIndex(ctx context.Context, pieceCid cid.Cid) (bool, er
 	defer span.End()
 
 	defer func(now time.Time) {
-		log.Debugw("handled.is-complete-index", "took", time.Since(now))
+		log.Debugw("handled.is-complete-index", "took", time.Since(now).String())
 	}(time.Now())
 
 	md, err := s.db.GetPieceCidToMetadata(ctx, pieceCid)
@@ -301,7 +301,7 @@ func (s *Store) AddIndex(ctx context.Context, pieceCid cid.Cid, records []model.
 	defer span.End()
 
 	defer func(now time.Time) {
-		log.Debugw("handled.add-index", "took", time.Since(now))
+		log.Debugw("handled.add-index", "took", time.Since(now).String())
 	}(time.Now())
 
 	s.Lock()
@@ -377,7 +377,7 @@ func (s *Store) IndexedAt(ctx context.Context, pieceCid cid.Cid) (time.Time, err
 	defer span.End()
 
 	defer func(now time.Time) {
-		log.Debugw("handled.indexed-at", "took", time.Since(now))
+		log.Debugw("handled.indexed-at", "took", time.Since(now).String())
 	}(time.Now())
 
 	s.Lock()
@@ -398,7 +398,7 @@ func (s *Store) ListPieces(ctx context.Context) ([]cid.Cid, error) {
 	defer span.End()
 
 	defer func(now time.Time) {
-		log.Debugw("handled.list-pieces", "took", time.Since(now))
+		log.Debugw("handled.list-pieces", "took", time.Since(now).String())
 	}(time.Now())
 
 	return s.db.ListPieces(ctx)
@@ -409,7 +409,7 @@ func (s *Store) NextPiecesToCheck(ctx context.Context) ([]cid.Cid, error) {
 	defer span.End()
 
 	defer func(now time.Time) {
-		log.Debugw("handled.next-pieces-to-check", "took", time.Since(now))
+		log.Debugw("handled.next-pieces-to-check", "took", time.Since(now).String())
 	}(time.Now())
 
 	return s.db.NextPiecesToCheck(ctx)
@@ -422,7 +422,7 @@ func (s *Store) FlagPiece(ctx context.Context, pieceCid cid.Cid) error {
 	defer span.End()
 
 	defer func(now time.Time) {
-		log.Debugw("handled.flag-piece", "took", time.Since(now))
+		log.Debugw("handled.flag-piece", "took", time.Since(now).String())
 	}(time.Now())
 
 	s.Lock()
@@ -458,7 +458,7 @@ func (s *Store) UnflagPiece(ctx context.Context, pieceCid cid.Cid) error {
 	defer span.End()
 
 	defer func(now time.Time) {
-		log.Debugw("handled.unflag-piece", "took", time.Since(now))
+		log.Debugw("handled.unflag-piece", "took", time.Since(now).String())
 	}(time.Now())
 
 	s.Lock()
@@ -478,7 +478,7 @@ func (s *Store) FlaggedPiecesList(ctx context.Context, cursor *time.Time, offset
 	defer span.End()
 
 	defer func(now time.Time) {
-		log.Debugw("handled.flagged-pieces-list", "took", time.Since(now))
+		log.Debugw("handled.flagged-pieces-list", "took", time.Since(now).String())
 	}(time.Now())
 
 	return s.db.ListFlaggedPieces(ctx)
@@ -491,7 +491,7 @@ func (s *Store) FlaggedPiecesCount(ctx context.Context) (int, error) {
 	defer span.End()
 
 	defer func(now time.Time) {
-		log.Debugw("handled.flagged-pieces-count", "took", time.Since(now))
+		log.Debugw("handled.flagged-pieces-count", "took", time.Since(now).String())
 	}(time.Now())
 
 	return s.db.FlaggedPiecesCount(ctx)

--- a/extern/boostd-data/svc/setup_couchbase_test_util.go
+++ b/extern/boostd-data/svc/setup_couchbase_test_util.go
@@ -24,7 +24,10 @@ import (
 var tlog = logging.Logger("cbtest")
 
 func init() {
-	logging.SetLogLevel("cbtest", "debug")
+	err := logging.SetLogLevel("cbtest", "debug")
+	if err != nil {
+		panic(err)
+	}
 }
 
 func SetupCouchbase(t *testing.T, dbSettings couchbase.DBSettings) {
@@ -167,7 +170,7 @@ func awaitServicesReady(t *testing.T, settings couchbase.DBSettings, duration ti
 			return
 		}
 
-		if time.Now().Sub(start) > duration {
+		if time.Since(start) > duration {
 			require.Fail(t, "timed out waiting for couchbase services to come up after "+duration.String())
 		}
 		time.Sleep(time.Second)
@@ -199,7 +202,7 @@ func awaitBucketCreationReady(t *testing.T, settings couchbase.DBSettings, durat
 			return
 		}
 
-		if time.Now().Sub(start) > duration {
+		if time.Since(start) > duration {
 			require.Fail(t, "timed out trying to create dummy bucket after "+duration.String())
 		}
 
@@ -229,7 +232,7 @@ func waitForOkResponse(t *testing.T, path string, duration time.Duration) {
 			}
 		}
 
-		if time.Now().Sub(start) > duration {
+		if time.Since(start) > duration {
 			msg := "failed to GET " + fullPath + " after " + duration.String()
 			if resp != nil {
 				msg += fmt.Sprintf(": %d - %s", resp.StatusCode, resp.Status)

--- a/extern/boostd-data/svc/svc.go
+++ b/extern/boostd-data/svc/svc.go
@@ -49,8 +49,7 @@ func MakeLevelDBDir(repoPath string) (string, error) {
 	return repoPath, nil
 }
 
-func (s *Service) Start(ctx context.Context, port int) error {
-	addr := fmt.Sprintf("localhost:%d", port)
+func (s *Service) Start(ctx context.Context, addr string) error {
 	ln, err := net.Listen("tcp", addr)
 	if err != nil {
 		return fmt.Errorf("setting up listener for local index directory service: %w", err)

--- a/extern/boostd-data/svc/svc_test.go
+++ b/extern/boostd-data/svc/svc_test.go
@@ -54,7 +54,7 @@ func TestService(t *testing.T) {
 		defer cancel()
 		bdsvc, err := NewLevelDB("")
 		require.NoError(t, err)
-		testService(ctx, t, bdsvc, 8042)
+		testService(ctx, t, bdsvc, "localhost:8042")
 	})
 	t.Run("couchbase", func(t *testing.T) {
 		// TODO: Unskip this test once the couchbase instance can be created
@@ -66,16 +66,16 @@ func TestService(t *testing.T) {
 		defer cancel()
 		SetupCouchbase(t, testCouchSettings)
 		bdsvc := NewCouchbase(testCouchSettings)
-		testService(ctx, t, bdsvc, 8043)
+		testService(ctx, t, bdsvc, "localhost:8043")
 	})
 }
 
-func testService(ctx context.Context, t *testing.T, bdsvc *Service, port int) {
-	err := bdsvc.Start(ctx, port)
+func testService(ctx context.Context, t *testing.T, bdsvc *Service, addr string) {
+	err := bdsvc.Start(ctx, addr)
 	require.NoError(t, err)
 
 	cl := client.NewStore()
-	err = cl.Dial(context.Background(), fmt.Sprintf("http://localhost:%d", port))
+	err = cl.Dial(context.Background(), fmt.Sprintf("http://%s", addr))
 	require.NoError(t, err)
 	defer cl.Close(ctx)
 
@@ -164,7 +164,7 @@ func TestServiceFuzz(t *testing.T) {
 	t.Run("level db", func(t *testing.T) {
 		bdsvc, err := NewLevelDB("")
 		require.NoError(t, err)
-		testServiceFuzz(ctx, t, bdsvc, 8042)
+		testServiceFuzz(ctx, t, bdsvc, "localhost:8042")
 	})
 	t.Run("couchbase", func(t *testing.T) {
 		// TODO: Unskip this test once the couchbase instance can be created
@@ -172,12 +172,12 @@ func TestServiceFuzz(t *testing.T) {
 		t.Skip()
 		SetupCouchbase(t, testCouchSettings)
 		bdsvc := NewCouchbase(testCouchSettings)
-		testServiceFuzz(ctx, t, bdsvc, 8043)
+		testServiceFuzz(ctx, t, bdsvc, "localhost:8043")
 	})
 }
 
-func testServiceFuzz(ctx context.Context, t *testing.T, bdsvc *Service, port int) {
-	err := bdsvc.Start(ctx, port)
+func testServiceFuzz(ctx context.Context, t *testing.T, bdsvc *Service, addr string) {
+	err := bdsvc.Start(ctx, addr)
 	require.NoError(t, err)
 
 	cl := client.NewStore()
@@ -384,7 +384,7 @@ func TestCleanup(t *testing.T) {
 	t.Run("level db", func(t *testing.T) {
 		bdsvc, err := NewLevelDB("")
 		require.NoError(t, err)
-		testCleanup(ctx, t, bdsvc, 8042)
+		testCleanup(ctx, t, bdsvc, "localhost:8042")
 	})
 	t.Run("couchbase", func(t *testing.T) {
 		// TODO: Unskip this test once the couchbase instance can be created
@@ -392,16 +392,16 @@ func TestCleanup(t *testing.T) {
 		t.Skip()
 		SetupCouchbase(t, testCouchSettings)
 		bdsvc := NewCouchbase(testCouchSettings)
-		testCleanup(ctx, t, bdsvc, 8043)
+		testCleanup(ctx, t, bdsvc, "localhost:8043")
 	})
 }
 
-func testCleanup(ctx context.Context, t *testing.T, bdsvc *Service, port int) {
-	err := bdsvc.Start(ctx, port)
+func testCleanup(ctx context.Context, t *testing.T, bdsvc *Service, addr string) {
+	err := bdsvc.Start(ctx, addr)
 	require.NoError(t, err)
 
 	cl := client.NewStore()
-	err = cl.Dial(context.Background(), fmt.Sprintf("http://localhost:%d", port))
+	err = cl.Dial(context.Background(), fmt.Sprintf("http://%s", addr))
 	require.NoError(t, err)
 	defer cl.Close(ctx)
 

--- a/node/modules/piecedirectory.go
+++ b/node/modules/piecedirectory.go
@@ -86,13 +86,14 @@ func NewPieceDirectoryStore(cfg *config.Boost) func(lc fx.Lifecycle, r lotus_rep
 				}
 
 				// Start the embedded local index directory service
-				err := bdsvc.Start(svcCtx, port)
+				addr := fmt.Sprintf("localhost:%d", port)
+				err := bdsvc.Start(svcCtx, addr)
 				if err != nil {
 					return fmt.Errorf("starting local index directory service: %w", err)
 				}
 
 				// Connect to the embedded service
-				return client.Dial(ctx, fmt.Sprintf("http://localhost:%d", port))
+				return client.Dial(ctx, fmt.Sprintf("http://%s", addr))
 			},
 			OnStop: func(ctx context.Context) error {
 				cancel()

--- a/piecedirectory/doctor_test.go
+++ b/piecedirectory/doctor_test.go
@@ -34,12 +34,12 @@ func TestPieceDoctor(t *testing.T) {
 		bdsvc, err := svc.NewLevelDB("")
 		require.NoError(t, err)
 
-		port := 8050
-		err = bdsvc.Start(ctx, port)
+		addr := "localhost:8050"
+		err = bdsvc.Start(ctx, addr)
 		require.NoError(t, err)
 
 		cl := client.NewStore()
-		err = cl.Dial(ctx, fmt.Sprintf("http://localhost:%d", port))
+		err = cl.Dial(ctx, fmt.Sprintf("http://%s", addr))
 		require.NoError(t, err)
 		defer cl.Close(ctx)
 
@@ -65,12 +65,12 @@ func TestPieceDoctor(t *testing.T) {
 		svc.SetupCouchbase(t, testCouchSettings)
 		bdsvc := svc.NewCouchbase(testCouchSettings)
 
-		port := 8051
-		err := bdsvc.Start(ctx, port)
+		addr := "localhost:8051"
+		err := bdsvc.Start(ctx, addr)
 		require.NoError(t, err)
 
 		cl := client.NewStore()
-		err = cl.Dial(ctx, fmt.Sprintf("http://localhost:%d", port))
+		err = cl.Dial(ctx, fmt.Sprintf("http://%s", addr))
 		require.NoError(t, err)
 		defer cl.Close(ctx)
 

--- a/piecedirectory/piecedirectory_test.go
+++ b/piecedirectory/piecedirectory_test.go
@@ -3,6 +3,7 @@ package piecedirectory
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"testing"
@@ -41,11 +42,12 @@ func TestPieceDirectory(t *testing.T) {
 }
 
 func testPieceDirectory(ctx context.Context, t *testing.T, bdsvc *svc.Service) {
-	err := bdsvc.Start(ctx, 8044)
+	addr := "localhost:8044"
+	err := bdsvc.Start(ctx, addr)
 	require.NoError(t, err)
 
 	cl := client.NewStore()
-	err = cl.Dial(ctx, "http://localhost:8044")
+	err = cl.Dial(ctx, fmt.Sprintf("http://%s", addr))
 	require.NoError(t, err)
 	defer cl.Close(ctx)
 


### PR DESCRIPTION
## Summary
This PR updates docker devnet in the LID (local index directory) branch so that booster-http and booster-bitswap are once again able to run.

_Note_: No changes have been made to the boostd api itself, the only change is in the boostd-data service mentioned below.

* BREAKING CHANGE: The boostd-data service now takes an `--addr` flag instead of `--port`, so that it can be bound to non localhost IP addresses. This is needed for cross container communication, and may be useful in larger scale deployments. - [919cb57](https://github.com/filecoin-project/boost/pull/1375/commits/919cb578b752017dd16f941e7c127367af6d22f8)
* Fixed linting in extern/boostd-data. We currently aren't linting the "sub project" in CI so linting was failing here. I separate this as it's own commit [6294ae0](https://github.com/filecoin-project/boost/pull/1375/commits/6294ae0d4bf7decd4a04e1297ad48f37597d5fe9) to make it easier to see the functional changes.
* [10fbdf4](https://github.com/filecoin-project/boost/pull/1375/commits/10fbdf4e2abdee1ad6c7aee509f9d091bcbadb2c) includes the updates to the docker devnet, as well as the needed invocation changes to Boostd for the piecedirectory.


## Remaining Items
- [X] Verify graphsync retrieval in devnet
- [X] Verify http piece and gateway retrieval in devnet
- [x] Verify devnet with bitswap