### PR TITLE
feat: add InUnsealed utility to boostx

### DIFF
--- a/cmd/boostx/boostd.go
+++ b/cmd/boostx/boostd.go
@@ -12,7 +12,7 @@ import (
 
 const metadataNamespace = "/metadata"
 
-var minerCmd = &cli.Command{
+var boostdCmd = &cli.Command{
 	Name:  "boostd",
 	Usage: "boostd utilities",
 	Subcommands: []*cli.Command{

--- a/cmd/boostx/main.go
+++ b/cmd/boostx/main.go
@@ -47,7 +47,7 @@ func main() {
 			marketWithdrawCmd,
 			statsCmd,
 			sectorCmd,
-			minerCmd,
+			boostdCmd,
 		},
 	}
 	app.Setup()

--- a/cmd/boostx/sector.go
+++ b/cmd/boostx/sector.go
@@ -133,11 +133,6 @@ var isUnsealedCmd = &cli.Command{
 		}
 		defer ncloser()
 
-		err = lib.CheckFullNodeApiVersion(ctx, fullnodeApi)
-		if err != nil {
-			return err
-		}
-
 		// Connect to the storage API and create a sector accessor
 		storageApiInfo := cctx.String("api-storage")
 		sa, storageCloser, err := lib.CreateSectorAccessor(ctx, storageApiInfo, fullnodeApi, log)

--- a/cmd/boostx/sector.go
+++ b/cmd/boostx/sector.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"fmt"
+	"strconv"
+	"time"
+
 	"github.com/filecoin-project/boost/cmd/lib"
 	"github.com/filecoin-project/go-state-types/abi"
 	lcli "github.com/filecoin-project/lotus/cli"
 	"github.com/urfave/cli/v2"
-	"strconv"
-	"time"
 )
 
 var sectorCmd = &cli.Command{
@@ -15,6 +16,7 @@ var sectorCmd = &cli.Command{
 	Usage: "Sector commands",
 	Subcommands: []*cli.Command{
 		sectorUnsealCmd,
+		isUnsealedCmd,
 	},
 }
 
@@ -88,6 +90,74 @@ var sectorUnsealCmd = &cli.Command{
 		}
 
 		fmt.Printf("Successfully unsealed sector %d after %s\n", sectorID, time.Since(start).String())
+
+		return nil
+	},
+}
+
+var isUnsealedCmd = &cli.Command{
+	Name:        "is-unsealed",
+	Usage:       "boostx sector is-unsealed <Sector ID>",
+	Description: "Check if a particular sector is unsealed using the miner API. This is a definitive method to check for unsealed copies",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:     "api-fullnode",
+			Usage:    "the endpoint for the full node API",
+			Required: true,
+		},
+		&cli.StringFlag{
+			Name:     "api-storage",
+			Usage:    "the endpoint for the storage node API",
+			Required: true,
+		},
+	},
+	Action: func(cctx *cli.Context) error {
+
+		if !cctx.Args().Present() {
+			return fmt.Errorf("must pass sector ID as first parameter")
+		}
+
+		sectorIDInt, err := strconv.Atoi(cctx.Args().First())
+		if err != nil {
+			return fmt.Errorf("parsing sector ID %s: %w", cctx.Args().First(), err)
+		}
+		sectorID := abi.SectorNumber(sectorIDInt)
+
+		ctx := lcli.ReqContext(cctx)
+
+		// Connect to the full node API
+		fnApiInfo := cctx.String("api-fullnode")
+		fullnodeApi, ncloser, err := lib.GetFullNodeApi(ctx, fnApiInfo, log)
+		if err != nil {
+			return fmt.Errorf("getting full node API: %w", err)
+		}
+		defer ncloser()
+
+		err = lib.CheckFullNodeApiVersion(ctx, fullnodeApi)
+		if err != nil {
+			return err
+		}
+
+		// Connect to the storage API and create a sector accessor
+		storageApiInfo := cctx.String("api-storage")
+		sa, storageCloser, err := lib.CreateSectorAccessor(ctx, storageApiInfo, fullnodeApi, log)
+		if err != nil {
+			return err
+		}
+		defer storageCloser()
+
+		pieceLength := abi.PaddedPieceSize(1024).Unpadded()
+		isUnsealed, err := sa.IsUnsealed(ctx, sectorID, 0, pieceLength)
+		if err != nil {
+			return fmt.Errorf("getting sealed state of sector: %w", err)
+		}
+
+		if isUnsealed {
+			fmt.Printf("Sector %d is unsealed\n", sectorID)
+			return nil
+		}
+
+		fmt.Printf("Sector %d is NOT unsealed\n", sectorID)
 
 		return nil
 	},


### PR DESCRIPTION
Tested on devnet

```
# boostx sector is-unsealed --help
NAME:
   boostx sector is-unsealed - boostx sector is-unsealed <Sector ID>

USAGE:
   boostx sector is-unsealed [command options] [arguments...]

DESCRIPTION:
   Check if a particular sector is unsealed using the miner API. This is a definitive method to check for unsealed copies

OPTIONS:
   --api-fullnode value  the endpoint for the full node API
   --api-storage value   the endpoint for the storage node API
   --help, -h            show help
```

For pre-sealed sector
```
# boostx sector is-unsealed --api-fullnode $FULLNODE_API_INFO --api-storage $MINER_API_INFO 0
Sector 0 is NOT unsealed
```

For a new deal sector
```
# boostx sector is-unsealed --api-fullnode $FULLNODE_API_INFO --api-storage $MINER_API_INFO 1
Sector 1 is unsealed
```