### PR TITLE
fix: refactor sealing status monitoring

### DIFF
--- a/storagemarket/deal_handler.go
+++ b/storagemarket/deal_handler.go
@@ -57,6 +57,11 @@ func (p *Provider) isRunning(dealUuid uuid.UUID) bool {
 	return dh.isRunning()
 }
 
+type sealingState struct {
+	err        *dealMakingError
+	finalState bool
+}
+
 // dealHandler keeps track of the deal while it's executing
 type dealHandler struct {
 	providerCtx context.Context
@@ -80,6 +85,8 @@ type dealHandler struct {
 
 	runningLk sync.RWMutex
 	running   bool
+
+	sealingSt sealingState
 }
 
 func newDealHandler(ctx context.Context, dealUuid uuid.UUID) (*dealHandler, error) {

--- a/storagemarket/provider.go
+++ b/storagemarket/provider.go
@@ -444,11 +444,17 @@ func (p *Provider) Start() error {
 
 	// Restart active deals
 	for _, deal := range activeDeals {
-		// Check if deal is already proving
+		// Check if deal is already proving and ensure sector contains the deals
 		if deal.Checkpoint >= dealcheckpoints.IndexedAndAnnounced {
 			si, err := p.sps.SectorsStatus(p.ctx, deal.SectorID, false)
-			if err != nil || IsFinalSealingState(si.State) {
+			if err != nil {
 				continue
+			}
+
+			if IsFinalSealingState(si.State) {
+				if HasDeal(si.Deals, deal.ChainDealID) {
+					continue
+				}
 			}
 		}
 


### PR DESCRIPTION


- Cannot implement shard recovery as it requires changes to Dagstore wrapper in Lotus. It would be ideal to just wait as this would all be gone in LID.