### PR TITLE
feat: manual publish storage deal message

### DIFF
--- a/gql/resolver_dealpublish.go
+++ b/gql/resolver_dealpublish.go
@@ -162,6 +162,11 @@ func (r *resolver) DealPublish(ctx context.Context) (*dealPublishResolver, error
 	}, nil
 }
 
+func (r *resolver) DealPublishNow(ctx context.Context) (bool, error) {
+	r.publisher.ForcePublishPendingDeals()
+	return true, nil
+}
+
 // mutation: publishPendingDeals([ID!]!): [ID!]!
 func (r *resolver) PublishPendingDeals(ctx context.Context, args struct{ IDs []graphql.ID }) ([]graphql.ID, error) {
 	var pcids []cid.Cid

--- a/gql/schema.graphql
+++ b/gql/schema.graphql
@@ -412,6 +412,7 @@ type FundsLog {
 }
 
 type DealPublish {
+  ManualPSD: Boolean!
   Period: Int!
   Start: Time!
   MaxDealsPerMsg: Int!
@@ -609,6 +610,9 @@ type RootMutation {
 
   """Update the Storage Ask (price of doing a storage deal)"""
   storageAskUpdate(update: StorageAskUpdate!): Boolean!
+
+  """Publish the deal for the supplied deal UUIDs"""
+  publishPendingDeals(ids: [ID!]!): Boolean!
 }
 
 type RootSubscription {

--- a/gql/schema.graphql
+++ b/gql/schema.graphql
@@ -599,6 +599,9 @@ type RootMutation {
   """Fail a Deal that was paused because of an error"""
   dealFailPaused(id: ID!): ID!
 
+  """Publish all pending deals now"""
+  dealPublishNow: Boolean!
+
   """Explicitly load the piece data from the sealing subsystem and index it"""
   pieceBuildIndex(pieceCid: String!): Boolean!
 

--- a/gql/schema.graphql
+++ b/gql/schema.graphql
@@ -612,7 +612,7 @@ type RootMutation {
   storageAskUpdate(update: StorageAskUpdate!): Boolean!
 
   """Publish the deal for the supplied deal UUIDs"""
-  publishPendingDeals(ids: [ID!]!): Boolean!
+  publishPendingDeals(ids: [ID!]!): [ID!]!
 }
 
 type RootSubscription {

--- a/gql/schema.graphql
+++ b/gql/schema.graphql
@@ -599,9 +599,6 @@ type RootMutation {
   """Fail a Deal that was paused because of an error"""
   dealFailPaused(id: ID!): ID!
 
-  """Publish all pending deals now"""
-  dealPublishNow: Boolean!
-
   """Explicitly load the piece data from the sealing subsystem and index it"""
   pieceBuildIndex(pieceCid: String!): Boolean!
 

--- a/markets/storageadapter/dealpublisher.go
+++ b/markets/storageadapter/dealpublisher.go
@@ -495,7 +495,7 @@ func (p *DealPublisher) PublishQueuedDeals(deals []cid.Cid) (error, []cid.Cid) {
 	for _, c := range deals {
 		found := false
 		for _, pd := range p.pending {
-			if c == pd.proposalCid {
+			if c.Equals(pd.proposalCid) {
 				found = true
 				toPublish = append(toPublish, pd)
 				break

--- a/markets/storageadapter/dealpublisher.go
+++ b/markets/storageadapter/dealpublisher.go
@@ -147,6 +147,7 @@ func newDealPublisher(
 		startEpochSealingBuffer: abi.ChainEpoch(publishMsgCfg.StartEpochSealingBuffer),
 		publishSpec:             publishSpec,
 		manualPSD:               publishMsgCfg.ManualDealPublish,
+		pending:                 make(map[cid.Cid]*pendingDeal),
 	}
 }
 

--- a/markets/storageadapter/dealpublisher.go
+++ b/markets/storageadapter/dealpublisher.go
@@ -176,6 +176,16 @@ func (p *DealPublisher) PendingDeals() api.PendingDealInfo {
 	}
 }
 
+// ForcePublishPendingDeals publishes all pending deals without waiting for
+// the publish period to elapse
+func (p *DealPublisher) ForcePublishPendingDeals() {
+	p.lk.Lock()
+	defer p.lk.Unlock()
+
+	log.Infof("force publishing deals")
+	p.publishAllDeals()
+}
+
 func (p *DealPublisher) Publish(ctx context.Context, deal market.ClientDealProposal) (cid.Cid, error) {
 	pdeal, err := newPendingDeal(ctx, deal)
 	if err != nil {

--- a/markets/storageadapter/dealpublisher.go
+++ b/markets/storageadapter/dealpublisher.go
@@ -295,7 +295,7 @@ func (p *DealPublisher) publishAllDeals() {
 	for _, deal := range p.pending {
 		deals = append(deals, deal)
 	}
-	p.pending = nil
+	p.pending = make(map[cid.Cid]*pendingDeal)
 	go p.publishReady(deals)
 }
 
@@ -460,14 +460,11 @@ func pieceCids(deals []market.ClientDealProposal) string {
 
 // filter out deals that have been cancelled
 func (p *DealPublisher) filterCancelledDeals() {
-	filtered := make(map[cid.Cid]*pendingDeal)
 	for c, pd := range p.pending {
 		if pd.ctx.Err() != nil {
-			continue
+			delete(p.pending, c)
 		}
-		filtered[c] = pd
 	}
-	p.pending = filtered
 }
 
 func (p *DealPublisher) PublishQueuedDeals(deals []cid.Cid) []cid.Cid {

--- a/markets/storageadapter/dealpublisher_test.go
+++ b/markets/storageadapter/dealpublisher_test.go
@@ -257,7 +257,7 @@ func TestPublishPendingDeals(t *testing.T) {
 	// Allow a moment for them to be queued
 	build.Clock.Sleep(10 * time.Millisecond)
 
-	// Should be two deals in the pending deals list
+	// Should be three deals in the pending deals list
 	// (deal with cancelled context is ignored)
 	pendingInfo := dp.PendingDeals()
 	require.Len(t, pendingInfo.Deals, 3)
@@ -277,11 +277,11 @@ func TestPublishPendingDeals(t *testing.T) {
 	c, err := cid.Decode("bafy2bzacea3wsdh6y3a36tb3skempjoxqpuyompjbmfeyf34fi3uy6uue42v4")
 	require.NoError(t, err)
 
-	// Publish all pending deals and verify all have been published
+	// Publish three pending deals and verify all deals whose context has not expired have been published
 	publishedDeals := dp.PublishQueuedDeals(append(toPublish, c))
 	require.Equal(t, toPublish, publishedDeals)
 
-	// Should be no pending deals
+	// Should be one remaining pending deal
 	pendingInfo1 := dp.PendingDeals()
 	var ppcids []cid.Cid
 	require.Len(t, pendingInfo1.Deals, 1)

--- a/node/builder.go
+++ b/node/builder.go
@@ -629,7 +629,7 @@ func ConfigBoost(cfg *config.Boost) Option {
 			Period:                     time.Duration(cfg.LotusDealmaking.PublishMsgPeriod),
 			MaxDealsPerMsg:             cfg.LotusDealmaking.MaxDealsPerPublishMsg,
 			StartEpochSealingBuffer:    cfg.LotusDealmaking.StartEpochSealingBuffer,
-			ExternalDealPublishControl: cfg.Dealmaking.ExternalDealPublishControl,
+			ExternalDealPublishControl: cfg.Dealmaking.ManualDealPublish,
 		})),
 
 		Override(new(sealer.Unsealer), From(new(lotus_modules.MinerStorageService))),

--- a/node/builder.go
+++ b/node/builder.go
@@ -626,10 +626,10 @@ func ConfigBoost(cfg *config.Boost) Option {
 		),
 
 		Override(new(*storageadapter.DealPublisher), storageadapter.NewDealPublisher(&legacyFees, storageadapter.PublishMsgConfig{
-			Period:                     time.Duration(cfg.LotusDealmaking.PublishMsgPeriod),
-			MaxDealsPerMsg:             cfg.LotusDealmaking.MaxDealsPerPublishMsg,
-			StartEpochSealingBuffer:    cfg.LotusDealmaking.StartEpochSealingBuffer,
-			ExternalDealPublishControl: cfg.Dealmaking.ManualDealPublish,
+			Period:                  time.Duration(cfg.LotusDealmaking.PublishMsgPeriod),
+			MaxDealsPerMsg:          cfg.LotusDealmaking.MaxDealsPerPublishMsg,
+			StartEpochSealingBuffer: cfg.LotusDealmaking.StartEpochSealingBuffer,
+			ManualDealPublish:       cfg.Dealmaking.ManualDealPublish,
 		})),
 
 		Override(new(sealer.Unsealer), From(new(lotus_modules.MinerStorageService))),

--- a/node/builder.go
+++ b/node/builder.go
@@ -626,9 +626,10 @@ func ConfigBoost(cfg *config.Boost) Option {
 		),
 
 		Override(new(*storageadapter.DealPublisher), storageadapter.NewDealPublisher(&legacyFees, storageadapter.PublishMsgConfig{
-			Period:                  time.Duration(cfg.LotusDealmaking.PublishMsgPeriod),
-			MaxDealsPerMsg:          cfg.LotusDealmaking.MaxDealsPerPublishMsg,
-			StartEpochSealingBuffer: cfg.LotusDealmaking.StartEpochSealingBuffer,
+			Period:                     time.Duration(cfg.LotusDealmaking.PublishMsgPeriod),
+			MaxDealsPerMsg:             cfg.LotusDealmaking.MaxDealsPerPublishMsg,
+			StartEpochSealingBuffer:    cfg.LotusDealmaking.StartEpochSealingBuffer,
+			ExternalDealPublishControl: cfg.Dealmaking.ExternalDealPublishControl,
 		})),
 
 		Override(new(sealer.Unsealer), From(new(lotus_modules.MinerStorageService))),

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -142,6 +142,7 @@ func DefaultBoost() *Boost {
 			SealingPipelineCacheTimeout:        Duration(30 * time.Second),
 			FundsTaggingEnabled:                true,
 			EnableLegacyStorageDeals:           false,
+			ExternalDealPublishControl:         false,
 		},
 
 		LotusDealmaking: lotus_config.DealmakingConfig{

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -142,7 +142,7 @@ func DefaultBoost() *Boost {
 			SealingPipelineCacheTimeout:        Duration(30 * time.Second),
 			FundsTaggingEnabled:                true,
 			EnableLegacyStorageDeals:           false,
-			ExternalDealPublishControl:         false,
+			ManualDealPublish:                  false,
 		},
 
 		LotusDealmaking: lotus_config.DealmakingConfig{

--- a/node/config/doc_gen.go
+++ b/node/config/doc_gen.go
@@ -426,6 +426,15 @@ for any other deal.`,
 			Comment: `Whether to enable legacy deals on the Boost node or not. We recommend keeping
 them disabled. These will be completely deprecated soon.`,
 		},
+		{
+			Name: "ExternalDealPublishControl",
+			Type: "bool",
+
+			Comment: `When set to true, user is responsible to publish the deal message.
+A list of pending deals can be queried and published using the GraphQL endpoint.
+If this value is set to true, the values of MaxDealsPerPublishMsg and PublishMsgPeriod will be
+ignored`,
+		},
 	},
 	"FeeConfig": []DocField{
 		{

--- a/node/config/doc_gen.go
+++ b/node/config/doc_gen.go
@@ -427,13 +427,12 @@ for any other deal.`,
 them disabled. These will be completely deprecated soon.`,
 		},
 		{
-			Name: "ExternalDealPublishControl",
+			Name: "ManualDealPublish",
 			Type: "bool",
 
-			Comment: `When set to true, user is responsible to publish the deal message.
-A list of pending deals can be queried and published using the GraphQL endpoint.
-If this value is set to true, the values of MaxDealsPerPublishMsg and PublishMsgPeriod will be
-ignored`,
+			Comment: `When set to true, the user is responsible for publishing deals manually.
+The values of MaxDealsPerPublishMsg and PublishMsgPeriod will be
+ignored, and deals will remain in the pending state until manually published.`,
 		},
 	},
 	"FeeConfig": []DocField{

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -272,6 +272,12 @@ type DealmakingConfig struct {
 	// Whether to enable legacy deals on the Boost node or not. We recommend keeping
 	// them disabled. These will be completely deprecated soon.
 	EnableLegacyStorageDeals bool
+
+	// When ExternalDealPublishControl is set to true, user is responsible to publish the deal message.
+	// A list of pending deals can be queried on the GraphQL endpoint
+	// If this value is set to true, the values of MaxDealsPerPublishMsg and PublishMsgPeriod will be
+	// ignored
+	ExternalDealPublishControl bool
 }
 
 type ContractDealsConfig struct {

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -273,11 +273,10 @@ type DealmakingConfig struct {
 	// them disabled. These will be completely deprecated soon.
 	EnableLegacyStorageDeals bool
 
-	// When set to true, user is responsible to publish the deal message.
-	// A list of pending deals can be queried and published using the GraphQL endpoint.
-	// If this value is set to true, the values of MaxDealsPerPublishMsg and PublishMsgPeriod will be
-	// ignored
-	ExternalDealPublishControl bool
+	// When set to true, the user is responsible for publishing deals manually.
+	// The values of MaxDealsPerPublishMsg and PublishMsgPeriod will be
+	// ignored, and deals will remain in the pending state until manually published.
+	ManualDealPublish bool
 }
 
 type ContractDealsConfig struct {

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -273,8 +273,8 @@ type DealmakingConfig struct {
 	// them disabled. These will be completely deprecated soon.
 	EnableLegacyStorageDeals bool
 
-	// When ExternalDealPublishControl is set to true, user is responsible to publish the deal message.
-	// A list of pending deals can be queried on the GraphQL endpoint
+	// When set to true, user is responsible to publish the deal message.
+	// A list of pending deals can be queried and published using the GraphQL endpoint.
 	// If this value is set to true, the values of MaxDealsPerPublishMsg and PublishMsgPeriod will be
 	// ignored
 	ExternalDealPublishControl bool

--- a/react/src/DealPublish.js
+++ b/react/src/DealPublish.js
@@ -40,6 +40,29 @@ function DealPublishContent() {
     var publishTime = moment(data.dealPublish.Start).add(period)
 
     var deals = data.dealPublish.Deals
+
+    if (data.dealPublish.ManualPSD) {
+        return <div>
+            {deals.length ? (
+                <>
+                    <p>
+                        {deals.length} deal{deals.length === 1 ? '' : 's'} pending to be published
+                    </p>
+
+                    <div className="buttons">
+                        <div className="button" onClick={doPublish}>Publish Now</div>
+                    </div>
+                </>
+            ) : null}
+
+            <h3>ExternalDealPublishControl is enabled. Users must publish deals manually</h3>
+
+            { deals.length ? <DealsTable deals={deals} /> : (
+                <p>There are no deals in the batch publish queue</p>
+            ) }
+        </div>
+    }
+
     return <div>
         {deals.length ? (
             <>

--- a/react/src/DealPublish.js
+++ b/react/src/DealPublish.js
@@ -55,7 +55,7 @@ function DealPublishContent() {
                 </>
             ) : null}
 
-            <h3>ExternalDealPublishControl is enabled. Users must publish deals manually</h3>
+            <h5>Note: Users must publish deals manually as external deal publish control is enabled</h5>
 
             { deals.length ? <DealsTable deals={deals} /> : (
                 <p>There are no deals in the batch publish queue</p>

--- a/react/src/DealPublish.js
+++ b/react/src/DealPublish.js
@@ -55,7 +55,7 @@ function DealPublishContent() {
                 </>
             ) : null}
 
-            <h5>Note: Users must publish deals manually as external deal publish control is enabled</h5>
+            <h5>Note: Manual deal publishing is enabled in config: deals will not be published automatically, the Storage Provider must publish deals manually</h5>
 
             { deals.length ? <DealsTable deals={deals} /> : (
                 <p>There are no deals in the batch publish queue</p>

--- a/react/src/gql.js
+++ b/react/src/gql.js
@@ -703,6 +703,12 @@ const DealPublishQuery = gql`
     }
 `;
 
+const DealPublishNowMutation = gql`
+    mutation AppDealPublishNowMutation {
+        dealPublishNow
+    }
+`;
+
 const FundsMoveToEscrow = gql`
     mutation AppDealPublishNowMutation($amount: BigInt!) {
         fundsMoveToEscrow(amount: $amount)
@@ -799,6 +805,7 @@ export {
     FundsQuery,
     FundsLogsQuery,
     DealPublishQuery,
+    DealPublishNowMutation,
     FundsMoveToEscrow,
     StorageAskUpdate,
     TransfersQuery,

--- a/react/src/gql.js
+++ b/react/src/gql.js
@@ -685,6 +685,7 @@ const FundsLogsQuery = gql`
 const DealPublishQuery = gql`
     query AppDealPublishQuery {
         dealPublish {
+            ManualPSD
             Start
             Period
             MaxDealsPerMsg
@@ -764,6 +765,12 @@ const StorageAskQuery = gql`
     }
 `;
 
+const PublishPendingDealsMutation = gql`
+    mutation AppPublishPendingDealMutation($ids: PublishDealIds) {
+        publishPendingDeals(ids: $ids)
+    }
+`;
+
 export {
     gqlClient,
     EpochQuery,
@@ -807,4 +814,5 @@ export {
     SealingPipelineQuery,
     Libp2pAddrInfoQuery,
     StorageAskQuery,
+    PublishPendingDealsMutation,
 }

--- a/react/src/gql.js
+++ b/react/src/gql.js
@@ -766,7 +766,7 @@ const StorageAskQuery = gql`
 `;
 
 const PublishPendingDealsMutation = gql`
-    mutation AppPublishPendingDealMutation($ids: PublishDealIds) {
+    mutation AppPublishPendingDealMutation($ids: [ID!]!) {
         publishPendingDeals(ids: $ids)
     }
 `;

--- a/react/src/gql.js
+++ b/react/src/gql.js
@@ -703,12 +703,6 @@ const DealPublishQuery = gql`
     }
 `;
 
-const DealPublishNowMutation = gql`
-    mutation AppDealPublishNowMutation {
-        dealPublishNow
-    }
-`;
-
 const FundsMoveToEscrow = gql`
     mutation AppDealPublishNowMutation($amount: BigInt!) {
         fundsMoveToEscrow(amount: $amount)
@@ -805,7 +799,6 @@ export {
     FundsQuery,
     FundsLogsQuery,
     DealPublishQuery,
-    DealPublishNowMutation,
     FundsMoveToEscrow,
     StorageAskUpdate,
     TransfersQuery,


### PR DESCRIPTION
## Current Scenario
Currently, Boost controls when the PSD message is sent for a deal. This decision is governed by a couple of factors.
1. A timeout value forcing to publish all deals (1 hour)
2. Maximum number of deal to be included in each message (8)
Another special case is to Publish all deals forcefully using UI button and Graphql mutation.

## Feature request background
SPs have expressed interest in being able to control how the deal are published. The reason this control ranges from being able to control deal flow to miner to control the cost of PSD message

## Feature
The new feature allows SPs to turn on manual PSD. Once this feature is turned on, Boost will no longer send any PSD messages unless explicitly prompted by the user. The feature can be turned on with the below config variable:

```
[Dealmaking]
        // When set to true, the user is responsible for publishing deals manually.
	// The values of MaxDealsPerPublishMsg and PublishMsgPeriod will be
	// ignored, and deals will remain in the pending state until manually published.
	ManualDealPublish bool

```

### Querying the deals pending to be published
The deals which have not been published can be queried using the Graphql endpoint of the Boost. The curl for the query:

`curl -X POST -H "Content-Type: application/json" -d '{"query":"query { dealPublish{ ManualPSD Deals {ID IsLegacy ClientAddress ProviderAddress CreatedAt PieceCid PieceSize ProviderCollateral StartEpoch EndEpoch ClientPeerID PublishCid Transfer { Type Size Params ClientID} Message }}}"}' http://localhost:8080/graphql/query | jq`

### Decision
SPs can create a decision script which queries the Graphql endpoint using the above curl and take a decision on which deal to be published.

### Publishing deals
Once the decision has been taken on which deals to be published, SPs can use the Grapqhql endpoint to Publish the deals.
The mutation is:

`publishPendingDeals(ids: [ID!]!): [ID!]!`

which takes an array of deal UUIDs to be published and an error message is returned. The following curl can be used to publish the deal.

`curl -X POST -H "Content-Type: application/json" -d '{"query":"mutation {publishPendingDeals(ids: [\"d9f849f1-d5d8-4bfc-b034-2866bddfc8cb\", \"a8eb58ef-7381-4251-ae7a-1227c032c0b9\"])}"}' http://localhost:8080/graphql/query | jq`

#### Successful output
```
{
  "data": {
    "publishPendingDeals": [
      "d9f849f1-d5d8-4bfc-b034-2866bddfc8cb",
      "a8eb58ef-7381-4251-ae7a-1227c032c0b9"
    ]
  }
}
```

#### Failure output

```
{
  "errors": [
    {
      "message": "failed to get deal details from DB cc78d877-f69c-410b-80a7-b23f2fab8951: scanning deal row: sql: no rows in result set",
      "path": [
        "publishPendingDeals"
      ]
    }
  ],
  "data": null
}
```

### Publish all deals
The publish all button in UI would have the same functionality as before. Same would be true for the Graphql mutation `dealPublishNow`

### UI screenshots
<img width="1235" alt="Screenshot 2023-07-19 at 11 09 14 AM" src="https://github.com/filecoin-project/boost/assets/88259624/92f73f93-dbb8-4be0-bc0e-22d5bdaab6fa">
