### PR TITLE
fix: disable leveldb as LID default

### DIFF
--- a/itests/framework/framework.go
+++ b/itests/framework/framework.go
@@ -342,6 +342,9 @@ func (f *TestFramework) Start(opts ...ConfigOpt) error {
 
 	cfg.Dealmaking.ExpectedSealDuration = 10
 
+	// Enable LID with leveldb
+	cfg.LocalIndexDirectory.Leveldb.Enabled = true
+
 	err = lr.SetConfig(func(raw interface{}) {
 		rcfg := raw.(*config.Boost)
 		*rcfg = *cfg

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -83,6 +83,9 @@ func DefaultBoost() *Boost {
 			Yugabyte: LocalIndexDirectoryYugabyteConfig{
 				Enabled: false,
 			},
+			Leveldb: LocalIndexDirectoryLeveldbConfig{
+				Enabled: false,
+			},
 			ParallelAddIndexLimit: 4,
 			EmbeddedServicePort:   8042,
 			ServiceApiInfo:        "",

--- a/node/config/doc_gen.go
+++ b/node/config/doc_gen.go
@@ -584,6 +584,12 @@ Note that this port must be open on the firewall.`,
 			Comment: ``,
 		},
 		{
+			Name: "Leveldb",
+			Type: "LocalIndexDirectoryLeveldbConfig",
+
+			Comment: ``,
+		},
+		{
 			Name: "ParallelAddIndexLimit",
 			Type: "int",
 
@@ -612,6 +618,14 @@ Set this value to "" if the local index directory data service is embedded.`,
 			Type: "Duration",
 
 			Comment: `The RPC timeout when making requests to the boostd-data service`,
+		},
+	},
+	"LocalIndexDirectoryLeveldbConfig": []DocField{
+		{
+			Name: "Enabled",
+			Type: "bool",
+
+			Comment: ``,
 		},
 	},
 	"LocalIndexDirectoryYugabyteConfig": []DocField{

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -401,6 +401,7 @@ type LocalIndexDirectoryYugabyteConfig struct {
 
 type LocalIndexDirectoryConfig struct {
 	Yugabyte LocalIndexDirectoryYugabyteConfig
+	Leveldb  LocalIndexDirectoryLeveldbConfig
 	// The maximum number of add index operations allowed to execute in parallel.
 	// The add index operation is executed when a new deal is created - it fetches
 	// the piece from the sealing subsystem, creates an index of where each block
@@ -415,4 +416,8 @@ type LocalIndexDirectoryConfig struct {
 	ServiceApiInfo string
 	// The RPC timeout when making requests to the boostd-data service
 	ServiceRPCTimeout Duration
+}
+
+type LocalIndexDirectoryLeveldbConfig struct {
+	Enabled bool
 }

--- a/node/modules/piecedirectory.go
+++ b/node/modules/piecedirectory.go
@@ -84,9 +84,10 @@ func NewPieceDirectoryStore(cfg *config.Boost) func(lc fx.Lifecycle, r lotus_rep
 					}
 
 				default:
-					return fmt.Errorf("starting local index directory client:" +
-						"either LocalIndexDirectory.Yugabyte{} details must be defined or " +
-						"LocalIndexDirectory.Leveldb must be enabled")
+					return fmt.Errorf("starting local index directory client: " +
+						"neither yugabyte nor leveldb is enabled in config - " +
+						"you must explicitly configure either LocalIndexDirectory.Yugabyte "+
+						"or LocalIndexDirectory.Leveldb as the local index directory implementation")
 				}
 
 				// Start the embedded local index directory service

--- a/node/modules/piecedirectory.go
+++ b/node/modules/piecedirectory.go
@@ -73,7 +73,7 @@ func NewPieceDirectoryStore(cfg *config.Boost) func(lc fx.Lifecycle, r lotus_rep
 					migrator := yugabyte.NewMigrator(settings, address.Address(maddr))
 					bdsvc = svc.NewYugabyte(settings, migrator)
 
-				default:
+				case cfg.LocalIndexDirectory.Leveldb.Enabled:
 					log.Infow("local index directory: connecting to leveldb instance")
 
 					// Setup a local index directory service that connects to the leveldb
@@ -82,6 +82,11 @@ func NewPieceDirectoryStore(cfg *config.Boost) func(lc fx.Lifecycle, r lotus_rep
 					if err != nil {
 						return fmt.Errorf("creating leveldb local index directory: %w", err)
 					}
+
+				default:
+					return fmt.Errorf("starting local index directory client:" +
+						"either LocalIndexDirectory.Yugabyte{} details must be defined or " +
+						"LocalIndexDirectory.Leveldb must be enabled")
 				}
 
 				// Start the embedded local index directory service


### PR DESCRIPTION
Tested on devnet

```
2023-09-07T16:01:53.112+0400	ERROR	fxlog	fxevent/zap.go:59	start failed	{"error": "starting local index directory client:either LocalIndexDirectory.Yugabyte{} details must be defined or LocalIndexDirectory.Leveldb must be enabled"}
Error: creating node: starting node: starting local index directory client:either LocalIndexDirectory.Yugabyte{} details must be defined or LocalIndexDirectory.Leveldb must be enabled
```