### PR TITLE
Properly cancel graphsync requests in unpaid retrieval

### DIFF
--- a/retrievalmarket/server/channelstate.go
+++ b/retrievalmarket/server/channelstate.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 
 	"github.com/filecoin-project/boost-gfm/retrievalmarket"
+	graphsync "github.com/filecoin-project/boost-graphsync"
 	datatransfer "github.com/filecoin-project/go-data-transfer"
 	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-ipld-prime"
@@ -22,6 +23,7 @@ type retrievalState struct {
 	retType RetrievalType
 	cs      *channelState
 	mkts    *retrievalmarket.ProviderDealState
+	gsReq   graphsync.RequestID
 }
 
 func (r retrievalState) ChannelState() channelState                           { return *r.cs }

--- a/retrievalmarket/server/gsunpaidretrieval_test.go
+++ b/retrievalmarket/server/gsunpaidretrieval_test.go
@@ -319,6 +319,10 @@ func runRequestTest(t *testing.T, tc testCase) {
 	} else {
 		require.NoError(t, err)
 	}
+
+	// final verification -- the server has no active graphsync requests
+	stats := gsupr.Stats()
+	require.Equal(t, stats.IncomingRequests.Active, uint64(0))
 }
 
 func createRetrievalProvider(ctx context.Context, t *testing.T, testData *tut.Libp2pTestData, pieceStore *tut.TestPieceStore, sectorAccessor *testnodes.TestSectorAccessor, dagstoreWrapper *tut.MockDagStoreWrapper, gs graphsync.GraphExchange, paymentAddress address.Address) retrievalmarket.RetrievalProvider {


### PR DESCRIPTION
# Goals

While I can't determine definitively if this is the root cause of the retrievals getting stuck, I can say with some assurance that the problem this PR aims to fix will in most cases prevent your automatic retrieval canceller from actually working.

# What happens

In the unpaid retrieval code, when CancelTransfer is called, while a message is sent to the client that the data transfer should be cancelled, the actual GraphSync request is not cancelled. If the client successfully receives the message AND their code is setup as it should be, they will cancel the GraphSync request based on the message. However, that's a big if, especially in the case of unresponsive data transfers where one can probably assume the client is no longer reachable. The proper behavior is to have the server immediately cancel the GraphSync request. If you dig into the code for [CloseDataTransferChannel](https://github.com/filecoin-project/go-data-transfer/blob/v1.15.4-boost/impl/impl.go#L304), you'll see [this line](https://github.com/filecoin-project/go-data-transfer/blob/v1.15.4-boost/impl/impl.go#L317) -- which if you follow the code ultimately cancels the graphsync request directly.

# Implementation

- in order to directly cancel a graphsync request, you need the graphsync request id, which you weren't currently tracking, so I did add it to the `retrievalState` struct
- added the code to call cancel. Note that I don't error the rest of the function when cancel calls -- there are a number of reasons it might have already been cancelled, resulting in a Request Not Found, which merits only a log
- finally, I added a clause at the end of the unpaid retrieval tests to verify there are no inflight requests on the responder side.  Note that because your client does properly close requests when it receives a cancel message, this means in the test environment this test could sometimes already pass without this change, but would do so in a racy way (I got about 6 out of 10 errors when run with `go test --count 10`). Again my hypothesis is that in the case of cancelling unpaid requests that have stalled, the message to close would almost never reach the client.