### PR TITLE
feat: redeclare storage when unsealed state is checked

### DIFF
--- a/indexprovider/unsealedstatemanager_test.go
+++ b/indexprovider/unsealedstatemanager_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/filecoin-project/boost/db"
 	"github.com/filecoin-project/boost/db/migrations"
 	"github.com/filecoin-project/boost/indexprovider/mock"
+	"github.com/filecoin-project/boost/node/config"
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/builtin/v9/market"
@@ -313,7 +314,9 @@ func setup(t *testing.T) (*UnsealedStateManager, *mock.MockStorageProvider, *moc
 		prov:        prov,
 		meshCreator: &meshCreatorStub{},
 	}
-	usm := NewUnsealedStateManager(wrapper, storageProvider, dealsDB, sectorStateDB, storageMiner)
+
+	cfg := config.StorageConfig{}
+	usm := NewUnsealedStateManager(wrapper, storageProvider, dealsDB, sectorStateDB, storageMiner, cfg)
 	return usm, storageProvider, storageMiner, prov
 }
 

--- a/indexprovider/unsealedstatemanager_test.go
+++ b/indexprovider/unsealedstatemanager_test.go
@@ -2,6 +2,8 @@ package indexprovider
 
 import (
 	"context"
+	"testing"
+
 	"github.com/filecoin-project/boost-gfm/storagemarket"
 	"github.com/filecoin-project/boost/db"
 	"github.com/filecoin-project/boost/db/migrations"
@@ -15,7 +17,6 @@ import (
 	"github.com/ipni/index-provider/metadata"
 	mock_provider "github.com/ipni/index-provider/mock"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 // Empty response from MinerAPI.StorageList()
@@ -324,6 +325,10 @@ var _ ApiStorageMiner = (*mockApiStorageMiner)(nil)
 
 func (m mockApiStorageMiner) StorageList(ctx context.Context) (map[storiface.ID][]storiface.Decl, error) {
 	return m.storageList, nil
+}
+
+func (m mockApiStorageMiner) StorageRedeclareLocal(ctx context.Context, id *storiface.ID, dropMissing bool) error {
+	return nil
 }
 
 type meshCreatorStub struct {

--- a/indexprovider/wrapper.go
+++ b/indexprovider/wrapper.go
@@ -82,7 +82,7 @@ func NewWrapper(cfg *config.Boost) func(lc fx.Lifecycle, h host.Host, r repo.Loc
 			OnStart: func(ctx context.Context) error {
 				// Watch for changes in sector unseal state and update the
 				// indexer when there are changes
-				usm := NewUnsealedStateManager(w, legacyProv, dealsDB, ssDB, storageService)
+				usm := NewUnsealedStateManager(w, legacyProv, dealsDB, ssDB, storageService, w.cfg.Storage)
 				go usm.Run(runCtx)
 
 				// Announce all deals on startup in case of a config change

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -60,7 +60,7 @@ func DefaultBoost() *Boost {
 
 		Storage: StorageConfig{
 			ParallelFetchLimit:            10,
-			StorageListRefreshDuration:    Duration(time.Hour * 12),
+			StorageListRefreshDuration:    Duration(time.Hour * 1),
 			RedeclareOnStorageListRefresh: true,
 		},
 

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -59,7 +59,9 @@ func DefaultBoost() *Boost {
 		Common: defCommon(),
 
 		Storage: StorageConfig{
-			ParallelFetchLimit: 10,
+			ParallelFetchLimit:            10,
+			StorageListRefreshDuration:    Duration(time.Hour * 12),
+			RedeclareOnStorageListRefresh: true,
 		},
 
 		Graphql: GraphqlConfig{

--- a/node/config/doc_gen.go
+++ b/node/config/doc_gen.go
@@ -532,7 +532,7 @@ see https://boost.filecoin.io/configuration/deal-filters for more details`,
 			Name: "StorageListRefreshDuration",
 			Type: "Duration",
 
-			Comment: `How frequently Boost should refresh the state of sectors with Lotus. (default: 12hours)
+			Comment: `How frequently Boost should refresh the state of sectors with Lotus. (default: 1hour)
 When run, Boost will trigger a storage redeclare on the miner in addition to a storage list.
 This ensures that index metadata for sectors reflects their status (removed, unsealed, etc).`,
 		},

--- a/node/config/doc_gen.go
+++ b/node/config/doc_gen.go
@@ -528,6 +528,22 @@ see https://boost.filecoin.io/configuration/deal-filters for more details`,
 
 			Comment: `The maximum number of concurrent fetch operations to the storage subsystem`,
 		},
+		{
+			Name: "StorageListRefreshDuration",
+			Type: "Duration",
+
+			Comment: `How frequently Boost should refresh the state of sectors with Lotus. (default: 12hours)
+When run, Boost will trigger a storage redeclare on the miner in addition to a storage list.
+This ensures that index metadata for sectors reflects their status (removed, unsealed, etc).`,
+		},
+		{
+			Name: "RedeclareOnStorageListRefresh",
+			Type: "bool",
+
+			Comment: `Whether or not Boost should have lotus redeclare its storage list (default: true).
+Disable this if you wish to manually handle the refresh. If manually managing the redeclare
+and it is not triggered, retrieval quality for users will be impacted.`,
+		},
 	},
 	"TracingConfig": []DocField{
 		{

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -289,4 +289,12 @@ func (c *FeeConfig) Legacy() lotus_config.MinerFeeConfig {
 type StorageConfig struct {
 	// The maximum number of concurrent fetch operations to the storage subsystem
 	ParallelFetchLimit int
+	// How frequently Boost should refresh the state of sectors with Lotus. (default: 12hours)
+	// When run, Boost will trigger a storage redeclare on the miner in addition to a storage list.
+	// This ensures that index metadata for sectors reflects their status (removed, unsealed, etc).
+	StorageListRefreshDuration Duration
+	// Whether or not Boost should have lotus redeclare its storage list (default: true).
+	// Disable this if you wish to manually handle the refresh. If manually managing the redeclare
+	// and it is not triggered, retrieval quality for users will be impacted.
+	RedeclareOnStorageListRefresh bool
 }

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -289,7 +289,7 @@ func (c *FeeConfig) Legacy() lotus_config.MinerFeeConfig {
 type StorageConfig struct {
 	// The maximum number of concurrent fetch operations to the storage subsystem
 	ParallelFetchLimit int
-	// How frequently Boost should refresh the state of sectors with Lotus. (default: 12hours)
+	// How frequently Boost should refresh the state of sectors with Lotus. (default: 1hour)
 	// When run, Boost will trigger a storage redeclare on the miner in addition to a storage list.
 	// This ensures that index metadata for sectors reflects their status (removed, unsealed, etc).
 	StorageListRefreshDuration Duration


### PR DESCRIPTION
## Summary
Adds to https://github.com/filecoin-project/boost/pull/1191 to call storage redeclare on the lotus-miner. Lotus doesn't currently automatically detect fs changes, so this is needed to ensure we're able to automatically keep indexes and their metadata up to date.

Speaking with the Lotus team, this call should be cheap so running it regularly shouldn't be an issue.

### Screenshot from devnet
This is a screenshot of the before and after `lotus-miner storage list`. On the left the list shows 2 of 4 sectors as being unsealed, but we can see by the screenshot that there is only 1 unsealed sector. After the logs of the job execute (on the right), the storage list then correctly shows 1 of 4 sectors as unsealed.

![Screenshot 2023-04-15 at 1 48 27 PM](https://user-images.githubusercontent.com/639834/232221225-0dae6f10-71d2-4c93-a709-86ce03189782.png)


## Note on Frequency of this check
It may be useful to allow configuring how often the unseal manager is run. Currently it runs every hour, but in reality it doesn't need to run that frequently. 12 or even 24h is likely a more reasonable default as we ultimately just care about eventual consistency and hour to hour changes aren't likely to be very frequent.

Edit: I set this to 12 hours for now, instead of the current 1 hour.

## Remaining Work
- [X] Add configuration so that SP's can disable this in case they want to control when redeclares occur (default to enabled)