### PR TITLE
feat: show ad chain head in UI

### DIFF
--- a/gql/schema.graphql
+++ b/gql/schema.graphql
@@ -561,6 +561,9 @@ type RootQuery {
   """Get count of entries for an IPNI advertisement"""
   ipniAdvertisementEntriesCount(adCid: String!): Int!
 
+  """Get the latest IPNI advertisemen"""
+  ipniLatestAdvertisement: String!
+
   """Get LID state"""
   lid: LID!
 

--- a/react/src/Ipni.js
+++ b/react/src/Ipni.js
@@ -5,6 +5,7 @@ import {
     IpniAdEntriesQuery,
     IpniAdQuery,
     IpniProviderInfoQuery,
+    IpniLatestAdQuery,
     RetrievalLogsCountQuery, RetrievalLogsListQuery,
 } from "./gql";
 import moment from "moment";
@@ -52,6 +53,7 @@ function ProviderInfo(props) {
 }
 
 function ProviderIpniInfo({peerId}) {
+    const head = useQuery(IpniLatestAdQuery)
     const [{loading, error, data}, setResp] = useState({ loading: true })
     const idxHost = indexerHost()
 
@@ -75,6 +77,11 @@ function ProviderIpniInfo({peerId}) {
     if (loading) return <div>Loading...</div>
     if (!data) return null
 
+    let defined = false
+    if (head.data !== undefined ) {
+        defined = true
+    }
+
     return <div className="ipni-prov-info">
         <h3>Provider Indexer Info</h3>
         <div className="subtitle">
@@ -96,6 +103,12 @@ function ProviderIpniInfo({peerId}) {
                     {data.LastAdvertisement['/']}
                     &nbsp;
                     <span className="aux">({moment(data.LastAdvertisementTime).fromNow()} ago)</span>
+                </td>
+            </tr>
+            <tr>
+                <th>Latest Advertisement on Boost</th>
+                <td>
+                    {defined ? <Link to={'/ipni/ad/'+head.data.ipniLatestAdvertisement}>{head.data.ipniLatestAdvertisement}</Link>: ''}
                 </td>
             </tr>
             <tr>

--- a/react/src/Ipni.js
+++ b/react/src/Ipni.js
@@ -77,11 +77,6 @@ function ProviderIpniInfo({peerId}) {
     if (loading) return <div>Loading...</div>
     if (!data) return null
 
-    let defined = false
-    if (head.data !== undefined ) {
-        defined = true
-    }
-
     return <div className="ipni-prov-info">
         <h3>Provider Indexer Info</h3>
         <div className="subtitle">
@@ -108,7 +103,7 @@ function ProviderIpniInfo({peerId}) {
             <tr>
                 <th>Latest Advertisement on Boost</th>
                 <td>
-                    {defined ? <Link to={'/ipni/ad/'+head.data.ipniLatestAdvertisement}>{head.data.ipniLatestAdvertisement}</Link>: ''}
+                    {head.data ? <Link to={'/ipni/ad/'+head.data.ipniLatestAdvertisement}>{head.data.ipniLatestAdvertisement}</Link>: ''}
                 </td>
             </tr>
             <tr>

--- a/react/src/gql.js
+++ b/react/src/gql.js
@@ -342,6 +342,12 @@ const IpniAdEntriesCountQuery = gql`
     }
 `;
 
+const IpniLatestAdQuery = gql`
+    query AppIpniLatestAdQuery {
+        ipniLatestAdvertisement
+    }
+`;
+
 const DealCancelMutation = gql`
     mutation AppDealCancelMutation($id: ID!) {
         dealCancel(id: $id)
@@ -793,6 +799,7 @@ export {
     IpniAdQuery,
     IpniAdEntriesQuery,
     IpniAdEntriesCountQuery,
+    IpniLatestAdQuery,
     PiecesWithRootPayloadCidQuery,
     PiecesWithPayloadCidQuery,
     PieceBuildIndexMutation,


### PR DESCRIPTION
This PR adds an extra row to the Provider info in Indexer page of Boost UI.
Users can compare the head to last sync ad and figure out if their sync is working or not.

<img width="1235" alt="Screenshot 2023-07-26 at 12 51 35 PM" src="https://github.com/filecoin-project/boost/assets/88259624/61d65b9a-7eb4-4130-a38c-83e0e76af5a6">
