### PR TITLE
fix: prevent accidental removal of valid sector index announcements

### DIFF
--- a/db/migrations/20230426120000_update_sealing_status.sql
+++ b/db/migrations/20230426120000_update_sealing_status.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+-- +goose StatementBegin
+DROP INDEX index_sector_state_sector_id;
+DELETE FROM SectorState;
+CREATE UNIQUE INDEX IF NOT EXISTS index_sector_state_sector_id on SectorState(MinerID,SectorID);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX IF EXISTS index_sector_state_sector_id;
+-- +goose StatementEnd

--- a/db/sectors.go
+++ b/db/sectors.go
@@ -3,8 +3,9 @@ package db
 import (
 	"context"
 	"database/sql"
-	"github.com/filecoin-project/go-state-types/abi"
 	"time"
+
+	"github.com/filecoin-project/go-state-types/abi"
 )
 
 type SealState string
@@ -12,6 +13,7 @@ type SealState string
 const SealStateSealed SealState = "Sealed"
 const SealStateUnsealed SealState = "Unsealed"
 const SealStateRemoved SealState = "Removed"
+const SealStateCache SealState = "Cache"
 
 type SectorState struct {
 	SectorID  abi.SectorID

--- a/node/modules/storageminer.go
+++ b/node/modules/storageminer.go
@@ -429,6 +429,7 @@ func HandleBoostLibp2pDeals(lc fx.Lifecycle, h host.Host, prov *storagemarket.Pr
 		OnStop: func(ctx context.Context) error {
 			lp2pnet.Stop()
 			prov.Stop()
+			idxProv.Stop()
 			return nil
 		},
 	})


### PR DESCRIPTION
## Summary
We discovered an issue where when calling the Lotus Storage API we were not properly handling the multiple states that can be returned for a sector (Cache status, Unsealed/Sealed status). This could result in a sector being considered as removed.

This update adds a state to the database to account for the various Cache states a sector may be in. In most instances the Sealed/Unsealed status should ultimately be recorded, but in the instance that is not returned for some reason, we will record the cache status so that the sector is not removed. Only if no status is returned will we consider the sector as removed.

* Also fixes an issue where the database was not treating sector entries as unique, leading to numerous entries per sector instead of 1
* Ensures the Database starts up and runs any migrations before the rest of the index provider starts

TODO:
- [X] Verify fix on SP
  - Ran multiple jobs to verify new index announcements were not being made, and we were no longer seeing incorrect removals (this previously was occurring on every run)
  - Deleted known entries from the DB and verified announcements were triggered

_Note: This will result in a full index ingest for affected users._