### PR TITLE
chore: fix docsgen on main

### DIFF
--- a/node/config/doc_gen.go
+++ b/node/config/doc_gen.go
@@ -424,6 +424,12 @@ for any other deal.`,
 	},
 	"GraphqlConfig": []DocField{
 		{
+			Name: "ListenAddress",
+			Type: "string",
+
+			Comment: `The ip address the GraphQL server will bind to. Default: 0.0.0.0`,
+		},
+		{
 			Name: "Port",
 			Type: "uint64",
 


### PR DESCRIPTION
Main and the 1.7.2 were off and the previous PR didnt catch that. This resolves the current discrepancy on main.