### PR TITLE
Fix block download

### DIFF
--- a/node/builder.go
+++ b/node/builder.go
@@ -515,7 +515,7 @@ func ConfigBoost(cfg *config.Boost) Option {
 		Override(new(*storagemarket.Provider), modules.NewStorageMarketProvider(walletMiner, cfg)),
 
 		// GraphQL server
-		Override(new(gql.BlockGetter), From(new(dtypes.IndexBackedBlockstore))),
+		Override(new(gql.BlockGetter), modules.NewBlockGetter),
 		Override(new(*gql.Server), modules.NewGraphqlServer(cfg)),
 
 		// Tracing


### PR DESCRIPTION
Resolves a panic when the user clicks on Download Block on the Inspect page (only occurs on the LID branch)