### PR TITLE
Reset read deadline after reading deal proposal message

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -320,7 +320,7 @@ require (
 	github.com/zondax/hid v0.9.1 // indirect
 	github.com/zondax/ledger-go v0.12.1 // indirect
 	go.uber.org/dig v1.15.0 // indirect
-	go.uber.org/zap v1.24.0 // indirect
+	go.uber.org/zap v1.24.0
 	go4.org v0.0.0-20200411211856-f5505b9728dd // indirect
 	golang.org/x/mod v0.7.0 // indirect
 	golang.org/x/net v0.7.0 // indirect

--- a/storagemarket/lp2pimpl/net.go
+++ b/storagemarket/lp2pimpl/net.go
@@ -23,6 +23,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/protocol"
+	"go.uber.org/zap"
 )
 
 var log = logging.Logger("boost-net")
@@ -197,31 +198,39 @@ func (p *DealProvider) Stop() {
 func (p *DealProvider) handleNewDealStream(s network.Stream) {
 	defer s.Close()
 
+	start := time.Now()
+	reqLogUuid := uuid.New()
+	reqLog := log.With("reqlog-uuid", reqLogUuid.String(), "client-peer", s.Conn().RemotePeer())
+	reqLog.Debugw("new deal proposal request")
+
+	defer func() {
+		reqLog.Debugw("handled deal proposal request", "duration", time.Since(start).String())
+	}()
+
 	// Set a deadline on reading from the stream so it doesn't hang
 	_ = s.SetReadDeadline(time.Now().Add(providerReadDeadline))
-	defer s.SetReadDeadline(time.Time{}) // nolint
 
 	// Read the deal proposal from the stream
 	var proposal types.DealParams
 	err := proposal.UnmarshalCBOR(s)
+	_ = s.SetReadDeadline(time.Time{}) // Clear read deadline so conn doesn't get closed
 	if err != nil {
-		log.Warnw("reading storage deal proposal from stream", "err", err)
+		reqLog.Warnw("reading storage deal proposal from stream", "err", err)
 		return
 	}
 
-	log.Infow("received deal proposal", "id", proposal.DealUUID, "client-peer", s.Conn().RemotePeer())
+	reqLog = reqLog.With("id", proposal.DealUUID)
+	reqLog.Infow("received deal proposal")
 
 	// Start executing the deal.
 	// Note: This method just waits for the deal to be accepted, it doesn't
 	// wait for deal execution to complete.
+	startExec := time.Now()
 	res, err := p.prov.ExecuteDeal(context.Background(), &proposal, s.Conn().RemotePeer())
+	reqLog.Debugw("processed deal proposal accept")
 	if err != nil {
-		log.Warnw("deal proposal failed", "id", proposal.DealUUID, "err", err, "reason", res.Reason)
+		reqLog.Warnw("deal proposal failed", "err", err, "reason", res.Reason)
 	}
-
-	// Set a deadline on writing to the stream so it doesn't hang
-	_ = s.SetWriteDeadline(time.Now().Add(providerWriteDeadline))
-	defer s.SetWriteDeadline(time.Time{}) // nolint
 
 	// Log the response
 	propLog.Infow("send deal proposal response",
@@ -238,44 +247,58 @@ func (p *DealProvider) handleNewDealStream(s network.Stream) {
 		"start epoch", proposal.ClientDealProposal.Proposal.StartEpoch,
 		"end epoch", proposal.ClientDealProposal.Proposal.EndEpoch,
 		"price per epoch", proposal.ClientDealProposal.Proposal.StoragePricePerEpoch,
+		"duration", time.Since(startExec).String(),
 	)
 	_ = p.plDB.InsertLog(p.ctx, proposal, res.Accepted, res.Reason) //nolint:errcheck
+
+	// Set a deadline on writing to the stream so it doesn't hang
+	_ = s.SetWriteDeadline(time.Now().Add(providerWriteDeadline))
+	defer s.SetWriteDeadline(time.Time{}) // nolint
 
 	// Write the response to the client
 	err = cborutil.WriteCborRPC(s, &types.DealResponse{Accepted: res.Accepted, Message: res.Reason})
 	if err != nil {
-		log.Warnw("writing deal response", "id", proposal.DealUUID, "err", err)
-		return
+		reqLog.Warnw("writing deal response", "err", err)
 	}
 }
 
 func (p *DealProvider) handleNewDealStatusStream(s network.Stream) {
 	defer s.Close()
 
-	_ = s.SetReadDeadline(time.Now().Add(providerReadDeadline))
-	defer s.SetReadDeadline(time.Time{}) // nolint
+	start := time.Now()
+	reqLogUuid := uuid.New()
+	reqLog := log.With("reqlog-uuid", reqLogUuid.String(), "client-peer", s.Conn().RemotePeer())
+	reqLog.Debugw("new deal status request")
 
+	defer func() {
+		reqLog.Debugw("handled deal status request", "duration", time.Since(start).String())
+	}()
+
+	// Read the deal status request from the stream
+	_ = s.SetReadDeadline(time.Now().Add(providerReadDeadline))
 	var req types.DealStatusRequest
 	err := req.UnmarshalCBOR(s)
+	_ = s.SetReadDeadline(time.Time{}) // Clear read deadline so conn doesn't get closed
 	if err != nil {
-		log.Warnw("reading deal status request from stream", "err", err)
+		reqLog.Warnw("reading deal status request from stream", "err", err)
 		return
 	}
-	log.Debugw("received deal status request", "id", req.DealUUID, "client-peer", s.Conn().RemotePeer())
+	reqLog = reqLog.With("id", req.DealUUID)
+	reqLog.Debugw("received deal status request")
 
-	resp := p.getDealStatus(req)
+	resp := p.getDealStatus(req, reqLog)
+	reqLog.Debugw("processed deal status request")
 
 	// Set a deadline on writing to the stream so it doesn't hang
 	_ = s.SetWriteDeadline(time.Now().Add(providerWriteDeadline))
 	defer s.SetWriteDeadline(time.Time{}) // nolint
 
 	if err := cborutil.WriteCborRPC(s, &resp); err != nil {
-		log.Errorw("failed to write deal status response", "err", err)
-		return
+		reqLog.Errorw("failed to write deal status response", "err", err)
 	}
 }
 
-func (p *DealProvider) getDealStatus(req types.DealStatusRequest) types.DealStatusResponse {
+func (p *DealProvider) getDealStatus(req types.DealStatusRequest, reqLog *zap.SugaredLogger) types.DealStatusResponse {
 	errResp := func(err string) types.DealStatusResponse {
 		return types.DealStatusResponse{DealUUID: req.DealUUID, Error: err}
 	}
@@ -286,34 +309,34 @@ func (p *DealProvider) getDealStatus(req types.DealStatusRequest) types.DealStat
 	}
 
 	if err != nil {
-		log.Errorw("failed to fetch deal status", "err", err)
+		reqLog.Errorw("failed to fetch deal status", "err", err)
 		return errResp("failed to fetch deal status")
 	}
 
 	// verify request signature
 	uuidBytes, err := req.DealUUID.MarshalBinary()
 	if err != nil {
-		log.Errorw("failed to serialize request deal UUID", "err", err)
+		reqLog.Errorw("failed to serialize request deal UUID", "err", err)
 		return errResp("failed to serialize request deal UUID")
 	}
 
 	clientAddr := pds.ClientDealProposal.Proposal.Client
 	addr, err := p.fullNode.StateAccountKey(p.ctx, clientAddr, chaintypes.EmptyTSK)
 	if err != nil {
-		log.Errorw("failed to get account key for client addr", "client", clientAddr.String(), "err", err)
+		reqLog.Errorw("failed to get account key for client addr", "client", clientAddr.String(), "err", err)
 		msg := fmt.Sprintf("failed to get account key for client addr %s", clientAddr.String())
 		return errResp(msg)
 	}
 
 	err = sigs.Verify(&req.Signature, addr, uuidBytes)
 	if err != nil {
-		log.Warnw("signature verification failed", "err", err)
+		reqLog.Warnw("signature verification failed", "err", err)
 		return errResp("signature verification failed")
 	}
 
 	signedPropCid, err := pds.SignedProposalCid()
 	if err != nil {
-		log.Errorw("getting signed proposal cid", "err", err)
+		reqLog.Errorw("getting signed proposal cid", "err", err)
 		return errResp("getting signed proposal cid")
 	}
 
@@ -321,7 +344,7 @@ func (p *DealProvider) getDealStatus(req types.DealStatusRequest) types.DealStat
 
 	si, err := p.spApi.SectorsStatus(p.ctx, pds.SectorID, false)
 	if err != nil {
-		log.Errorw("getting sector status from sealer", "err", err)
+		reqLog.Errorw("getting sector status from sealer", "err", err)
 		return errResp("getting sector status from sealer")
 	}
 


### PR DESCRIPTION
Fixes https://github.com/filecoin-project/boost/issues/1478

Also adds some more detailed logging to help track down slow parts of the code in future (at the debug level):
```
2023-05-31T09:40:29.458+0200	DEBUG	boost-net	lp2pimpl/net.go:204	new deal proposal request
{"reqlog-uuid": "d2f985bc-fe38-4f90-9ddf-a46c123e55d4", "client-peer": "12D3KooWMkmxGo988mtZWeNoUZD4mJpmeLym1P962bRNLDF6qX8D"}

2023-05-31T09:40:29.458+0200	INFO	boost-net	lp2pimpl/net.go:223	received deal proposal
{"reqlog-uuid": "d2f985bc-fe38-4f90-9ddf-a46c123e55d4", "client-peer": "12D3KooWMkmxGo988mtZWeNoUZD4mJpmeLym1P962bRNLDF6qX8D", "id": "9bda7d00-100e-427e-a24e-88d1fd48ce00"}

2023-05-31T09:40:29.465+0200	DEBUG	boost-net	lp2pimpl/net.go:230	processed deal proposal accept
{"reqlog-uuid": "d2f985bc-fe38-4f90-9ddf-a46c123e55d4", "client-peer": "12D3KooWMkmxGo988mtZWeNoUZD4mJpmeLym1P962bRNLDF6qX8D", "id": "9bda7d00-100e-427e-a24e-88d1fd48ce00"}

2023-05-31T09:40:29.465+0200	INFO	boost-prop	lp2pimpl/net.go:236	send deal proposal response
{"id": "9bda7d00-100e-427e-a24e-88d1fd48ce00", "accepted": true, "msg": "", "peer id": "12D3KooWMkmxGo988mtZWeNoUZD4mJpmeLym1P962bRNLDF6qX8D", "client address": "f3sqdss4zx5pv2ekkky5gmngasrynweju5atrmg7kp6idur25csunxmu22ncvrdlzzgjmzvxyjktggomxbqpeq", "provider address": "f01000", "piece cid": "baga6ea4seaqik4k7fzqn5fnaqi4c3lu2dzyw2hhgcfxnbv5fgiigt5jerujb4kq", "piece size": 4194304, "verified": false, "label": "bafyaa4asfyfcmalqudsaeiclsn2n56lmy7rolvh3hcmbb7lailbxpowb4quv6ggvqayqo7pj7mjaagejsbbrelqkeyaxbiheaiqp7e4gsn3ajlb533z2wp377int6fxiluov6il34itoaemeb5w5qeasaamk35b4bihaqaqyqcexuieaqbacbaejhi", "start epoch": "2116", "end epoch": "520516", "price per epoch": "2000000", "duration": "6.81325ms"}

2023-05-31T09:40:29.465+0200	DEBUG	boost-net	lp2pimpl/net.go:207	handled deal proposal request
{"reqlog-uuid": "d2f985bc-fe38-4f90-9ddf-a46c123e55d4", "client-peer": "12D3KooWMkmxGo988mtZWeNoUZD4mJpmeLym1P962bRNLDF6qX8D", "id": "9bda7d00-100e-427e-a24e-88d1fd48ce00", "duration": "7.694625ms"}
```
