### PR TITLE
Build and publish boost devnet containers via CI

### DIFF
--- a/.github/actions/container-builder/action.yaml
+++ b/.github/actions/container-builder/action.yaml
@@ -1,0 +1,48 @@
+name: Build
+description: Build tag and optionally push container images
+inputs:
+  name:
+    required: true
+    type: string
+  target:
+    required: false
+    type: string
+  file:
+    required: false
+    type: string
+  context:
+    required: false
+    type: string
+    default: '.'
+  build-args:
+    required: false
+    type: string
+  push:
+    required: false
+    type: boolean
+    default: false
+runs:
+  using: "composite"
+  steps:
+      - name: Extract metadata for ${{ inputs.name }}
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/${{ github.repository }}
+          flavor: latest=false
+          tags: |
+            type=semver,pattern={{version}}
+            type=ref,event=branch
+            type=sha,prefix=${{ inputs.name }}-
+      - name: Build ${{ inputs.name }}
+        uses: docker/build-push-action@v4
+        with:
+          context: ${{ inputs.context }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          push: ${{ inputs.push }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          file: ${{ inputs.file }}
+          target: ${{ inputs.target }}
+          build-args: ${{ inputs.build-args }}

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -1,0 +1,80 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - 'main'
+    tags:
+      - 'v*'
+  pull_request:
+
+jobs:
+  build:
+    name: Containers
+    runs-on: ubuntu-latest
+    env:
+      LOTUS_TEST_IMAGE: 'filecoin/lotus-all-in-one:v1.23.2'
+      FFI_BUILD_FROM_SOURCE: '0'
+      DOCKER_BUILDKIT: '1'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Update Boost modules
+        run: make build/.update-modules
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        if: ${{ github.event_name != 'pull_request' }}
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build boost-dev
+        uses: ./.github/actions/container-builder
+        with:
+          name: boost-dev
+          file: docker/devnet/Dockerfile.source
+          target: boost-dev
+          push: ${{ github.event_name != 'pull_request' }}
+          build-args: |
+            LOTUS_TEST_IMAGE=${{ env.LOTUS_TEST_IMAGE }}
+            FFI_BUILD_FROM_SOURCE=${{ env.FFI_BUILD_FROM_SOURCE }}
+      - name: Build booster-http-dev
+        uses: ./.github/actions/container-builder
+        with:
+          name: booster-http-dev
+          file: docker/devnet/Dockerfile.source
+          target: booster-http-dev
+          push: ${{ github.event_name != 'pull_request' }}
+          build-args: |
+            LOTUS_TEST_IMAGE=${{ env.LOTUS_TEST_IMAGE }}
+            FFI_BUILD_FROM_SOURCE=${{ env.FFI_BUILD_FROM_SOURCE }}
+      - name: Build booster-bitswap-dev
+        uses: ./.github/actions/container-builder
+        with:
+          name: booster-bitswap-dev
+          file: docker/devnet/Dockerfile.source
+          target: booster-bitswap-dev
+          push: ${{ github.event_name != 'pull_request' }}
+          build-args: |
+            LOTUS_TEST_IMAGE=${{ env.LOTUS_TEST_IMAGE }}
+            FFI_BUILD_FROM_SOURCE=${{ env.FFI_BUILD_FROM_SOURCE }}
+      - name: Build lotus-dev
+        uses: ./.github/actions/container-builder
+        with:
+          name: lotus-dev
+          context: ./docker/devnet/lotus
+          push: ${{ github.event_name != 'pull_request' }}
+          build-args: |
+            LOTUS_TEST_IMAGE=${{ env.LOTUS_TEST_IMAGE }}
+            FFI_BUILD_FROM_SOURCE=${{ env.FFI_BUILD_FROM_SOURCE }}
+      - name: Build lotus-miner-dev
+        uses: ./.github/actions/container-builder
+        with:
+          name: lotus-miner-dev
+          context: ./docker/devnet/lotus-miner
+          push: ${{ github.event_name != 'pull_request' }}
+          build-args: |
+            LOTUS_TEST_IMAGE=${{ env.LOTUS_TEST_IMAGE }}
+            FFI_BUILD_FROM_SOURCE=${{ env.FFI_BUILD_FROM_SOURCE }}


### PR DESCRIPTION
Build boost containers on each PR to assert that all containers used by devnet build. On non PR events publish the containers onto ghcr.io.

This should significantly reduce wait time when interacting with devnet for well known versions of boost since a user would no longer have to build all related images from scratch. The CI is setup to use GitHub actions caching layers which should further speed up builds per commit.

The containers built will have a tag prefix that corresponds to the target name of devnet dockerfile.source. This includes:

* `boost-dev`
* `booster-http-dev`
* `booster-bitswap-dev`
* `lotus-dev`
* `lotus-miner-dev`