### PR TITLE
fix: mpool all messages panic

### DIFF
--- a/gql/resolver_mpool.go
+++ b/gql/resolver_mpool.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+
 	"github.com/filecoin-project/lotus/chain/consensus"
 
 	gqltypes "github.com/filecoin-project/boost/gql/types"
@@ -67,7 +68,7 @@ func (r *resolver) Mpool(ctx context.Context, args struct{ Local bool }) ([]*msg
 		method := m.Message.Method.String()
 		toact, err := r.fullNode.StateGetActor(ctx, m.Message.To, types.EmptyTSK)
 		if err == nil {
-			consensus.NewActorRegistry().Methods[toact.Code][m.Message.Method].Params.Name()
+			method = consensus.NewActorRegistry().Methods[toact.Code][m.Message.Method].Params.Name()
 		}
 
 		var params string


### PR DESCRIPTION
Fixes below panic:

```
2023/05/01 10:57:52 graphql: panic occurred: runtime error: invalid memory address or nil pointer dereference
goroutine 5624764 [running]:
github.com/graph-gophers/graphql-go/log.(*DefaultLogger).LogPanic(0x9249208?, {0x6a14b08?, 0xc0206470e0}, {0x517fde0, 0x8e50930})
	/home/nonsense/go/pkg/mod/github.com/graph-gophers/graphql-go@v1.3.0/log/log.go:21 +0x65
github.com/graph-gophers/graphql-go/internal/exec.execFieldSelection.func2.1()
	/home/nonsense/go/pkg/mod/github.com/graph-gophers/graphql-go@v1.3.0/internal/exec/exec.go:187 +0x89
panic({0x517fde0, 0x8e50930})
	/usr/local/go/src/runtime/panic.go:884 +0x213
github.com/filecoin-project/boost/gql.(*resolver).Mpool(0xc0009141e0, {0x6a14b08, 0xc0206471a0}, {0x39?})
	/home/nonsense/boost/gql/resolver_mpool.go:70 +0x496
reflect.Value.call({0x56291e0?, 0xc0009141e0?, 0x7ed436?}, {0x5678452, 0x4}, {0xc0206471d0, 0x2, 0x848dee?})
	/usr/local/go/src/reflect/value.go:586 +0xb0b
reflect.Value.Call({0x56291e0?, 0xc0009141e0?, 0xc02db933b0?}, {0xc0206471d0?, 0x565b400?, 0x0?})
	/usr/local/go/src/reflect/value.go:370 +0xbc
github.com/graph-gophers/graphql-go/internal/exec.execFieldSelection.func2(0x884c00?, {0x6a14b08?, 0xc0206470e0?}, 0xc02807b938, 0xc025180500, 0xc015e67ec0, {0x6a14b08?, 0xc0206471a0})
	/home/nonsense/go/pkg/mod/github.com/graph-gophers/graphql-go@v1.3.0/internal/exec/exec.go:211 +0x4c6
github.com/graph-gophers/graphql-go/internal/exec.execFieldSelection({0x6a14b08, 0xc0206470e0}, 0xc026a0b980, 0x5147280?, 0xc025180500, 0xc026a0b800?, 0x1)
	/home/nonsense/go/pkg/mod/github.com/graph-gophers/graphql-go@v1.3.0/internal/exec/exec.go:231 +0x1ce
github.com/graph-gophers/graphql-go/internal/exec.(*Request).execSelections.func1(0xc025180500)
	/home/nonsense/go/pkg/mod/github.com/graph-gophers/graphql-go@v1.3.0/internal/exec/exec.go:81 +0x1b8
created by github.com/graph-gophers/graphql-go/internal/exec.(*Request).execSelections
	/home/nonsense/go/pkg/mod/github.com/graph-gophers/graphql-go@v1.3.0/internal/exec/exec.go:77 +0x1d0
```