### PR TITLE
feat: add support for deserialized response

### DIFF
--- a/cmd/booster-http/gateway_handler.go
+++ b/cmd/booster-http/gateway_handler.go
@@ -14,19 +14,26 @@ type gatewayHandler struct {
 	supportedFormats map[string]struct{}
 }
 
-func newGatewayHandler(gw *gateway.BlocksBackend, supportedFormats []string) http.Handler {
+func newGatewayHandler(gw *gateway.BlocksBackend, supportedFormats []string, serveGateway string) http.Handler {
 	headers := map[string][]string{}
+	var deserializedResponse bool
 	gateway.AddAccessControlHeaders(headers)
 
 	fmtsMap := make(map[string]struct{}, len(supportedFormats))
 	for _, f := range supportedFormats {
 		fmtsMap[f] = struct{}{}
 	}
-
+	if serveGateway == "none" {
+		return &gatewayHandler{}
+	} else if serveGateway == "all" {
+		deserializedResponse = true
+	}else if serveGateway == "verifiable" {
+		deserializedResponse = false
+	}
 	return &gatewayHandler{
 		gwh: gateway.NewHandler(gateway.Config{
 			Headers:               headers,
-			DeserializedResponses: true,
+			DeserializedResponses: deserializedResponse,
 		}, gw),
 		supportedFormats: fmtsMap,
 	}

--- a/cmd/booster-http/gateway_handler.go
+++ b/cmd/booster-http/gateway_handler.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	
+
 	"mime"
 	"net/http"
 	"strings"
@@ -36,58 +36,4 @@ func newGatewayHandler(gw *gateway.BlocksBackend, serveGateway string) http.Hand
 
 func (h *gatewayHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h.gwh.ServeHTTP(w, r)
-}
-
-func webError(w http.ResponseWriter, err error, code int) {
-	http.Error(w, err.Error(), code)
-}
-
-// Unfortunately this function is not exported from go-libipfs so we need to copy it here.
-// return explicit response format if specified in request as query parameter or via Accept HTTP header
-func customResponseFormat(r *http.Request) (mediaType string, params map[string]string, err error) {
-	if formatParam := r.URL.Query().Get("format"); formatParam != "" {
-		// translate query param to a content type
-		switch formatParam {
-		case "raw":
-			return "application/vnd.ipld.raw", nil, nil
-		case "car":
-			return "application/vnd.ipld.car", nil, nil
-		case "tar":
-			return "application/x-tar", nil, nil
-		case "json":
-			return "application/json", nil, nil
-		case "cbor":
-			return "application/cbor", nil, nil
-		case "dag-json":
-			return "application/vnd.ipld.dag-json", nil, nil
-		case "dag-cbor":
-			return "application/vnd.ipld.dag-cbor", nil, nil
-		case "ipns-record":
-			return "application/vnd.ipfs.ipns-record", nil, nil
-		}
-	}
-	// Browsers and other user agents will send Accept header with generic types like:
-	// Accept:text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8
-	// We only care about explicit, vendor-specific content-types and respond to the first match (in order).
-	// TODO: make this RFC compliant and respect weights (eg. return CAR for Accept:application/vnd.ipld.dag-json;q=0.1,application/vnd.ipld.car;q=0.2)
-	for _, header := range r.Header.Values("Accept") {
-		for _, value := range strings.Split(header, ",") {
-			accept := strings.TrimSpace(value)
-			// respond to the very first matching content type
-			if strings.HasPrefix(accept, "application/vnd.ipld") ||
-				strings.HasPrefix(accept, "application/x-tar") ||
-				strings.HasPrefix(accept, "application/json") ||
-				strings.HasPrefix(accept, "application/cbor") ||
-				strings.HasPrefix(accept, "application/vnd.ipfs") {
-				mediatype, params, err := mime.ParseMediaType(accept)
-				if err != nil {
-					return "", nil, err
-				}
-				return mediatype, params, nil
-			}
-		}
-	}
-	// If none of special-cased content types is found, return empty string
-	// to indicate default, implicit UnixFS response should be prepared
-	return "", nil, nil
 }

--- a/cmd/booster-http/gateway_handler.go
+++ b/cmd/booster-http/gateway_handler.go
@@ -2,9 +2,7 @@ package main
 
 import (
 
-	"mime"
 	"net/http"
-	"strings"
 
 	"github.com/ipfs/boxo/gateway"
 )

--- a/cmd/booster-http/gateway_handler.go
+++ b/cmd/booster-http/gateway_handler.go
@@ -21,9 +21,10 @@ func newGatewayHandler(gw *gateway.BlocksBackend, serveGateway string) http.Hand
 
 	if serveGateway == "none" {
 		return &gatewayHandler{}
-	} else if serveGateway == "all" {
+	}
+	if serveGateway == "all" {
 		deserializedResponse = true
-	}else if serveGateway == "verifiable" {
+	} else if serveGateway == "verifiable" {
 		deserializedResponse = false
 	}
 	return &gatewayHandler{

--- a/cmd/booster-http/gateway_handler.go
+++ b/cmd/booster-http/gateway_handler.go
@@ -14,15 +14,11 @@ type gatewayHandler struct {
 	supportedFormats map[string]struct{}
 }
 
-func newGatewayHandler(gw *gateway.BlocksBackend, supportedFormats []string, serveGateway string) http.Handler {
+func newGatewayHandler(gw *gateway.BlocksBackend, serveGateway string) http.Handler {
 	headers := map[string][]string{}
 	var deserializedResponse bool
 	gateway.AddAccessControlHeaders(headers)
 
-	fmtsMap := make(map[string]struct{}, len(supportedFormats))
-	for _, f := range supportedFormats {
-		fmtsMap[f] = struct{}{}
-	}
 	if serveGateway == "none" {
 		return &gatewayHandler{}
 	} else if serveGateway == "all" {
@@ -35,7 +31,6 @@ func newGatewayHandler(gw *gateway.BlocksBackend, supportedFormats []string, ser
 			Headers:               headers,
 			DeserializedResponses: deserializedResponse,
 		}, gw),
-		supportedFormats: fmtsMap,
 	}
 }
 

--- a/cmd/booster-http/gateway_handler.go
+++ b/cmd/booster-http/gateway_handler.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	
 	"mime"
 	"net/http"
 	"strings"
@@ -11,7 +11,6 @@ import (
 
 type gatewayHandler struct {
 	gwh              http.Handler
-	supportedFormats map[string]struct{}
 }
 
 func newGatewayHandler(gw *gateway.BlocksBackend, serveGateway string) http.Handler {
@@ -36,20 +35,6 @@ func newGatewayHandler(gw *gateway.BlocksBackend, serveGateway string) http.Hand
 }
 
 func (h *gatewayHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	responseFormat, _, err := customResponseFormat(r)
-	if err != nil {
-		webError(w, fmt.Errorf("error while processing the Accept header: %w", err), http.StatusBadRequest)
-		return
-	}
-
-	if _, ok := h.supportedFormats[responseFormat]; !ok {
-		if responseFormat == "" {
-			responseFormat = "unixfs"
-		}
-		webError(w, fmt.Errorf("unsupported response format: %s", responseFormat), http.StatusBadRequest)
-		return
-	}
-
 	h.gwh.ServeHTTP(w, r)
 }
 

--- a/cmd/booster-http/run.go
+++ b/cmd/booster-http/run.go
@@ -76,21 +76,6 @@ var runCmd = &cli.Command{
 			Usage: "enables serving raw pieces",
 			Value: true,
 		},
-		//&cli.BoolFlag{
-		//	Name:  "serve-blocks",
-		//	Usage: "serve blocks with the ipfs gateway API",
-		//	Value: true,
-		//},
-		//&cli.BoolFlag{
-		//	Name:  "serve-cars",
-		//	Usage: "serve CAR files with the ipfs gateway API",
-		//	Value: true,
-		//},
-		//&cli.BoolFlag{
-		//	Name:  "serve-files",
-		//	Usage: "serve original files (eg jpg, mov) with the ipfs gateway API",
-		//	Value: false,
-		//},
 		&cli.StringFlag{
 			Name:  "serve-gateway",
 			Usage: "serve deserialized responses with the ipfs gateway API (values: 'verifiable','all','none')",
@@ -271,37 +256,22 @@ var runCmd = &cli.Command{
 func parseSupportedResponseFormats(cctx *cli.Context) ([]string) {
 	fmts := []string{}
 	switch cctx.String("serve-gateway") {
-	case "all":
+	case "verifiable":
 		fmts = append(fmts, "application/vnd.ipld.raw") // raw
 		fmts = append(fmts, "application/vnd.ipld.car") // car
-	case "verifiable":
+	case "all":
 		fmts = append(fmts, "")
 	}
-	//if cctx.String("serve-gateway") != "all" { // true decentralized response
-	//
-	//}
-	//if cctx.Bool("serve-blocks") {
-	//	fmts = append(fmts, "application/vnd.ipld.raw")
-	//}
-	//if cctx.Bool("serve-cars") {
-	//	fmts = append(fmts, "application/vnd.ipld.car")
-	//}
-	//if cctx.Bool("serve-files") {
-	//	// Allow the user to not specify a specific response format.
-	//	// In that case the gateway will respond with any kind of file
-	//	// (eg jpg, mov etc)
-	//	fmts = append(fmts, "")
-	//}
 	return fmts
 }
 
 func ipfsGatewayMsg(cctx *cli.Context, ipfsBasePath string) string {
 	fmts := []string{}
 	switch cctx.String("serve-gateway") {
-	case "all":
+	case "verifiable":
 		fmts = append(fmts, "blocks")
 		fmts = append(fmts, "CARs")
-	case "verifiable":
+	case "all":
 		fmts = append(fmts, "files")
 	}
 

--- a/cmd/booster-http/run.go
+++ b/cmd/booster-http/run.go
@@ -78,7 +78,8 @@ var runCmd = &cli.Command{
 		},
 		&cli.StringFlag{
 			Name:  "serve-gateway",
-			Usage: "serve deserialized responses with the ipfs gateway API (values: 'verifiable','all','none')",
+			Usage: "This flag enables serving deserialized responses with the ipfs gateway API. " +
+				"Values: 'verifiable' (default) - only serve verifiable responses, 'all' - serve all responses, 'none' - disable serving responses with the ipfs gateway API",
 			Value: "verifiable",
 		},
 		&cli.BoolFlag{
@@ -170,7 +171,6 @@ var runCmd = &cli.Command{
 		serveGateway := cctx.String("serve-gateway")
 		opts := &HttpServerOptions{
 			ServePieces:              servePieces,
-			SupportedResponseFormats: responseFormats,
 			ServeGateway: serveGateway,
 		}
 		if enableIpfsGateway {

--- a/cmd/booster-http/run.go
+++ b/cmd/booster-http/run.go
@@ -167,9 +167,11 @@ var runCmd = &cli.Command{
 		pr := &piecedirectory.SectorAccessorAsPieceReader{SectorAccessor: sa}
 		pd := piecedirectory.NewPieceDirectory(cl, pr, cctx.Int("add-index-throttle"))
 
+		serveGateway := cctx.String("serve-gateway")
 		opts := &HttpServerOptions{
 			ServePieces:              servePieces,
 			SupportedResponseFormats: responseFormats,
+			ServeGateway: serveGateway,
 		}
 		if enableIpfsGateway {
 			repoDir, err := createRepoDir(cctx.String(FlagRepo.Name))
@@ -207,7 +209,6 @@ var runCmd = &cli.Command{
 			cctx.Int("port"),
 			sapi,
 			opts,
-			cctx.String("serve-gateway"),
 		)
 
 		// Start the local index directory

--- a/cmd/booster-http/run.go
+++ b/cmd/booster-http/run.go
@@ -76,20 +76,25 @@ var runCmd = &cli.Command{
 			Usage: "enables serving raw pieces",
 			Value: true,
 		},
-		&cli.BoolFlag{
-			Name:  "serve-blocks",
-			Usage: "serve blocks with the ipfs gateway API",
-			Value: true,
-		},
-		&cli.BoolFlag{
-			Name:  "serve-cars",
-			Usage: "serve CAR files with the ipfs gateway API",
-			Value: true,
-		},
-		&cli.BoolFlag{
-			Name:  "serve-files",
-			Usage: "serve original files (eg jpg, mov) with the ipfs gateway API",
-			Value: false,
+		//&cli.BoolFlag{
+		//	Name:  "serve-blocks",
+		//	Usage: "serve blocks with the ipfs gateway API",
+		//	Value: true,
+		//},
+		//&cli.BoolFlag{
+		//	Name:  "serve-cars",
+		//	Usage: "serve CAR files with the ipfs gateway API",
+		//	Value: true,
+		//},
+		//&cli.BoolFlag{
+		//	Name:  "serve-files",
+		//	Usage: "serve original files (eg jpg, mov) with the ipfs gateway API",
+		//	Value: false,
+		//},
+		&cli.StringFlag{
+			Name:  "serve-gateway",
+			Usage: "serve deserialized responses with the ipfs gateway API (values: 'verifiable','all','none')",
+			Value: "verifiable",
 		},
 		&cli.BoolFlag{
 			Name:  "tracing",
@@ -217,6 +222,7 @@ var runCmd = &cli.Command{
 			cctx.Int("port"),
 			sapi,
 			opts,
+			cctx.String("serve-gateway"),
 		)
 
 		// Start the local index directory
@@ -262,32 +268,40 @@ var runCmd = &cli.Command{
 	},
 }
 
-func parseSupportedResponseFormats(cctx *cli.Context) []string {
+func parseSupportedResponseFormats(cctx *cli.Context) ([]string) {
 	fmts := []string{}
-	if cctx.Bool("serve-blocks") {
-		fmts = append(fmts, "application/vnd.ipld.raw")
-	}
-	if cctx.Bool("serve-cars") {
-		fmts = append(fmts, "application/vnd.ipld.car")
-	}
-	if cctx.Bool("serve-files") {
-		// Allow the user to not specify a specific response format.
-		// In that case the gateway will respond with any kind of file
-		// (eg jpg, mov etc)
+	switch cctx.String("serve-gateway") {
+	case "all":
+		fmts = append(fmts, "application/vnd.ipld.raw") // raw
+		fmts = append(fmts, "application/vnd.ipld.car") // car
+	case "verifiable":
 		fmts = append(fmts, "")
 	}
+	//if cctx.String("serve-gateway") != "all" { // true decentralized response
+	//
+	//}
+	//if cctx.Bool("serve-blocks") {
+	//	fmts = append(fmts, "application/vnd.ipld.raw")
+	//}
+	//if cctx.Bool("serve-cars") {
+	//	fmts = append(fmts, "application/vnd.ipld.car")
+	//}
+	//if cctx.Bool("serve-files") {
+	//	// Allow the user to not specify a specific response format.
+	//	// In that case the gateway will respond with any kind of file
+	//	// (eg jpg, mov etc)
+	//	fmts = append(fmts, "")
+	//}
 	return fmts
 }
 
 func ipfsGatewayMsg(cctx *cli.Context, ipfsBasePath string) string {
 	fmts := []string{}
-	if cctx.Bool("serve-blocks") {
+	switch cctx.String("serve-gateway") {
+	case "all":
 		fmts = append(fmts, "blocks")
-	}
-	if cctx.Bool("serve-cars") {
 		fmts = append(fmts, "CARs")
-	}
-	if cctx.Bool("serve-files") {
+	case "verifiable":
 		fmts = append(fmts, "files")
 	}
 

--- a/cmd/booster-http/run.go
+++ b/cmd/booster-http/run.go
@@ -108,8 +108,7 @@ var runCmd = &cli.Command{
 	},
 	Action: func(cctx *cli.Context) error {
 		servePieces := cctx.Bool("serve-pieces")
-		responseFormats := parseSupportedResponseFormats(cctx)
-		enableIpfsGateway := len(responseFormats) > 0
+		enableIpfsGateway := shouldEnableIPFSGateway(cctx)
 		if !servePieces && !enableIpfsGateway {
 			return errors.New("one of --serve-pieces, --serve-blocks, etc must be enabled")
 		}
@@ -254,16 +253,13 @@ var runCmd = &cli.Command{
 	},
 }
 
-func parseSupportedResponseFormats(cctx *cli.Context) ([]string) {
-	fmts := []string{}
+func shouldEnableIPFSGateway(cctx *cli.Context) (bool) {
 	switch cctx.String("serve-gateway") {
 	case "verifiable":
-		fmts = append(fmts, "application/vnd.ipld.raw") // raw
-		fmts = append(fmts, "application/vnd.ipld.car") // car
 	case "all":
-		fmts = append(fmts, "")
+		return true
 	}
-	return fmts
+	return false
 }
 
 func ipfsGatewayMsg(cctx *cli.Context, ipfsBasePath string) string {

--- a/cmd/booster-http/server.go
+++ b/cmd/booster-http/server.go
@@ -69,7 +69,7 @@ type HttpServerOptions struct {
 	ServeGateway			 string
 }
 
-func NewHttpServer(path string, listenAddr string, port int, api HttpServerApi, opts *HttpServerOptions, serveGateway string) *HttpServer {
+func NewHttpServer(path string, listenAddr string, port int, api HttpServerApi, opts *HttpServerOptions) *HttpServer {
 	if opts == nil {
 		opts = &HttpServerOptions{ServePieces: true}
 	}

--- a/cmd/booster-http/server.go
+++ b/cmd/booster-http/server.go
@@ -65,7 +65,6 @@ type HttpServerApi interface {
 type HttpServerOptions struct {
 	Blockstore               blockstore.Blockstore
 	ServePieces              bool
-	SupportedResponseFormats []string
 	ServeGateway			 string
 }
 
@@ -107,7 +106,7 @@ func (s *HttpServer) Start(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("creating blocks gateway: %w", err)
 		}
-		handler.Handle(s.ipfsBasePath(), newGatewayHandler(gw, s.opts.SupportedResponseFormats, s.opts.ServeGateway))
+		handler.Handle(s.ipfsBasePath(), newGatewayHandler(gw, s.opts.ServeGateway))
 	}
 
 	handler.HandleFunc("/", s.handleIndex)

--- a/cmd/booster-http/server.go
+++ b/cmd/booster-http/server.go
@@ -66,9 +66,10 @@ type HttpServerOptions struct {
 	Blockstore               blockstore.Blockstore
 	ServePieces              bool
 	SupportedResponseFormats []string
+	ServeGateway			 string
 }
 
-func NewHttpServer(path string, listenAddr string, port int, api HttpServerApi, opts *HttpServerOptions) *HttpServer {
+func NewHttpServer(path string, listenAddr string, port int, api HttpServerApi, opts *HttpServerOptions, serveGateway string) *HttpServer {
 	if opts == nil {
 		opts = &HttpServerOptions{ServePieces: true}
 	}
@@ -106,7 +107,7 @@ func (s *HttpServer) Start(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("creating blocks gateway: %w", err)
 		}
-		handler.Handle(s.ipfsBasePath(), newGatewayHandler(gw, s.opts.SupportedResponseFormats))
+		handler.Handle(s.ipfsBasePath(), newGatewayHandler(gw, s.opts.SupportedResponseFormats, s.opts.ServeGateway))
 	}
 
 	handler.HandleFunc("/", s.handleIndex)

--- a/cmd/migrate-lid/migrate_lid.go
+++ b/cmd/migrate-lid/migrate_lid.go
@@ -307,7 +307,7 @@ func migrateIndex(ctx context.Context, ipath idxPath, store StoreMigrationApi, f
 	respch := store.AddIndex(ctx, pieceCid, records, false)
 	for resp := range respch {
 		if resp.Err != "" {
-			return false, fmt.Errorf("adding index %s to store: %s", ipath.path, err)
+			return false, fmt.Errorf("adding index %s to store: %s", ipath.path, resp.Err)
 		}
 	}
 	log.Debugw("AddIndex", "took", time.Since(addStart).String())

--- a/docker/devnet/booster-http/entrypoint.sh
+++ b/docker/devnet/booster-http/entrypoint.sh
@@ -9,4 +9,4 @@ echo $MINER_API_INFO
 echo $LID_API_INFO
 
 echo Starting booster-http...
-exec booster-http run --serve-gateway=all --api-lid=$LID_API_INFO  --api-fullnode=$FULLNODE_API_INFO --api-storage=$MINER_API_INFO --tracing
+exec booster-http run --serve-gateway=verifiable --api-lid=$LID_API_INFO  --api-fullnode=$FULLNODE_API_INFO --api-storage=$MINER_API_INFO --tracing

--- a/docker/devnet/booster-http/entrypoint.sh
+++ b/docker/devnet/booster-http/entrypoint.sh
@@ -9,4 +9,4 @@ echo $MINER_API_INFO
 echo $LID_API_INFO
 
 echo Starting booster-http...
-exec booster-http run --api-lid=$LID_API_INFO  --api-fullnode=$FULLNODE_API_INFO --api-storage=$MINER_API_INFO --tracing
+exec booster-http run --serve-gateway=all --api-lid=$LID_API_INFO  --api-fullnode=$FULLNODE_API_INFO --api-storage=$MINER_API_INFO --tracing

--- a/docker/devnet/booster-http/entrypoint.sh
+++ b/docker/devnet/booster-http/entrypoint.sh
@@ -9,4 +9,4 @@ echo $MINER_API_INFO
 echo $LID_API_INFO
 
 echo Starting booster-http...
-exec booster-http run --serve-files=true --api-lid=$LID_API_INFO  --api-fullnode=$FULLNODE_API_INFO --api-storage=$MINER_API_INFO --tracing
+exec booster-http run --api-lid=$LID_API_INFO  --api-fullnode=$FULLNODE_API_INFO --api-storage=$MINER_API_INFO --tracing


### PR DESCRIPTION
# Changes

support for deserialized response based on the requirement https://github.com/filecoin-project/boost/issues/1531

## Verification
### Added the --serve-gateway on the `entrypoint.sh` and deployed to local devnet

#### Set value to `all`
```
echo Starting booster-http...
exec booster-http run --serve-gateway=all --api-lid=$LID_API_INFO  --api-fullnode=$FULLNODE_API_INFO --api-storage=$MINER_API_INFO --tracing
```
```
2023-08-20 19:15:01 2023-08-20T10:15:01.190Z    INFO    booster lib/api.go:38   Using full node API at ws://lotus:1234/rpc/v1
2023-08-20 19:15:01 2023-08-20T10:15:01.193Z    INFO    booster booster-http/run.go:156 Tracing exporter enabled
2023-08-20 19:15:01 2023-08-20T10:15:01.193Z    INFO    booster lib/api.go:64   Using storage API at ws://lotus-miner:2345/rpc/v0
2023-08-20 19:15:01 2023-08-20T10:15:01.194Z    INFO    booster lib/api.go:106  Miner address: t01000
2023-08-20 19:15:18 2023-08-20T10:15:18.354Z    INFO    booster booster-http/run.go:217 Starting booster-http node on listen address 0.0.0.0 and port 7777 with base path ''
2023-08-20 19:15:18 2023-08-20T10:15:18.355Z    INFO    booster booster-http/run.go:224 serving IPFS gateway at /ipfs/ (serving files)
2023-08-20 19:15:18 2023-08-20T10:15:18.355Z    INFO    booster booster-http/run.go:226 serving raw pieces at /piece/
```
<img width="1508" alt="image" src="https://github.com/filecoin-project/boost/assets/4479171/451715d3-c161-4547-93c9-d2c90e4a779f">

#### Set value to `verifiable`
```
echo Starting booster-http...
exec booster-http run --serve-gateway=verifiable --api-lid=$LID_API_INFO  --api-fullnode=$FULLNODE_API_INFO --api-storage=$MINER_API_INFO --tracing
```
```
2023-08-21 19:58:36 http://boost:8042
2023-08-21 19:58:36 Starting booster-http...
2023-08-21 19:58:36 2023-08-21T10:58:36.942Z    INFO    booster lib/api.go:38   Using full node API at ws://lotus:1234/rpc/v1
2023-08-21 19:58:36 2023-08-21T10:58:36.950Z    INFO    booster booster-http/run.go:155 Tracing exporter enabled
2023-08-21 19:58:36 2023-08-21T10:58:36.950Z    INFO    booster lib/api.go:64   Using storage API at ws://lotus-miner:2345/rpc/v0
2023-08-21 19:58:36 2023-08-21T10:58:36.951Z    INFO    booster lib/api.go:106  Miner address: t01000
2023-08-21 19:58:46 2023-08-21T10:58:46.378Z    INFO    booster booster-http/run.go:216 Starting booster-http node on listen address 0.0.0.0 and port 7777 with base path ''
2023-08-21 19:58:46 2023-08-21T10:58:46.379Z    INFO    booster booster-http/run.go:223 serving IPFS gateway at /ipfs/ (serving blocks, CARs)
2023-08-21 19:58:46 2023-08-21T10:58:46.379Z    INFO    booster booster-http/run.go:225 serving raw pieces at /piece/
```
<img width="1133" alt="image" src="https://github.com/filecoin-project/boost/assets/4479171/67ba3495-f790-406f-8388-e844f207599f">

#### set value to `none`
```
echo Starting booster-http...
exec booster-http run --serve-gateway=none --api-lid=$LID_API_INFO  --api-fullnode=$FULLNODE_API_INFO --api-storage=$MINER_API_INFO --tracing
```
```
2023-08-21 19:58:36 2023-08-21T10:58:36.942Z    INFO    booster lib/api.go:38   Using full node API at ws://lotus:1234/rpc/v1
2023-08-21 19:58:36 2023-08-21T10:58:36.950Z    INFO    booster booster-http/run.go:155 Tracing exporter enabled
2023-08-21 19:58:36 2023-08-21T10:58:36.950Z    INFO    booster lib/api.go:64   Using storage API at ws://lotus-miner:2345/rpc/v0
2023-08-21 19:58:36 2023-08-21T10:58:36.951Z    INFO    booster lib/api.go:106  Miner address: t01000
2023-08-21 19:58:46 2023-08-21T10:58:46.378Z    INFO    booster booster-http/run.go:216 Starting booster-http node on listen address 0.0.0.0 and port 7777 with base path ''
2023-08-21 19:58:46 2023-08-21T10:58:46.379Z    INFO    booster booster-http/run.go:223 serving IPFS gateway at /ipfs/ (serving blocks, CARs)
2023-08-21 19:58:46 2023-08-21T10:58:46.379Z    INFO    booster booster-http/run.go:225 serving raw pieces at /piece/
```
<img width="1133" alt="image" src="https://github.com/filecoin-project/boost/assets/4479171/42ac7bb6-1d4d-4797-b3bf-bfb6a252a3af">

## Running booster-http after making a deal
### made a online unverified deal for a simple car file
```
boost -vv deal --verified=false --provider=t01000 --commp=baga6ea4seaqdcoodqrjm65fkx5bstoh5aqe57zx7rbulpnfyp477b6d4vtyespq --car-size=104 --piece-size=128 --http-url=https://radiant.edge.estuary.tech/gw/bafybeieo26tuorkzzh5p347ucintyxgaqichmga3pv4euinokvyvemj5ya --payload-cid=bafkqagcineqee33pon2cyid3gexc4njxpuqhi2lnmvzqu --storage-price=1000000000

2023-08-22T08:19:14.983Z        DEBUG   boost   boost/deal_cmd.go:279   about to submit deal proposal   {"uuid": "d011c703-7bca-4a43-8629-0f40c737a283"}
sent deal proposal
  deal uuid: d011c703-7bca-4a43-8629-0f40c737a283
  storage provider: t01000
  client wallet: t3quyq27bdclsakjo5usrhejle3wch46fbcysvtk2vy5c2gwkqmtgco6jgeerxbjqot7v5o5rnnoan57b75pxa
  payload cid: bafkqagcineqee33pon2cyid3gexc4njxpuqhi2lnmvzqu
  url: https://radiant.edge.estuary.tech/gw/bafybeieo26tuorkzzh5p347ucintyxgaqichmga3pv4euinokvyvemj5ya
  commp: baga6ea4seaqdcoodqrjm65fkx5bstoh5aqe57zx7rbulpnfyp477b6d4vtyespq
  start epoch: 6096
  end epoch: 524496
  provider collateral: 0
```
<img width="1512" alt="image" src="https://github.com/filecoin-project/boost/assets/4479171/be35ac7a-23ec-4e3f-a2d3-77bcdaa8c710">

### Ready to publish deal
<img width="1143" alt="image" src="https://github.com/filecoin-project/boost/assets/4479171/96dff40a-899a-4b1f-b29c-5f2d49f2a4d3">

### Configure booster-http to set serve-gateway=all

#### Look by CID
<img width="1004" alt="image" src="https://github.com/filecoin-project/boost/assets/4479171/95efb72e-b686-4f4c-9a0c-84defea7085c">

### Configure booster-http to set serve-gateway=verifiable
<img width="1512" alt="image" src="https://github.com/filecoin-project/boost/assets/4479171/c94d4504-956e-4f3d-81dd-175553cd0a66">

### Configure booster-http to set serve-gateway=none
<img width="1018" alt="image" src="https://github.com/filecoin-project/boost/assets/4479171/4ee355cd-ead9-4c8b-a233-dc4913743c42">
