### PR TITLE
Allow container build job to push images

### DIFF
--- a/.github/actions/container-builder/action.yaml
+++ b/.github/actions/container-builder/action.yaml
@@ -24,25 +24,25 @@ inputs:
 runs:
   using: "composite"
   steps:
-      - name: Extract metadata for ${{ inputs.name }}
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          images: ghcr.io/${{ github.repository }}
-          flavor: latest=false
-          tags: |
-            type=semver,pattern={{version}},prefix=${{ inputs.name }}-
-            type=ref,event=branch,prefix=${{ inputs.name }}-
-            type=sha,prefix=${{ inputs.name }}-
-      - name: Build ${{ inputs.name }}
-        uses: docker/build-push-action@v4
-        with:
-          context: ${{ inputs.context }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          push: ${{ inputs.push }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          file: ${{ inputs.file }}
-          target: ${{ inputs.target }}
-          build-args: ${{ inputs.build-args }}
+    - name: Extract metadata for ${{ inputs.name }}
+      id: meta
+      uses: docker/metadata-action@v4
+      with:
+        images: ghcr.io/${{ github.repository }}
+        flavor: latest=false
+        tags: |
+          type=semver,pattern={{version}},prefix=${{ inputs.name }}-
+          type=ref,event=branch,prefix=${{ inputs.name }}-
+          type=sha,prefix=${{ inputs.name }}-
+    - name: Build ${{ inputs.name }}
+      uses: docker/build-push-action@v4
+      with:
+        context: ${{ inputs.context }}
+        cache-from: type=gha,scope=${{ inputs.name }}
+        cache-to: type=gha,mode=max,scope=${{ inputs.name }}
+        push: ${{ inputs.push }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        file: ${{ inputs.file }}
+        target: ${{ inputs.target }}
+        build-args: ${{ inputs.build-args }}

--- a/.github/actions/container-builder/action.yaml
+++ b/.github/actions/container-builder/action.yaml
@@ -31,8 +31,8 @@ runs:
           images: ghcr.io/${{ github.repository }}
           flavor: latest=false
           tags: |
-            type=semver,pattern={{version}}
-            type=ref,event=branch
+            type=semver,pattern={{version}},prefix=${{ inputs.name }}-
+            type=ref,event=branch,prefix=${{ inputs.name }}-
             type=sha,prefix=${{ inputs.name }}-
       - name: Build ${{ inputs.name }}
         uses: docker/build-push-action@v4

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -12,6 +12,9 @@ jobs:
   build:
     name: Containers
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     env:
       LOTUS_TEST_IMAGE: 'filecoin/lotus-all-in-one:v1.23.2'
       FFI_BUILD_FROM_SOURCE: '0'


### PR DESCRIPTION
Fix permissions to allow github actions to push images to ghrc.io.

Fix tag prefix for all tagging flavours to include the intermediate image name.