### PR TITLE
log panic (instead of just printing to stdout)

### DIFF
--- a/storagemarket/deal_execution.go
+++ b/storagemarket/deal_execution.go
@@ -83,7 +83,8 @@ func (p *Provider) execDeal(deal *smtypes.ProviderDealState, dh *dealHandler) (d
 	// Capture any panic as a manually retryable error
 	defer func() {
 		if err := recover(); err != nil {
-			fmt.Println("panic: ", err, string(debug.Stack()))
+			log.Errorw("caught panic executing deal", "id", deal.DealUuid, "err", err)
+			fmt.Fprint(os.Stderr, string(debug.Stack()))
 			dmerr = &dealMakingError{
 				error: fmt.Errorf("Caught panic in deal execution: %s\n%s", err, debug.Stack()),
 				retry: smtypes.DealRetryManual,


### PR DESCRIPTION
```
2023-06-05T15:15:20.168+0200    ERROR   boost-provider  storagemarket/deal_execution.go:86      caught panic executing deal     {"id": "51734ff6-62ca-4180-9969-f793d863d593", "err": "something went wrong"}
goroutine 1123 [running]:
runtime/debug.Stack()
        /usr/local/go/src/runtime/debug/stack.go:24 +0x64
github.com/filecoin-project/boost/storagemarket.(*Provider).execDeal.func1()
        /Users/dirk/go/src/github.com/filecoin-project/boost/storagemarket/deal_execution.go:87 +0x1a8
panic({0x1073db1e0, 0x107a76840})
        /usr/local/go/src/runtime/panic.go:890 +0x26c
github.com/filecoin-project/boost/storagemarket.(*Provider).execDeal(0x1400c67afc0, 0x1400ca7c380, 0x1400090e8c0)
        /Users/dirk/go/src/github.com/filecoin-project/boost/storagemarket/deal_execution.go:95 +0x90
github.com/filecoin-project/boost/storagemarket.(*Provider).runDeal(0x1400c67afc0, 0x1400ca7c380, 0x1400090e8c0)
        /Users/dirk/go/src/github.com/filecoin-project/boost/storagemarket/deal_execution.go:52 +0x358
github.com/filecoin-project/boost/storagemarket.(*Provider).startDealThread.func1()
        /Users/dirk/go/src/github.com/filecoin-project/boost/storagemarket/provider_loop.go:544 +0xd8
created by github.com/filecoin-project/boost/storagemarket.(*Provider).startDealThread
        /Users/dirk/go/src/github.com/filecoin-project/boost/storagemarket/provider_loop.go:537 +0x110
```