### PR TITLE
Build indexes for legacy deals

### DIFF
--- a/gql/resolver.go
+++ b/gql/resolver.go
@@ -15,6 +15,7 @@ import (
 	"github.com/filecoin-project/boost/db"
 	"github.com/filecoin-project/boost/fundmanager"
 	gqltypes "github.com/filecoin-project/boost/gql/types"
+	"github.com/filecoin-project/boost/lib/legacy"
 	"github.com/filecoin-project/boost/lib/mpoolmonitor"
 	"github.com/filecoin-project/boost/markets/storageadapter"
 	"github.com/filecoin-project/boost/node/config"
@@ -61,6 +62,7 @@ type resolver struct {
 	fundMgr        *fundmanager.FundManager
 	storageMgr     *storagemanager.StorageManager
 	provider       *storagemarket.Provider
+	legacyDeals    *legacy.LegacyDealsManager
 	legacyProv     gfm_storagemarket.StorageProvider
 	legacyDT       dtypes.ProviderDataTransfer
 	ps             piecestore.PieceStore
@@ -73,7 +75,7 @@ type resolver struct {
 	mpool          *mpoolmonitor.MpoolMonitor
 }
 
-func NewResolver(ctx context.Context, cfg *config.Boost, r lotus_repo.LockedRepo, h host.Host, dealsDB *db.DealsDB, logsDB *db.LogsDB, retDB *rtvllog.RetrievalLogDB, plDB *db.ProposalLogsDB, fundsDB *db.FundsDB, fundMgr *fundmanager.FundManager, storageMgr *storagemanager.StorageManager, spApi sealingpipeline.API, provider *storagemarket.Provider, legacyProv gfm_storagemarket.StorageProvider, legacyDT dtypes.ProviderDataTransfer, ps piecestore.PieceStore, sa retrievalmarket.SectorAccessor, piecedirectory *piecedirectory.PieceDirectory, publisher *storageadapter.DealPublisher, fullNode v1api.FullNode, ssm *sectorstatemgr.SectorStateMgr, mpool *mpoolmonitor.MpoolMonitor) *resolver {
+func NewResolver(ctx context.Context, cfg *config.Boost, r lotus_repo.LockedRepo, h host.Host, dealsDB *db.DealsDB, logsDB *db.LogsDB, retDB *rtvllog.RetrievalLogDB, plDB *db.ProposalLogsDB, fundsDB *db.FundsDB, fundMgr *fundmanager.FundManager, storageMgr *storagemanager.StorageManager, spApi sealingpipeline.API, provider *storagemarket.Provider, legacyDeals *legacy.LegacyDealsManager, legacyProv gfm_storagemarket.StorageProvider, legacyDT dtypes.ProviderDataTransfer, ps piecestore.PieceStore, sa retrievalmarket.SectorAccessor, piecedirectory *piecedirectory.PieceDirectory, publisher *storageadapter.DealPublisher, fullNode v1api.FullNode, ssm *sectorstatemgr.SectorStateMgr, mpool *mpoolmonitor.MpoolMonitor) *resolver {
 	return &resolver{
 		ctx:            ctx,
 		cfg:            cfg,
@@ -87,6 +89,7 @@ func NewResolver(ctx context.Context, cfg *config.Boost, r lotus_repo.LockedRepo
 		fundMgr:        fundMgr,
 		storageMgr:     storageMgr,
 		provider:       provider,
+		legacyDeals:    legacyDeals,
 		legacyProv:     legacyProv,
 		legacyDT:       legacyDT,
 		ps:             ps,

--- a/gql/resolver_legacy.go
+++ b/gql/resolver_legacy.go
@@ -115,8 +115,8 @@ func (r *resolver) LegacyDeals(ctx context.Context, args dealsArgs) (*legacyDeal
 	}, nil
 }
 
-func (r *resolver) LegacyDealsCount() (int32, error) {
-	dealCount, err := r.legacyProv.LocalDealCount()
+func (r *resolver) LegacyDealsCount(ctx context.Context) (int32, error) {
+	dealCount, err := r.legacyDeals.DealCount(ctx)
 	if err != nil {
 		return 0, fmt.Errorf("getting deal count: %w", err)
 	}

--- a/gql/resolver_sealingpipeline.go
+++ b/gql/resolver_sealingpipeline.go
@@ -228,7 +228,7 @@ func (r *resolver) populateWaitDealsSectors(ctx context.Context, sectorNumbers [
 			}
 
 			// match not found in boost db - fallback to legacy deals list
-			lds, err := r.legacyProv.ListLocalDeals()
+			lds, err := r.legacyDeals.ByPublishCid(ctx, *publishCid)
 			if err != nil {
 				return nil, err
 			}
@@ -236,16 +236,12 @@ func (r *resolver) populateWaitDealsSectors(ctx context.Context, sectorNumbers [
 			var j int
 			for ; j < len(lds); j++ {
 				l := lds[j]
-				if l.PublishCid == nil {
-					continue
-				}
-
 				lpcid, err := l.ClientDealProposal.Proposal.Cid()
 				if err != nil {
 					return nil, err
 				}
 
-				if l.PublishCid.Equals(*publishCid) && lpcid.Equals(dcid) {
+				if lpcid.Equals(dcid) {
 					break
 				}
 			}

--- a/gql/schema.graphql
+++ b/gql/schema.graphql
@@ -187,7 +187,9 @@ type PieceStatus {
 
 type FlaggedPieceStatus {
   CreatedAt: Time!
-  Piece: PieceStatus!
+  PieceCid: String!
+  IndexStatus: IndexStatus!
+  DealCount: Int!
 }
 
 type FlaggedPiecesList {

--- a/lib/legacy/dealmanager.go
+++ b/lib/legacy/dealmanager.go
@@ -1,0 +1,190 @@
+package legacy
+
+import (
+	"context"
+	"errors"
+	gfm_storagemarket "github.com/filecoin-project/boost-gfm/storagemarket"
+	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-datastore"
+	logging "github.com/ipfs/go-log/v2"
+	"sync"
+	"time"
+)
+
+var log = logging.Logger("legacydeals")
+
+type LegacyDealsManager struct {
+	legacyProv gfm_storagemarket.StorageProvider
+
+	startedOnce sync.Once
+	started     chan struct{}
+
+	lk            sync.RWMutex
+	dealCount     int
+	pieceCidIdx   map[cid.Cid][]cid.Cid
+	payloadCidIdx map[cid.Cid][]cid.Cid
+	publishCidIdx map[cid.Cid][]cid.Cid
+}
+
+func NewLegacyDealsManager(legacyProv gfm_storagemarket.StorageProvider) *LegacyDealsManager {
+	return &LegacyDealsManager{
+		legacyProv:    legacyProv,
+		started:       make(chan struct{}),
+		pieceCidIdx:   make(map[cid.Cid][]cid.Cid),
+		payloadCidIdx: make(map[cid.Cid][]cid.Cid),
+		publishCidIdx: make(map[cid.Cid][]cid.Cid),
+	}
+}
+
+func (m *LegacyDealsManager) Run(ctx context.Context) {
+	refresh := func() {
+		err := m.refresh()
+		if err != nil {
+			log.Warnf("refreshing list of legacy deals: %s", err)
+		}
+	}
+
+	// Refresh list on startup
+	refresh()
+
+	// Refresh list every 10 minutes
+	ticker := time.NewTicker(10 * time.Minute)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			refresh()
+		}
+	}
+}
+
+func (m *LegacyDealsManager) refresh() error {
+	start := time.Now()
+	log.Infow("refreshing legacy deals list")
+	dls, err := m.legacyProv.ListLocalDeals()
+	if err != nil {
+		return err
+	}
+
+	log.Infow("refreshed legacy deals list",
+		"elapsed", time.Since(start).String(), "count", len(dls))
+
+	m.lk.Lock()
+	{
+		m.dealCount = len(dls)
+
+		for _, dl := range dls {
+			// piece cid -> signed proposal cid
+			if dl.Ref != nil && dl.Ref.PieceCid != nil && dl.Ref.PieceCid.Defined() {
+				m.pieceCidIdx[*dl.Ref.PieceCid] = append(m.pieceCidIdx[*dl.Ref.PieceCid], dl.ProposalCid)
+			}
+
+			// payload cid -> signed proposal cid
+			if dl.Ref != nil && dl.Ref.Root.Defined() {
+				m.payloadCidIdx[dl.Ref.Root] = append(m.payloadCidIdx[dl.Ref.Root], dl.ProposalCid)
+			}
+
+			// publish cid -> signed proposal cid
+			if dl.PublishCid != nil && dl.PublishCid.Defined() {
+				m.publishCidIdx[*dl.PublishCid] = append(m.publishCidIdx[*dl.PublishCid], dl.ProposalCid)
+			}
+		}
+	}
+	m.lk.Unlock()
+
+	m.startedOnce.Do(func() {
+		close(m.started)
+	})
+
+	return nil
+}
+
+func (m *LegacyDealsManager) waitStarted(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-m.started:
+		return nil
+	}
+}
+
+func (m *LegacyDealsManager) DealCount(ctx context.Context) (int, error) {
+	if err := m.waitStarted(ctx); err != nil {
+		return 0, err
+	}
+
+	m.lk.RLock()
+	defer m.lk.RUnlock()
+
+	return m.dealCount, nil
+}
+
+func (m *LegacyDealsManager) ByPieceCid(ctx context.Context, pieceCid cid.Cid) ([]gfm_storagemarket.MinerDeal, error) {
+	if err := m.waitStarted(ctx); err != nil {
+		return nil, err
+	}
+
+	// The index stores a mapping of piece cid -> deal proposal cids
+	m.lk.RLock()
+	propCids, ok := m.pieceCidIdx[pieceCid]
+	m.lk.RUnlock()
+	if !ok {
+		return nil, nil
+	}
+
+	return m.byPropCids(propCids)
+}
+
+func (m *LegacyDealsManager) ByPayloadCid(ctx context.Context, payloadCid cid.Cid) ([]gfm_storagemarket.MinerDeal, error) {
+	if err := m.waitStarted(ctx); err != nil {
+		return nil, err
+	}
+
+	// The index stores a mapping of payload cid -> deal proposal cids
+	m.lk.RLock()
+	propCids, ok := m.payloadCidIdx[payloadCid]
+	m.lk.RUnlock()
+	if !ok {
+		return nil, nil
+	}
+
+	return m.byPropCids(propCids)
+}
+
+func (m *LegacyDealsManager) ByPublishCid(ctx context.Context, publishCid cid.Cid) ([]gfm_storagemarket.MinerDeal, error) {
+	if err := m.waitStarted(ctx); err != nil {
+		return nil, err
+	}
+
+	// The index stores a mapping of publish cid -> deal proposal cids
+	m.lk.RLock()
+	propCids, ok := m.publishCidIdx[publishCid]
+	m.lk.RUnlock()
+	if !ok {
+		return nil, nil
+	}
+
+	return m.byPropCids(propCids)
+}
+
+// Get deals by deal signed proposal cid
+func (m *LegacyDealsManager) byPropCids(propCids []cid.Cid) ([]gfm_storagemarket.MinerDeal, error) {
+	dls := make([]gfm_storagemarket.MinerDeal, 0, len(propCids))
+	for _, propCid := range propCids {
+		dl, err := m.legacyProv.GetLocalDeal(propCid)
+		if err == nil {
+			dls = append(dls, dl)
+			continue
+		}
+
+		// If there's a "not found" error, ignore it.
+		// For any other type of error, stop processing and return it.
+		if !errors.Is(err, datastore.ErrNotFound) {
+			return nil, err
+		}
+	}
+
+	return dls, nil
+}

--- a/node/builder.go
+++ b/node/builder.go
@@ -18,6 +18,7 @@ import (
 	"github.com/filecoin-project/boost/fundmanager"
 	"github.com/filecoin-project/boost/gql"
 	"github.com/filecoin-project/boost/indexprovider"
+	"github.com/filecoin-project/boost/lib/legacy"
 	"github.com/filecoin-project/boost/lib/mpoolmonitor"
 	"github.com/filecoin-project/boost/markets/idxprov"
 	"github.com/filecoin-project/boost/markets/retrievaladapter"
@@ -513,6 +514,7 @@ func ConfigBoost(cfg *config.Boost) Option {
 		Override(new(*sectorstatemgr.SectorStateMgr), sectorstatemgr.NewSectorStateMgr(cfg)),
 		Override(new(*indexprovider.Wrapper), indexprovider.NewWrapper(cfg)),
 
+		Override(new(*legacy.LegacyDealsManager), modules.NewLegacyDealsManager),
 		Override(new(*storagemarket.ChainDealManager), modules.NewChainDealManager),
 		Override(new(smtypes.CommpCalculator), From(new(lotus_modules.MinerStorageService))),
 

--- a/react/src/LID.js
+++ b/react/src/LID.js
@@ -303,8 +303,8 @@ function FlaggedPieces({setSearchQuery}) {
 
                 {rows.map(piece => (
                     <FlaggedPieceRow
-                        key={piece.Piece.PieceCid}
-                        piece={piece.Piece}
+                        key={piece.PieceCid}
+                        piece={piece}
                         setSearchQuery={setSearchQuery}
                     />
                 ))}
@@ -348,7 +348,7 @@ function FlaggedPieceRow({piece}) {
             </Link>
         </td>
         <td>{piece.IndexStatus.Status}</td>
-        <td>{piece.Deals.length}</td>
+        <td>{piece.DealCount}</td>
     </tr>
 }
 
@@ -436,8 +436,8 @@ function NoUnsealedSectorPieces() {
 
                 {rows.map(piece => (
                     <FlaggedPieceRow
-                        key={piece.Piece.PieceCid}
-                        piece={piece.Piece}
+                        key={piece.PieceCid}
+                        piece={piece}
                     />
                 ))}
                 </tbody>

--- a/react/src/gql.js
+++ b/react/src/gql.js
@@ -402,21 +402,12 @@ const FlaggedPiecesQuery = gql`
         piecesFlagged(hasUnsealedCopy: $hasUnsealedCopy, cursor: $cursor, offset: $offset, limit: $limit) {
             pieces {
                 CreatedAt
-                Piece {
-                    PieceCid
-                    IndexStatus {
-                        Status
-                        Error
-                    }
-                    Deals {
-                        Deal {
-                            ID
-                            IsLegacy
-                            CreatedAt
-                            DealDataRoot
-                        }
-                    }
+                PieceCid
+                IndexStatus {
+                    Status
+                    Error
                 }
+                DealCount
             }
             totalCount
             more


### PR DESCRIPTION
The list of flagged pieces is quite slow to load. This is because it scans through all the legacy deals to find matches against flagged pieces.

This PR adds an index for legacy deals by piece cid, root payload cid and publish cid. The index is refreshed every 10 minutes.

Test:
- [x] Manual test on sofiaminer