### PR TITLE
feat: user defined allocation policy

### DIFF
--- a/cmd/boost/direct_deal.go
+++ b/cmd/boost/direct_deal.go
@@ -165,7 +165,7 @@ var directDealAllocate = &cli.Command{
 		}
 
 		if abi.ChainEpoch(cctx.Int64("term-max")) < head.Height() || abi.ChainEpoch(cctx.Int64("term-min")) < head.Height() {
-			return fmt.Errorf("current chain head %d is greater than termMin %d or termMax %d", head.Height(), cctx.Int64("term-min"), cctx.Int64("term-max"))
+			return fmt.Errorf("current chain head %d is greater than TermMin %d or TermMax %d", head.Height(), cctx.Int64("term-min"), cctx.Int64("term-max"))
 		}
 
 		// Create allocation requests
@@ -179,8 +179,8 @@ var directDealAllocate = &cli.Command{
 					Provider:   mid,
 					Data:       p.PieceCID,
 					Size:       p.Size,
-					TermMin:    abi.ChainEpoch(cctx.Int64("termmin")),
-					TermMax:    abi.ChainEpoch(cctx.Int64("termmax")),
+					TermMin:    abi.ChainEpoch(cctx.Int64("term-min")),
+					TermMax:    abi.ChainEpoch(cctx.Int64("term-max")),
 					Expiration: abi.ChainEpoch(cctx.Int64("expiration")),
 				})
 			}

--- a/cmd/boost/direct_deal.go
+++ b/cmd/boost/direct_deal.go
@@ -38,7 +38,7 @@ var directDealAllocate = &cli.Command{
 		},
 		&cli.StringSliceFlag{
 			Name:     "piece-info",
-			Usage:    "data pieceInfo[s] to create the allocation. The format must be --pieceInfo pieceCid1=pieceSize1 --pieceInfo pieceCid2=pieceSize2",
+			Usage:    "data piece-info[s] to create the allocation. The format must be --piece-info pieceCid1=pieceSize1 --piece-info pieceCid2=pieceSize2",
 			Required: true,
 			Aliases:  []string{"pi"},
 		},

--- a/docker/devnet/Dockerfile.source
+++ b/docker/devnet/Dockerfile.source
@@ -107,6 +107,8 @@ LABEL org.opencontainers.image.version=$BUILD_VERSION \
       description="This image is used to host the boost-dev storage provider"
 
 ENV BOOST_PATH /var/lib/boost
+ENV BOOST_CLIENT_REPO /var/lib/boost/boost-client
+env LID_LEVELDB_PATH /var/lib/boost
 VOLUME /var/lib/boost
 EXPOSE 8080
 

--- a/extern/boostd-data/cmd/run.go
+++ b/extern/boostd-data/cmd/run.go
@@ -49,9 +49,10 @@ var leveldbCmd = &cli.Command{
 	Before: before,
 	Flags: append([]cli.Flag{
 		&cli.StringFlag{
-			Name:  "repo",
-			Usage: "repo directory where the leveldb database is created",
-			Value: "~/.boost",
+			Name:    "repo",
+			EnvVars: []string{"LID_LEVELDB_PATH"},
+			Usage:   "repo directory where the leveldb database is created. Default is ~/.boost",
+			Value:   "~/.boost",
 		}},
 		runFlags...,
 	),


### PR DESCRIPTION
This PR will add the functionality to allow users to set termMin, termMax and expiration for allocations.
It also updated the `get-allocations` command to `list-allocations`

The default are:
TermMin = 180 days
TermMax = 5 years
Expiration = 60 days