### PR TITLE
add peerID to multiaddresses returned by boost provider retrieval-transports query

### DIFF
--- a/cmd/boost/provider_cmd_test.go
+++ b/cmd/boost/provider_cmd_test.go
@@ -33,11 +33,6 @@ func TestMultiaddrToNative(t *testing.T) {
 		proto:    "fancynewproto",
 		ma:       "/dns/foo.com/tcp/80/http",
 		expected: "",
-	}, {
-		name:     "test protocol",
-		proto:    "http",
-		ma:       "/dns/foo.com/tcp/7777/http/p2p/12D3KooWHf7cahZvAVB36SGaVXc7fiVDoJdRJq42zDRcN2s2512h",
-		expected: "http://foo.com:7777",
 	}}
 
 	for _, tc := range testCases {

--- a/cmd/boost/provider_cmd_test.go
+++ b/cmd/boost/provider_cmd_test.go
@@ -1,9 +1,10 @@
 package main
 
 import (
+	"testing"
+
 	"github.com/multiformats/go-multiaddr"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestMultiaddrToNative(t *testing.T) {
@@ -32,6 +33,11 @@ func TestMultiaddrToNative(t *testing.T) {
 		proto:    "fancynewproto",
 		ma:       "/dns/foo.com/tcp/80/http",
 		expected: "",
+	}, {
+		name:     "test protocol",
+		proto:    "http",
+		ma:       "/dns/foo.com/tcp/7777/http/p2p/12D3KooWHf7cahZvAVB36SGaVXc7fiVDoJdRJq42zDRcN2s2512h",
+		expected: "http://foo.com:7777",
 	}}
 
 	for _, tc := range testCases {

--- a/node/modules/retrieval.go
+++ b/node/modules/retrieval.go
@@ -35,7 +35,7 @@ func bitswapMultiAddrs(cfg *config.Boost, h host.Host) ([]multiaddr.Multiaddr, e
 			Addrs: h.Addrs(),
 		})
 		if err != nil {
-			return nil, fmt.Errorf("could not parse bitswap address: %w", err)
+			return nil, fmt.Errorf("could not parse bitswap addresses: %w", err)
 		}
 		return maddr, nil
 	}
@@ -75,7 +75,7 @@ func NewTransportsListener(cfg *config.Boost) func(h host.Host) (*lp2pimpl.Trans
 				Addrs: h.Addrs(),
 			})
 			if err != nil {
-				return nil, fmt.Errorf("could not parse libp2p address: %w", err)
+				return nil, fmt.Errorf("could not parse libp2p addresses: %w", err)
 			}
 			protos = append(protos, types.Protocol{
 				Name:      "libp2p",
@@ -97,7 +97,7 @@ func NewTransportsListener(cfg *config.Boost) func(h host.Host) (*lp2pimpl.Trans
 				Addrs: []multiaddr.Multiaddr{maddr},
 			})
 			if err != nil {
-				return nil, fmt.Errorf("could not parse libp2p address: %w", err)
+				return nil, fmt.Errorf("could not parse http addresses: %w", err)
 			}
 			protos = append(protos, types.Protocol{
 				Name:      "http",

--- a/node/modules/retrieval.go
+++ b/node/modules/retrieval.go
@@ -92,16 +92,9 @@ func NewTransportsListener(cfg *config.Boost) func(h host.Host) (*lp2pimpl.Trans
 				msg += "Could not parse '%s' as multiaddr: %w"
 				return nil, fmt.Errorf(msg, cfg.Dealmaking.HTTPRetrievalMultiaddr, err)
 			}
-			httpaddr, err := peer.AddrInfoToP2pAddrs(&peer.AddrInfo{
-				ID:    h.ID(),
-				Addrs: []multiaddr.Multiaddr{maddr},
-			})
-			if err != nil {
-				return nil, fmt.Errorf("could not parse http addresses: %w", err)
-			}
 			protos = append(protos, types.Protocol{
 				Name:      "http",
-				Addresses: httpaddr,
+				Addresses: []multiaddr.Multiaddr{maddr},
 			})
 		}
 


### PR DESCRIPTION
Fixed #1555 

- [x] Devnet test

Output with Public Bitswap address:
```
# boost provider retrieval-transports t01000
libp2p
  /ip4/127.0.0.1/tcp/50000/p2p/12D3KooWQwgwg4FwN1SDxXvuQkYRtuDsW7ysgHtqsZyfYv1nurQj
  /ip4/172.18.0.4/tcp/50000/p2p/12D3KooWQwgwg4FwN1SDxXvuQkYRtuDsW7ysgHtqsZyfYv1nurQj
http
  /dns/foo.com/tcp/443/https/p2p/12D3KooWQwgwg4FwN1SDxXvuQkYRtuDsW7ysgHtqsZyfYv1nurQj
    https://foo.com:443
bitswap
  /ip4/172.18.0.7/tcp/8888/p2p/12D3KooWBUE8A4hmnAQBJLusjYDjQ7DUTFKcqh2H2PATzCv4VLCH
  /ip4/127.0.0.1/tcp/8888/p2p/12D3KooWBUE8A4hmnAQBJLusjYDjQ7DUTFKcqh2H2PATzCv4VLCH
```


Output with Private (proxy) Bitswap address:
```
libp2p
  /ip4/127.0.0.1/tcp/50000/p2p/12D3KooWQwgwg4FwN1SDxXvuQkYRtuDsW7ysgHtqsZyfYv1nurQj
  /ip4/172.18.0.4/tcp/50000/p2p/12D3KooWQwgwg4FwN1SDxXvuQkYRtuDsW7ysgHtqsZyfYv1nurQj
http
  /dns/foo.com/tcp/443/https/p2p/12D3KooWQwgwg4FwN1SDxXvuQkYRtuDsW7ysgHtqsZyfYv1nurQj
    https://foo.com:443
bitswap
  /ip4/127.0.0.1/tcp/50000/p2p/12D3KooWQwgwg4FwN1SDxXvuQkYRtuDsW7ysgHtqsZyfYv1nurQj
  /ip4/172.18.0.4/tcp/50000/p2p/12D3KooWQwgwg4FwN1SDxXvuQkYRtuDsW7ysgHtqsZyfYv1nurQj
```

Output without HTTP public multiaddress:

```
libp2p
  /ip4/127.0.0.1/tcp/50000/p2p/12D3KooWQwgwg4FwN1SDxXvuQkYRtuDsW7ysgHtqsZyfYv1nurQj
  /ip4/172.18.0.4/tcp/50000/p2p/12D3KooWQwgwg4FwN1SDxXvuQkYRtuDsW7ysgHtqsZyfYv1nurQj
bitswap
  /ip4/127.0.0.1/tcp/50000/p2p/12D3KooWQwgwg4FwN1SDxXvuQkYRtuDsW7ysgHtqsZyfYv1nurQj
  /ip4/172.18.0.4/tcp/50000/p2p/12D3KooWQwgwg4FwN1SDxXvuQkYRtuDsW7ysgHtqsZyfYv1nurQj
```