### PR TITLE
fix: set UI default listen address to localhost

### DIFF
--- a/node/config/def.go
+++ b/node/config/def.go
@@ -65,7 +65,7 @@ func DefaultBoost() *Boost {
 		},
 
 		Graphql: GraphqlConfig{
-			ListenAddress: "0.0.0.0",
+			ListenAddress: "127.0.0.1",
 			Port:          8080,
 		},
 

--- a/node/config/doc_gen.go
+++ b/node/config/doc_gen.go
@@ -427,7 +427,7 @@ for any other deal.`,
 			Name: "ListenAddress",
 			Type: "string",
 
-			Comment: `The ip address the GraphQL server will bind to. Default: 0.0.0.0`,
+			Comment: `The ip address the GraphQL server will bind to. Default: 127.0.0.1`,
 		},
 		{
 			Name: "Port",

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -73,7 +73,7 @@ type WalletsConfig struct {
 }
 
 type GraphqlConfig struct {
-	// The ip address the GraphQL server will bind to. Default: 0.0.0.0
+	// The ip address the GraphQL server will bind to. Default: 127.0.0.1
 	ListenAddress string
 	// The port that the graphql server listens on
 	Port uint64


### PR DESCRIPTION
We should avoid setting it to 0.0.0.0 by default as SPs might end up exposing their UI to the internet if firewall is not configured properly.
I have just come across one such instance. Better safe than sorry.
We also need to update our V2 docs with much more detail about networking and security. 