### PR TITLE
car size required only for online deals

### DIFF
--- a/cmd/boost/deal_cmd.go
+++ b/cmd/boost/deal_cmd.go
@@ -47,7 +47,7 @@ var dealFlags = []cli.Flag{
 	&cli.Uint64Flag{
 		Name:     "car-size",
 		Usage:    "size of the CAR file",
-		Required: true,
+		Required: false,
 	},
 	&cli.StringFlag{
 		Name:     "payload-cid",

--- a/cmd/boost/deal_cmd.go
+++ b/cmd/boost/deal_cmd.go
@@ -44,11 +44,6 @@ var dealFlags = []cli.Flag{
 		Usage:    "size of the CAR file as a padded piece",
 		Required: true,
 	},
-	&cli.Uint64Flag{
-		Name:     "car-size",
-		Usage:    "size of the CAR file: required for online deals",
-		Required: false,
-	},
 	&cli.StringFlag{
 		Name:     "payload-cid",
 		Usage:    "root CID of the CAR file",
@@ -109,6 +104,11 @@ var dealCmd = &cli.Command{
 		&cli.StringSliceFlag{
 			Name:  "http-headers",
 			Usage: "http headers to be passed with the request (e.g key=value)",
+		},
+		&cli.Uint64Flag{
+			Name:     "car-size",
+			Usage:    "size of the CAR file: required for online deals",
+			Required: true,
 		},
 	}, dealFlags...),
 	Before: before,

--- a/cmd/boost/deal_cmd.go
+++ b/cmd/boost/deal_cmd.go
@@ -46,7 +46,7 @@ var dealFlags = []cli.Flag{
 	},
 	&cli.Uint64Flag{
 		Name:     "car-size",
-		Usage:    "size of the CAR file",
+		Usage:    "size of the CAR file: required for online deals",
 		Required: false,
 	},
 	&cli.StringFlag{
@@ -195,6 +195,9 @@ func dealCmdAction(cctx *cli.Context, isOnline bool) error {
 	transfer := types.Transfer{}
 	if isOnline {
 
+		if !cctx.IsSet("car-size") {
+			return fmt.Errorf("car size is required for online deals")
+		}
 		carFileSize := cctx.Uint64("car-size")
 		if carFileSize == 0 {
 			return fmt.Errorf("size of car file cannot be 0")

--- a/cmd/boost/deal_cmd.go
+++ b/cmd/boost/deal_cmd.go
@@ -195,9 +195,6 @@ func dealCmdAction(cctx *cli.Context, isOnline bool) error {
 	transfer := types.Transfer{}
 	if isOnline {
 
-		if !cctx.IsSet("car-size") {
-			return fmt.Errorf("car size is required for online deals")
-		}
 		carFileSize := cctx.Uint64("car-size")
 		if carFileSize == 0 {
 			return fmt.Errorf("size of car file cannot be 0")

--- a/cmd/boost/deal_cmd.go
+++ b/cmd/boost/deal_cmd.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	cid "github.com/ipfs/go-cid/_rsrch/cidiface"
 	"strings"
 
 	bcli "github.com/filecoin-project/boost/cli"
@@ -12,7 +13,6 @@ import (
 	"github.com/filecoin-project/boost/cmd"
 	"github.com/filecoin-project/boost/storagemarket/types"
 	types2 "github.com/filecoin-project/boost/transport/types"
-	"github.com/filecoin-project/go-address"
 	cborutil "github.com/filecoin-project/go-cbor-util"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
@@ -21,7 +21,6 @@ import (
 	chain_types "github.com/filecoin-project/lotus/chain/types"
 	lcli "github.com/filecoin-project/lotus/cli"
 	"github.com/google/uuid"
-	"github.com/ipfs/go-cid"
 	inet "github.com/libp2p/go-libp2p/core/network"
 	"github.com/urfave/cli/v2"
 )
@@ -192,15 +191,15 @@ func dealCmdAction(cctx *cli.Context, isOnline bool) error {
 		return fmt.Errorf("parsing payload cid %s: %w", payloadCidStr, err)
 	}
 
-	carFileSize := cctx.Uint64("car-size")
-	if carFileSize == 0 {
-		return fmt.Errorf("size of car file cannot be 0")
-	}
-
-	transfer := types.Transfer{
-		Size: carFileSize,
-	}
+	transfer := types.Transfer{}
 	if isOnline {
+
+		carFileSize := cctx.Uint64("car-size")
+		if carFileSize == 0 {
+			return fmt.Errorf("size of car file cannot be 0")
+		}
+
+		transfer.Size = carFileSize
 		// Store the path to the CAR file as a transfer parameter
 		transferParams := &types2.HttpRequest{URL: cctx.String("http-url")}
 

--- a/cmd/boost/deal_cmd.go
+++ b/cmd/boost/deal_cmd.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	cid "github.com/ipfs/go-cid/_rsrch/cidiface"
 	"strings"
 
 	bcli "github.com/filecoin-project/boost/cli"
@@ -13,6 +12,7 @@ import (
 	"github.com/filecoin-project/boost/cmd"
 	"github.com/filecoin-project/boost/storagemarket/types"
 	types2 "github.com/filecoin-project/boost/transport/types"
+	"github.com/filecoin-project/go-address"
 	cborutil "github.com/filecoin-project/go-cbor-util"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
@@ -21,6 +21,7 @@ import (
 	chain_types "github.com/filecoin-project/lotus/chain/types"
 	lcli "github.com/filecoin-project/lotus/cli"
 	"github.com/google/uuid"
+	"github.com/ipfs/go-cid"
 	inet "github.com/libp2p/go-libp2p/core/network"
 	"github.com/urfave/cli/v2"
 )


### PR DESCRIPTION
I was confused about something here for “offline” deals.

[car-size is a required parameter](https://github.com/filecoin-project/boost/blob/main/cmd/boost/deal_cmd.go#L50)
[which is not allowed to be zero](https://github.com/filecoin-project/boost/blob/main/cmd/boost/deal_cmd.go#L196-L199)
but [transfer](https://github.com/filecoin-project/boost/blob/main/cmd/boost/deal_cmd.go#L200) is zeroed out for offline deals.

This PR means car-size is no longer checked unless it's an online deal.