### PR TITLE
Dont throw error if deal already announced

### DIFF
--- a/indexprovider/unsealedstatemanager.go
+++ b/indexprovider/unsealedstatemanager.go
@@ -141,17 +141,12 @@ func (m *UnsealedStateManager) checkForUpdates(ctx context.Context) error {
 					VerifiedDeal:  deal.DealProposal.Proposal.VerifiedDeal,
 				}
 				announceCid, err := m.idxprov.announceBoostDealMetadata(ctx, md, propCid)
-				if err != nil {
-					// Check if the error is because the deal was already advertised
-					if !errors.Is(err, provider.ErrAlreadyAdvertised) {
-						// There was some other error, write it to the log
-						usmlog.Errorf("announcing deal %s to index provider: %w", deal.DealID, err)
-						continue
-					}
-				} else {
+				if err == nil {
 					usmlog.Infow("announced deal seal state to index provider",
 						"deal id", deal.DealID, "sector id", deal.SectorID.Number,
 						"seal state", sectorSealState, "announce cid", announceCid.String())
+				} else {
+					usmlog.Errorf("announcing deal %s to index provider: %w", deal.DealID, err)
 				}
 			}
 		}

--- a/indexprovider/wrapper.go
+++ b/indexprovider/wrapper.go
@@ -354,9 +354,13 @@ func (w *Wrapper) announceBoostDealMetadata(ctx context.Context, md metadata.Gra
 	fm := metadata.Default.New(&md)
 	annCid, err := w.prov.NotifyPut(ctx, nil, propCid.Bytes(), fm)
 	if err != nil {
-		return cid.Undef, fmt.Errorf("failed to announce deal to index provider: %w", err)
+		// Check if the error is because the deal was already advertised
+		// (we can safely ignore this error)
+		if !errors.Is(err, provider.ErrAlreadyAdvertised) {
+			return cid.Undef, fmt.Errorf("failed to announce deal to index provider: %w", err)
+		}
 	}
-	return annCid, err
+	return annCid, nil
 }
 
 func (w *Wrapper) AnnounceBoostDealRemoved(ctx context.Context, propCid cid.Cid) (cid.Cid, error) {


### PR DESCRIPTION
Currently we announce a deal from two places:
- when a new storage deal is created, it gets indexed and announced
- when a deal is unsealed, it gets announced

In the case where the deal is unsealed, and there is an error, we ignore the error if it's because the deal has already been announced.

This change ensures that we also ignore the "already announced" error when a new deal is indexed and announced.