### PR TITLE
fix(docker): no inline `sed` commands

### DIFF
--- a/docker/devnet/boost/entrypoint.sh
+++ b/docker/devnet/boost/entrypoint.sh
@@ -39,8 +39,8 @@ if [ ! -f $BOOST_PATH/.init.boost ]; then
 	# echo exit code: $?
 
 	echo Setting port in boost config...
-	sed -i 's|ip4/0.0.0.0/tcp/0|ip4/0.0.0.0/tcp/50000|g' $BOOST_PATH/config.toml
-	sed -i 's|127.0.0.1|0.0.0.0|g' $BOOST_PATH/config.toml
+	sed 's|ip4/0.0.0.0/tcp/0|ip4/0.0.0.0/tcp/50000|g' $BOOST_PATH/config.toml > $BOOST_PATH/config.toml.tmp; cp $BOOST_PATH/config.toml.tmp $BOOST_PATH/config.toml; rm $BOOST_PATH/config.toml.tmp
+	sed 's|127.0.0.1|0.0.0.0|g' $BOOST_PATH/config.toml > $BOOST_PATH/config.toml.tmp; cp $BOOST_PATH/config.toml.tmp $BOOST_PATH/config.toml; rm $BOOST_PATH/config.toml.tmp
 
 	echo Done
 	touch $BOOST_PATH/.init.boost
@@ -76,8 +76,8 @@ fi
 
 ## Override config options
 echo Updating config values
-sed -i 's|ServiceApiInfo = ""|ServiceApiInfo = "ws://localhost:8042"|g' $BOOST_PATH/config.toml
-sed -i 's|ExpectedSealDuration = "24h0m0s"|ExpectedSealDuration = "0h0m10s"|g' $BOOST_PATH/config.toml
+sed 's|ServiceApiInfo = ""|ServiceApiInfo = "ws://localhost:8042"|g' $BOOST_PATH/config.toml > $BOOST_PATH/config.toml.tmp; cp $BOOST_PATH/config.toml.tmp $BOOST_PATH/config.toml; rm $BOOST_PATH/config.toml.tmp
+sed 's|ExpectedSealDuration = "24h0m0s"|ExpectedSealDuration = "0h0m10s"|g' $BOOST_PATH/config.toml > $BOOST_PATH/config.toml.tmp; cp $BOOST_PATH/config.toml.tmp $BOOST_PATH/config.toml; rm $BOOST_PATH/config.toml.tmp
 
 echo Starting LID service and boost in dev mode...
 trap 'kill %1' SIGINT


### PR DESCRIPTION
# Goals

Fix an issue encountered using `sed` in the devnet with Docker Desktop for Mac.

# Implemention

When I tried to run devnet on my machine with Docker Desktop For Mac, I encountered an error where the boost container would shutdown while trying to run `sed` commands to update it's config, due to a permission error.

I tracked this down to https://forums.docker.com/t/sed-couldnt-open-temporary-file-xyz-permission-denied-when-using-virtiofs/125473/5 and was able to fix it by making `sed` not running inline.

# For Discussion

Possible alternate approach: Farther down the thread there's a suggestion the problem is fixed in `sed` 4.8, but that would require updating Ubuntu to 22 in the runner.