### PR TITLE
piece doctor to ignore expired/slashed deals

### DIFF
--- a/node/modules/piecedirectory.go
+++ b/node/modules/piecedirectory.go
@@ -23,6 +23,7 @@ import (
 	"github.com/filecoin-project/dagstore/shard"
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-jsonrpc"
+	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/api/v1api"
 	"github.com/filecoin-project/lotus/node/modules/dtypes"
 	lotus_repo "github.com/filecoin-project/lotus/node/repo"
@@ -157,8 +158,8 @@ func NewPieceStore(pm *piecedirectory.PieceDirectory, maddr address.Address) pie
 	return &boostPieceStoreWrapper{piecedirectory: pm, maddr: maddr}
 }
 
-func NewPieceDoctor(lc fx.Lifecycle, store *bdclient.Store, ssm *sectorstatemgr.SectorStateMgr) *piecedirectory.Doctor {
-	doc := piecedirectory.NewDoctor(store, ssm)
+func NewPieceDoctor(lc fx.Lifecycle, store *bdclient.Store, ssm *sectorstatemgr.SectorStateMgr, fullnodeApi api.FullNode) *piecedirectory.Doctor {
+	doc := piecedirectory.NewDoctor(store, ssm, fullnodeApi)
 	docctx, cancel := context.WithCancel(context.Background())
 	lc.Append(fx.Hook{
 		OnStart: func(ctx context.Context) error {

--- a/piecedirectory/doctor.go
+++ b/piecedirectory/doctor.go
@@ -149,6 +149,8 @@ func (d *Doctor) checkPiece(ctx context.Context, pieceCid cid.Cid, lu *sectorsta
 	if d.fullnodeApi != nil { // nil in tests
 		found := false
 		for _, dealId := range chainDealIds {
+			doclog.Debugw("checking state for market deal", "piece", pieceCid, "deal", dealId)
+
 			_, err := d.fullnodeApi.StateMarketStorageDeal(ctx, dealId, head.Key())
 			if err == nil {
 				found = true

--- a/piecedirectory/doctor.go
+++ b/piecedirectory/doctor.go
@@ -12,6 +12,7 @@ import (
 	bdclient "github.com/filecoin-project/boostd-data/client"
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/lotus/api"
 	"github.com/ipfs/go-cid"
 	logging "github.com/ipfs/go-log/v2"
 )
@@ -24,12 +25,13 @@ var doclog = logging.Logger("piecedoc")
 // Note that multiple Doctor processes can run in parallel. The logic for which
 // pieces to give to the Doctor to check is in the local index directory.
 type Doctor struct {
-	store *bdclient.Store
-	ssm   *sectorstatemgr.SectorStateMgr
+	store       *bdclient.Store
+	ssm         *sectorstatemgr.SectorStateMgr
+	fullnodeApi api.FullNode
 }
 
-func NewDoctor(store *bdclient.Store, ssm *sectorstatemgr.SectorStateMgr) *Doctor {
-	return &Doctor{store: store, ssm: ssm}
+func NewDoctor(store *bdclient.Store, ssm *sectorstatemgr.SectorStateMgr, fullnodeApi api.FullNode) *Doctor {
+	return &Doctor{store: store, ssm: ssm, fullnodeApi: fullnodeApi}
 }
 
 // The average interval between calls to NextPiecesToCheck
@@ -98,12 +100,75 @@ func (d *Doctor) Run(ctx context.Context) {
 }
 
 func (d *Doctor) checkPiece(ctx context.Context, pieceCid cid.Cid, lu *sectorstatemgr.SectorStateUpdates) error {
+	////////////////////////////////////////////////
+	// Check if piece belongs to an active sector
+	////////////////////////////////////////////////
 	md, err := d.store.GetPieceMetadata(ctx, pieceCid)
 	if err != nil {
 		return fmt.Errorf("failed to get piece %s from local index directory: %w", pieceCid, err)
 	}
 
+	lacksActiveSector := true // check whether the piece is present in active sector
+
+	var chainDealIds []abi.DealID
+	for _, dl := range md.Deals {
+		mid, err := address.IDFromAddress(dl.MinerAddr)
+		if err != nil {
+			return err
+		}
+
+		sectorID := abi.SectorID{
+			Miner:  abi.ActorID(mid),
+			Number: dl.SectorID,
+		}
+
+		// check if we have an active sector
+		if _, ok := lu.ActiveSectors[sectorID]; ok {
+			lacksActiveSector = false
+			chainDealIds = append(chainDealIds, dl.ChainDealID)
+		}
+	}
+
+	if lacksActiveSector {
+		doclog.Debugw("ignoring and unflagging piece as it is not present in an active sector", "piece", pieceCid)
+
+		err = d.store.UnflagPiece(ctx, pieceCid)
+		if err != nil {
+			return fmt.Errorf("failed to unflag piece %s: %w", pieceCid, err)
+		}
+		return nil
+	}
+
+	/////////////////////////////////////////////////////////////////
+	// Check that Deal is actually on-chain for the active sectors
+	/////////////////////////////////////////////////////////////////
+	head, err := d.fullnodeApi.ChainHead(ctx)
+	if err != nil {
+		return err
+	}
+
+	found := false
+	for _, dealId := range chainDealIds {
+		_, err := d.fullnodeApi.StateMarketStorageDeal(ctx, dealId, head.Key())
+		if err == nil {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		doclog.Debugw("ignoring and unflagging piece as no deal id found on chain", "piece", pieceCid)
+
+		err = d.store.UnflagPiece(ctx, pieceCid)
+		if err != nil {
+			return fmt.Errorf("failed to unflag piece %s: %w", pieceCid, err)
+		}
+		return nil
+	}
+
+	/////////////////////////////////////
 	// Check if piece has been indexed
+	/////////////////////////////////////
 	isIndexed, err := d.store.IsIndexed(ctx, pieceCid)
 	if err != nil {
 		return fmt.Errorf("failed to check index status of piece %s: %w", pieceCid, err)
@@ -118,15 +183,12 @@ func (d *Doctor) checkPiece(ctx context.Context, pieceCid cid.Cid, lu *sectorsta
 		return nil
 	}
 
-	// Check if there is an unsealed copy of the piece
+	//////////////////////////////////////////////////////////////////////////////////////////////
+	// If piece is indexed and has active sector and active deal on chain, check for unsealed copy
+	//////////////////////////////////////////////////////////////////////////////?///////////////
 	var hasUnsealedDeal bool
 
-	// Check whether the piece is present in active sector
-	lacksActiveSector := true
-
-	dls := md.Deals
-
-	for _, dl := range dls {
+	for _, dl := range md.Deals {
 		mid, err := address.IDFromAddress(dl.MinerAddr)
 		if err != nil {
 			return err
@@ -137,24 +199,19 @@ func (d *Doctor) checkPiece(ctx context.Context, pieceCid cid.Cid, lu *sectorsta
 			Number: dl.SectorID,
 		}
 
-		// check if we have an active sector
-		if _, ok := lu.ActiveSectors[sectorID]; ok {
-			lacksActiveSector = false
-		}
-
 		if lu.SectorStates[sectorID] == db.SealStateUnsealed {
 			hasUnsealedDeal = true
 			break
 		}
 	}
 
-	if !hasUnsealedDeal && !lacksActiveSector {
+	if !hasUnsealedDeal {
 		err = d.store.FlagPiece(ctx, pieceCid, false)
 		if err != nil {
 			return fmt.Errorf("failed to flag piece %s with no unsealed deal: %w", pieceCid, err)
 		}
 
-		doclog.Debugw("flagging piece as having no unsealed copy", "piece", pieceCid, "hasUnsealedDeal", hasUnsealedDeal, "lacksActiveSector", lacksActiveSector, "len(activeSectors)", len(lu.ActiveSectors), "len(sectorStates)", len(lu.SectorStates))
+		doclog.Debugw("flagging piece as having no unsealed copy", "piece", pieceCid, "hasUnsealedDeal", hasUnsealedDeal, "len(activeSectors)", len(lu.ActiveSectors), "len(sectorStates)", len(lu.SectorStates))
 		return nil
 	}
 

--- a/piecedirectory/doctor.go
+++ b/piecedirectory/doctor.go
@@ -100,6 +100,8 @@ func (d *Doctor) Run(ctx context.Context) {
 }
 
 func (d *Doctor) checkPiece(ctx context.Context, pieceCid cid.Cid, lu *sectorstatemgr.SectorStateUpdates) error {
+	defer func(start time.Time) { log.Debugw("checkPiece processing", "took", time.Since(start)) }(time.Now())
+
 	////////////////////////////////////////////////
 	// Check if piece belongs to an active sector
 	////////////////////////////////////////////////

--- a/piecedirectory/doctor_test.go
+++ b/piecedirectory/doctor_test.go
@@ -290,7 +290,7 @@ func testCheckPieces(ctx context.Context, t *testing.T, cl *client.Store) {
 	}
 
 	// Create a doctor
-	doc := NewDoctor(cl, nil)
+	doc := NewDoctor(cl, nil, nil)
 
 	// Check the piece
 	err = doc.checkPiece(ctx, commpCalc.PieceCID, ssu)

--- a/sectorstatemgr/sectorstatemgr_test.go
+++ b/sectorstatemgr/sectorstatemgr_test.go
@@ -110,9 +110,11 @@ func TestRefreshState(t *testing.T) {
 				mockExpectations := func() {
 					minerApi.EXPECT().StorageList(gomock.Any()).Return(input_StorageList1, nil)
 					fullnodeApi.EXPECT().StateMinerActiveSectors(gomock.Any(), gomock.Any(), gomock.Any()).Return(input_StateMinerActiveSectors1, nil)
+					fullnodeApi.EXPECT().StateMinerSectors(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
 
 					minerApi.EXPECT().StorageList(gomock.Any()).Return(input_StorageList2, nil)
 					fullnodeApi.EXPECT().StateMinerActiveSectors(gomock.Any(), gomock.Any(), gomock.Any()).Return(input_StateMinerActiveSectors2, nil)
+					fullnodeApi.EXPECT().StateMinerSectors(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
 
 					fullnodeApi.EXPECT().ChainHead(gomock.Any()).Times(2)
 				}
@@ -132,6 +134,7 @@ func TestRefreshState(t *testing.T) {
 						sid4: db.SealStateSealed,
 						sid5: db.SealStateCache,
 					},
+					SectorWithDeals: map[abi.SectorID]struct{}{},
 				}
 
 				exerciseAndVerify := func() {
@@ -192,6 +195,7 @@ func TestRefreshState(t *testing.T) {
 				mockExpectations := func() {
 					minerApi.EXPECT().StorageList(gomock.Any()).Return(input_StorageList, nil)
 					fullnodeApi.EXPECT().ChainHead(gomock.Any()).Times(1)
+					fullnodeApi.EXPECT().StateMinerSectors(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
 					fullnodeApi.EXPECT().StateMinerActiveSectors(gomock.Any(), gomock.Any(), gomock.Any()).Return(input_StateMinerActiveSectors, nil)
 				}
 
@@ -210,6 +214,7 @@ func TestRefreshState(t *testing.T) {
 						sid2: db.SealStateSealed,
 						sid3: db.SealStateSealed,
 					},
+					SectorWithDeals: map[abi.SectorID]struct{}{},
 				}
 
 				exerciseAndVerify := func() {


### PR DESCRIPTION
The algorithm in `checkPiece` currently flags piececids that the SP never stored -- they submitted a PSD, but the deal was never added to a sector. Even worse, another deal later on got added to that particular sectorID, which means that based on the metadata in LID, we would "think" that the deal's sector is `active`.

Therefore I am changing the algorithm to:
1. Check if piece belongs to an active sector
2. For the active sectors / deals from 1, check that at least one deal is actually found on-chain
3. At this stage we know there is an active sector and a real ChainDealID; check if the piececid is indexed
4. If the piece is indexed and has active sector and active deal on chain, check for unsealed copy

We `Flag` a piece on step 3 and 4 if a piece is not indexed or if there is no unsealed copy.
Otherwise we `Unflag` a piece.