### PR TITLE
fix: BitswapPublicAddresses default

### DIFF
--- a/node/config/def.go
+++ b/node/config/def.go
@@ -142,6 +142,7 @@ func DefaultBoost() *Boost {
 			SealingPipelineCacheTimeout:        Duration(30 * time.Second),
 			FundsTaggingEnabled:                true,
 			EnableLegacyStorageDeals:           false,
+			BitswapPublicAddresses:             []string{},
 		},
 
 		LotusDealmaking: lotus_config.DealmakingConfig{


### PR DESCRIPTION
fixes #1587 

```
./boostd config default | grep Bitswap
  # When BitswapPeerID is not empty boostd will:
  #BitswapPeerID = ""
  #BitswapPublicAddresses = []
  #BitswapPrivKeyFile = ""
```