### PR TITLE
chore: enable files gateway in devnet by default

### DIFF
--- a/docker/devnet/booster-http/entrypoint.sh
+++ b/docker/devnet/booster-http/entrypoint.sh
@@ -10,4 +10,4 @@ echo $MINER_API_INFO
 echo $BOOST_API_INFO
 
 echo Starting booster-http...
-exec booster-http run --api-boost=$BOOST_API_INFO --api-fullnode=$FULLNODE_API_INFO --api-storage=$MINER_API_INFO --tracing
+exec booster-http run --serve-files=true --api-boost=$BOOST_API_INFO --api-fullnode=$FULLNODE_API_INFO --api-storage=$MINER_API_INFO --tracing


### PR DESCRIPTION
## Summary
For ease of devnet testing, this just updates the booster-http entrypoint to also include the `--serve-files=true` flag to enable the files view of the IPFS gateway, which is disabled by default.