### PR TITLE
Look up unseal status against multi-miner accessor

### DIFF
--- a/gql/resolver.go
+++ b/gql/resolver.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/dustin/go-humanize"
 	"github.com/filecoin-project/boost-gfm/piecestore"
-	"github.com/filecoin-project/boost-gfm/retrievalmarket"
 	gfm_storagemarket "github.com/filecoin-project/boost-gfm/storagemarket"
 	"github.com/filecoin-project/boost/cmd/lib"
 	"github.com/filecoin-project/boost/db"
@@ -70,7 +69,6 @@ type resolver struct {
 	legacyDT       dtypes.ProviderDataTransfer
 	ps             piecestore.PieceStore
 	ssm            *sectorstatemgr.SectorStateMgr
-	sa             retrievalmarket.SectorAccessor
 	piecedirectory *piecedirectory.PieceDirectory
 	publisher      *storageadapter.DealPublisher
 	idxProv        provider.Interface
@@ -81,7 +79,7 @@ type resolver struct {
 	mma            *lib.MultiMinerAccessor
 }
 
-func NewResolver(ctx context.Context, cfg *config.Boost, r lotus_repo.LockedRepo, h host.Host, dealsDB *db.DealsDB, logsDB *db.LogsDB, retDB *rtvllog.RetrievalLogDB, plDB *db.ProposalLogsDB, fundsDB *db.FundsDB, fundMgr *fundmanager.FundManager, storageMgr *storagemanager.StorageManager, spApi sealingpipeline.API, provider *storagemarket.Provider, legacyDeals *legacy.LegacyDealsManager, legacyProv gfm_storagemarket.StorageProvider, legacyDT dtypes.ProviderDataTransfer, ps piecestore.PieceStore, sa retrievalmarket.SectorAccessor, piecedirectory *piecedirectory.PieceDirectory, publisher *storageadapter.DealPublisher, indexProv provider.Interface, idxProvWrapper *indexprovider.Wrapper, fullNode v1api.FullNode, ssm *sectorstatemgr.SectorStateMgr, mpool *mpoolmonitor.MpoolMonitor, mma *lib.MultiMinerAccessor) *resolver {
+func NewResolver(ctx context.Context, cfg *config.Boost, r lotus_repo.LockedRepo, h host.Host, dealsDB *db.DealsDB, logsDB *db.LogsDB, retDB *rtvllog.RetrievalLogDB, plDB *db.ProposalLogsDB, fundsDB *db.FundsDB, fundMgr *fundmanager.FundManager, storageMgr *storagemanager.StorageManager, spApi sealingpipeline.API, provider *storagemarket.Provider, legacyDeals *legacy.LegacyDealsManager, legacyProv gfm_storagemarket.StorageProvider, legacyDT dtypes.ProviderDataTransfer, ps piecestore.PieceStore, piecedirectory *piecedirectory.PieceDirectory, publisher *storageadapter.DealPublisher, indexProv provider.Interface, idxProvWrapper *indexprovider.Wrapper, fullNode v1api.FullNode, ssm *sectorstatemgr.SectorStateMgr, mpool *mpoolmonitor.MpoolMonitor, mma *lib.MultiMinerAccessor) *resolver {
 	return &resolver{
 		ctx:            ctx,
 		cfg:            cfg,
@@ -99,7 +97,6 @@ func NewResolver(ctx context.Context, cfg *config.Boost, r lotus_repo.LockedRepo
 		legacyProv:     legacyProv,
 		legacyDT:       legacyDT,
 		ps:             ps,
-		sa:             sa,
 		piecedirectory: piecedirectory,
 		publisher:      publisher,
 		spApi:          spApi,

--- a/gql/resolver_piece.go
+++ b/gql/resolver_piece.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 	"time"
 
-	"github.com/filecoin-project/boost-gfm/retrievalmarket"
+	"github.com/filecoin-project/boost/cmd/lib"
 	"github.com/filecoin-project/boost/db"
 	gqltypes "github.com/filecoin-project/boost/gql/types"
 	pdtypes "github.com/filecoin-project/boost/piecedirectory/types"
@@ -56,9 +56,10 @@ func (pdr *pieceDealResolver) SealStatus(ctx context.Context) *sealStatusResolve
 }
 
 type pieceInfoDeal struct {
-	ChainDealID gqltypes.Uint64
-	Sector      *sectorResolver
-	ss          *sealStatusReporter
+	MinerAddress string
+	ChainDealID  gqltypes.Uint64
+	Sector       *sectorResolver
+	ss           *sealStatusReporter
 }
 
 func (pid *pieceInfoDeal) SealStatus(ctx context.Context) *sealStatusResolver {
@@ -334,10 +335,11 @@ func (r *resolver) PieceStatus(ctx context.Context, args struct{ PieceCid string
 		}
 
 		pids = append(pids, &pieceInfoDeal{
-			ChainDealID: gqltypes.Uint64(dl.ChainDealID),
-			Sector:      sector,
+			MinerAddress: dl.MinerAddr.String(),
+			ChainDealID:  gqltypes.Uint64(dl.ChainDealID),
+			Sector:       sector,
 			ss: &sealStatusReporter{
-				sa:      r.sa,
+				mma:     r.mma,
 				ssm:     r.ssm,
 				sector:  sector,
 				minerID: abi.ActorID(actorId),
@@ -378,7 +380,7 @@ func (r *resolver) PieceStatus(ctx context.Context, args struct{ PieceCid string
 			Deal:   &bd,
 			Sector: sector,
 			ss: &sealStatusReporter{
-				sa:      r.sa,
+				mma:     r.mma,
 				sector:  sector,
 				ssm:     r.ssm,
 				minerID: abi.ActorID(minerId),
@@ -420,7 +422,7 @@ func (r *resolver) PieceStatus(ctx context.Context, args struct{ PieceCid string
 			Sector: sector,
 			ss: &sealStatusReporter{
 				sector:  sector,
-				sa:      r.sa,
+				mma:     r.mma,
 				ssm:     r.ssm,
 				minerID: abi.ActorID(minerId),
 			},
@@ -497,7 +499,7 @@ func (r *resolver) getLegacyDealSector(ctx context.Context, pids []*pieceInfoDea
 const isUnsealedTimeout = 5 * time.Second
 
 type sealStatusReporter struct {
-	sa      retrievalmarket.SectorAccessor
+	mma     *lib.MultiMinerAccessor
 	sector  *sectorResolver
 	ssm     *sectorstatemgr.SectorStateMgr
 	minerID abi.ActorID
@@ -517,8 +519,13 @@ func (ss *sealStatusReporter) sealStatus(ctx context.Context) *sealStatusResolve
 	isUnsealedCtx, cancel := context.WithTimeout(ctx, isUnsealedTimeout)
 	defer cancel()
 
-	sectorsStatusApiIsUnsealed, err := ss.sa.IsUnsealed(
-		isUnsealedCtx, abi.SectorNumber(ss.sector.ID),
+	maddr, err := address.NewIDAddress(uint64(ss.minerID))
+	if err != nil {
+		// There should never be an error but handle it just in case
+		return &sealStatusResolver{Error: fmt.Sprintf("unable to convert miner ID %d into ID address: %s", ss.minerID, err)}
+	}
+	sectorsStatusApiIsUnsealed, err := ss.mma.IsUnsealed(
+		isUnsealedCtx, maddr, abi.SectorNumber(ss.sector.ID),
 		abi.PaddedPieceSize(ss.sector.Offset).Unpadded(),
 		abi.PaddedPieceSize(ss.sector.Length).Unpadded(),
 	)

--- a/gql/schema.graphql
+++ b/gql/schema.graphql
@@ -173,6 +173,7 @@ type PieceDeal {
 }
 
 type PieceInfoDeal {
+  MinerAddress: String!
   ChainDealID: Uint64!
   Sector: Sector!
   SealStatus: SealStatus!

--- a/node/modules/storageminer.go
+++ b/node/modules/storageminer.go
@@ -666,27 +666,27 @@ func NewStorageMarketProvider(provAddr address.Address, cfg *config.Boost) func(
 	}
 }
 
-func NewGraphqlServer(cfg *config.Boost) func(lc fx.Lifecycle, r repo.LockedRepo, h host.Host, prov *storagemarket.Provider, dealsDB *db.DealsDB, logsDB *db.LogsDB, retDB *rtvllog.RetrievalLogDB, plDB *db.ProposalLogsDB, fundsDB *db.FundsDB, fundMgr *fundmanager.FundManager, storageMgr *storagemanager.StorageManager, publisher *storageadapter.DealPublisher, spApi sealingpipeline.API, legacyDeals *legacy.LegacyDealsManager, legacyProv gfm_storagemarket.StorageProvider, legacyDT dtypes.ProviderDataTransfer, ps dtypes.ProviderPieceStore, sa retrievalmarket.SectorAccessor, piecedirectory *piecedirectory.PieceDirectory, indexProv provider.Interface, idxProvWrapper *indexprovider.Wrapper, fullNode v1api.FullNode, bg gql.BlockGetter, ssm *sectorstatemgr.SectorStateMgr, mpool *mpoolmonitor.MpoolMonitor, mma *lib.MultiMinerAccessor) *gql.Server {
+func NewGraphqlServer(cfg *config.Boost) func(lc fx.Lifecycle, r repo.LockedRepo, h host.Host, prov *storagemarket.Provider, dealsDB *db.DealsDB, logsDB *db.LogsDB, retDB *rtvllog.RetrievalLogDB, plDB *db.ProposalLogsDB, fundsDB *db.FundsDB, fundMgr *fundmanager.FundManager, storageMgr *storagemanager.StorageManager, publisher *storageadapter.DealPublisher, spApi sealingpipeline.API, legacyDeals *legacy.LegacyDealsManager, legacyProv gfm_storagemarket.StorageProvider, legacyDT dtypes.ProviderDataTransfer, ps dtypes.ProviderPieceStore, piecedirectory *piecedirectory.PieceDirectory, indexProv provider.Interface, idxProvWrapper *indexprovider.Wrapper, fullNode v1api.FullNode, bg gql.BlockGetter, ssm *sectorstatemgr.SectorStateMgr, mpool *mpoolmonitor.MpoolMonitor, mma *lib.MultiMinerAccessor) *gql.Server {
 	return func(lc fx.Lifecycle, r repo.LockedRepo, h host.Host, prov *storagemarket.Provider, dealsDB *db.DealsDB, logsDB *db.LogsDB, retDB *rtvllog.RetrievalLogDB, plDB *db.ProposalLogsDB, fundsDB *db.FundsDB, fundMgr *fundmanager.FundManager,
 		storageMgr *storagemanager.StorageManager, publisher *storageadapter.DealPublisher, spApi sealingpipeline.API,
 		legacyDeals *legacy.LegacyDealsManager, legacyProv gfm_storagemarket.StorageProvider, legacyDT dtypes.ProviderDataTransfer,
-		ps dtypes.ProviderPieceStore, sa retrievalmarket.SectorAccessor, piecedirectory *piecedirectory.PieceDirectory,
+		ps dtypes.ProviderPieceStore, piecedirectory *piecedirectory.PieceDirectory,
 		indexProv provider.Interface, idxProvWrapper *indexprovider.Wrapper, fullNode v1api.FullNode, bg gql.BlockGetter,
 		ssm *sectorstatemgr.SectorStateMgr, mpool *mpoolmonitor.MpoolMonitor, mma *lib.MultiMinerAccessor) *gql.Server {
 
 		resolverCtx, cancel := context.WithCancel(context.Background())
-		resolver := gql.NewResolver(resolverCtx, cfg, r, h, dealsDB, logsDB, retDB, plDB, fundsDB, fundMgr, storageMgr, spApi, prov, legacyDeals, legacyProv, legacyDT, ps, sa, piecedirectory, publisher, indexProv, idxProvWrapper, fullNode, ssm, mpool, mma)
-		server := gql.NewServer(cfg, resolver, bg)
+		resolver := gql.NewResolver(resolverCtx, cfg, r, h, dealsDB, logsDB, retDB, plDB, fundsDB, fundMgr, storageMgr, spApi, prov, legacyDeals, legacyProv, legacyDT, ps, piecedirectory, publisher, indexProv, idxProvWrapper, fullNode, ssm, mpool, mma)
+		svr := gql.NewServer(cfg, resolver, bg)
 
 		lc.Append(fx.Hook{
-			OnStart: server.Start,
+			OnStart: svr.Start,
 			OnStop: func(ctx context.Context) error {
 				cancel()
-				return server.Stop(ctx)
+				return svr.Stop(ctx)
 			},
 		})
 
-		return server
+		return svr
 	}
 }
 

--- a/react/src/LID.js
+++ b/react/src/LID.js
@@ -643,6 +643,7 @@ function PieceStatus({pieceCid, pieceStatus, searchQuery}) {
                 <table className="deals">
                     <tbody>
                     <tr>
+                        <th>Miner Address</th>
                         <th>Chain Deal ID</th>
                         <th>Sector Number</th>
                         <th>Piece Offset</th>
@@ -651,6 +652,7 @@ function PieceStatus({pieceCid, pieceStatus, searchQuery}) {
                     </tr>
                     {pieceStatus.PieceInfoDeals.map(deal => (
                         <tr key={deal.ChainDealID+''}>
+                            <td>{deal.MinerAddress+''}</td>
                             <td>{deal.ChainDealID+''}</td>
                             <td>{deal.Sector.ID+''}</td>
                             <td>{deal.Sector.Offset+''}</td>

--- a/react/src/gql.js
+++ b/react/src/gql.js
@@ -519,6 +519,7 @@ const PieceStatusQuery = gql`
                 }
             }
             PieceInfoDeals {
+                MinerAddress
                 ChainDealID
                 Sector {
                     ID


### PR DESCRIPTION
Fixes https://github.com/filecoin-project/boost/issues/1619

Look up the unseal status of a deal against the multi-miner accessor, rather than just on local miner.
Also, display the miner address in the list of deals.

TODO:
- [x] Test in production

Note that the miner address of the local miner (in the top left) is different from the miner address listed under LID:

<img width="1208" alt="Screenshot 2023-08-24 at 12 08 45 PM" src="https://github.com/filecoin-project/boost/assets/169124/d006c223-1432-4e5a-adac-cd1ea9d317fc">

