### PR TITLE
Build containers for arm64 and amd64 platforms

### DIFF
--- a/.github/actions/container-builder/action.yaml
+++ b/.github/actions/container-builder/action.yaml
@@ -46,3 +46,4 @@ runs:
         file: ${{ inputs.file }}
         target: ${{ inputs.target }}
         build-args: ${{ inputs.build-args }}
+        platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
Add multi platform build for container images for platforms:
* `linux/amd64`
* `linux/arm64`