### PR TITLE
feat: refactor mpool page in UI

### DIFF
--- a/gql/resolver_mpool.go
+++ b/gql/resolver_mpool.go
@@ -100,15 +100,6 @@ func (r *resolver) Mpool(ctx context.Context, args struct{ Alerts bool }) (mpool
 	return mpoolmsg{Count: int32(len(msgs)), Messages: ret}, nil
 }
 
-// query: mpoolAlertsCount: int
-func (r *resolver) MpoolAlertsCount(ctx context.Context) (int32, error) {
-	msgs, err := r.mpool.Alerts(ctx)
-	if err != nil {
-		return 0, fmt.Errorf("getting alert count: %w", err)
-	}
-	return int32(len(msgs)), nil
-}
-
 func mockMessages() []*types.SignedMessage {
 	to0, _ := address.NewFromString("f01469945")
 	from0, _ := address.NewFromString("f3uakndzne4lorwykinlitx2d2puuhgburvxw4dpkfskeofmzg33pm7okyzikqe2gzvaqj2k3hpunwayij6haa")

--- a/gql/schema.graphql
+++ b/gql/schema.graphql
@@ -418,7 +418,7 @@ type MpoolMessage {
 }
 
 type MpoolMessages {
-  Count: Uint64!
+  Count: Int!
   Messages: [MpoolMessage]!
 }
 

--- a/gql/schema.graphql
+++ b/gql/schema.graphql
@@ -417,6 +417,11 @@ type MpoolMessage {
   BaseFee: BigInt!
 }
 
+type MpoolMessages {
+  Count: Uint64!
+  Messages: [MpoolMessage]!
+}
+
 type Libp2pAddrInfo {
   Addresses: [String]!
   PeerID: String!
@@ -529,10 +534,7 @@ type RootQuery {
   transferStats: TransferStats!
 
   """Get local messages in the mpool"""
-  mpool(local: Boolean!): [MpoolMessage]!
-
-  """Get number of messages stuck in mpool"""
-  mpoolAlertsCount: Int!
+  mpool(alerts: Boolean!): MpoolMessages!
 
   """Get libp2p addresses and peer id"""
   libp2pAddrInfo: Libp2pAddrInfo!

--- a/lib/mpoolmonitor/mpoolmonitor.go
+++ b/lib/mpoolmonitor/mpoolmonitor.go
@@ -157,6 +157,8 @@ func (mm *MpoolMonitor) Alerts(ctx context.Context) ([]*TimeStampedMsg, error) {
 		return nil, fmt.Errorf("failed to get chain head: %w", err)
 	}
 
+	mm.lk.Lock()
+	defer mm.lk.Unlock()
 	for _, msg := range mm.msgs {
 		if msg.Added+mm.mpoolAlertEpochs <= ts.Height() {
 			ret = append(ret, msg)

--- a/react/src/MonitoringAlert.js
+++ b/react/src/MonitoringAlert.js
@@ -3,21 +3,22 @@ import './MonitoringAlert.css'
 import warnImg from "./bootstrap-icons/icons/exclamation-circle.svg"
 import {Link} from "react-router-dom";
 import {useQuery} from "@apollo/react-hooks";
-import {MpoolAlertsQuery} from "./gql";
+import {MpoolQuery} from "./gql";
 
 export function MonitoringAlert(props) {
-    const {data} = useQuery(MpoolAlertsQuery, {
-        pollInterval: 10000,
-        fetchPolicy: `network-only`,
-    })
+    // const alerts = true
+    // const {data} = useQuery(MpoolQuery, { variables: { alerts },
+    //     pollInterval: 10000,
+    //     fetchPolicy: `network-only`,
+    // })
 
     var count = 0
-    if (data) {
-        count = data.mpoolAlertsCount
-    }
-    if (count < 1) {
-        return null
-    }
+    // if (data) {
+    //     count = data.mpool.count
+    // }
+    // if (count < 1) {
+    //     return null
+    // }
 
     return (
         <div id="monitoring-alert" className="showing">

--- a/react/src/MonitoringAlert.js
+++ b/react/src/MonitoringAlert.js
@@ -6,19 +6,19 @@ import {useQuery} from "@apollo/react-hooks";
 import {MpoolQuery} from "./gql";
 
 export function MonitoringAlert(props) {
-    // const alerts = true
-    // const {data} = useQuery(MpoolQuery, { variables: { alerts },
-    //     pollInterval: 10000,
-    //     fetchPolicy: `network-only`,
-    // })
+    const alerts = true
+    const {data} = useQuery(MpoolQuery, { variables: { alerts },
+        pollInterval: 10000,
+        fetchPolicy: `network-only`,
+    })
 
     var count = 0
-    // if (data) {
-    //     count = data.mpool.count
-    // }
-    // if (count < 1) {
-    //     return null
-    // }
+    if (data) {
+        count = data.mpool.Count
+    }
+    if (count < 1) {
+        return null
+    }
 
     return (
         <div id="monitoring-alert" className="showing">

--- a/react/src/Mpool.js
+++ b/react/src/Mpool.js
@@ -24,13 +24,13 @@ function MpoolContent(props) {
         return <div>Error: {error.message}</div>
     }
 
-    const msgs = data.mpool.Messages
+    msgs.sort();
 
     return <div className="mpool">
         <div className="header">
-            Showing {msgs.length} {alerts ? 'alerts' : ''} messages in message pool.
+            Showing {msgs.length} {alerts ? 'alerts' : 'messages'} in message pool.
             <div className="button" onClick={() => setAlerts(!alerts)}>
-                Show {alerts ? 'All local messages' : 'alerts'}
+                Show {alerts ? 'All local messages' : 'Alerts'}
             </div>
         </div>
 

--- a/react/src/Mpool.js
+++ b/react/src/Mpool.js
@@ -14,8 +14,8 @@ export function MpoolPage(props) {
 }
 
 function MpoolContent(props) {
-    const [local, setLocal] = useState(true)
-    const {loading, error, data} = useQuery(MpoolQuery, { variables: { local } , pollInterval: 10000, fetchPolicy: "network-only"})
+    const [alerts, setAlerts] = useState(true)
+    const {loading, error, data} = useQuery(MpoolQuery, { variables: { alerts } , pollInterval: 10000, fetchPolicy: "network-only"})
 
     if (loading) {
         return <div>Loading...</div>
@@ -24,13 +24,13 @@ function MpoolContent(props) {
         return <div>Error: {error.message}</div>
     }
 
-    const msgs = data.mpool
+    const msgs = data.mpool.Messages
 
     return <div className="mpool">
         <div className="header">
-            Showing {msgs.length} {local ? 'local' : ''} messages in message pool.
-            <div className="button" onClick={() => setLocal(!local)}>
-                Show {local ? 'All' : 'Local'} messages
+            Showing {msgs.length} {alerts ? 'alerts' : ''} messages in message pool.
+            <div className="button" onClick={() => setAlerts(!alerts)}>
+                Show {alerts ? 'All local messages' : 'alerts'}
             </div>
         </div>
 

--- a/react/src/Mpool.js
+++ b/react/src/Mpool.js
@@ -24,7 +24,7 @@ function MpoolContent(props) {
         return <div>Error: {error.message}</div>
     }
 
-    msgs.sort();
+    const msgs = data.mpool.Messages
 
     return <div className="mpool">
         <div className="header">

--- a/react/src/gql.js
+++ b/react/src/gql.js
@@ -682,26 +682,23 @@ const StorageAskUpdate = gql`
 `;
 
 const MpoolQuery = gql`
-    query AppMpoolQuery($local: Boolean!) {
-        mpool(local: $local) {
-            SentEpoch
-            From
-            To
-            Nonce
-            Value
-            GasFeeCap
-            GasLimit
-            GasPremium
-            Method
-            Params
-            BaseFee
+    query AppMpoolQuery($alerts: Boolean!) {
+        mpool(alerts: $alerts) {
+            Count
+            Messages {
+                SentEpoch
+                From
+                To
+                Nonce
+                Value
+                GasFeeCap
+                GasLimit
+                GasPremium
+                Method
+                Params
+                BaseFee
+            }
         }
-    }
-`;
-
-const MpoolAlertsQuery = gql`
-    query AppMpoolAlertsQuery {
-        mpoolAlertsCount
     }
 `;
 
@@ -764,7 +761,6 @@ export {
     TransfersQuery,
     TransferStatsQuery,
     MpoolQuery,
-    MpoolAlertsQuery,
     SealingPipelineQuery,
     Libp2pAddrInfoQuery,
     StorageAskQuery,


### PR DESCRIPTION
This PR fixes https://github.com/filecoin-project/boost/issues/1526  and introduces the following changes to the Mpool page in UI.

1. It removed the all messages
2. Only local messages are captured by mpoolMonitor
3. Mpool resolver now works for alert messages or all messages
4. By default mpool UI will show all alert messages in details. This would allow for better debugging than just saying how many messages are stuck.

<img width="1496" alt="Screenshot 2023-06-19 at 7 51 47 PM" src="https://github.com/filecoin-project/boost/assets/88259624/c3469423-f033-412f-8c94-1b14bef9e9ad">


5. The button had been updated to show all local messages. User will have less use of local messages as well if there are not alerts. Thus the decision to make alerts primary and all messages a secondary query. 

<img width="1496" alt="Screenshot 2023-06-19 at 7 51 51 PM" src="https://github.com/filecoin-project/boost/assets/88259624/5b62e0cd-5d12-4945-8d4d-0185aef62479">
