### PR TITLE
Watch sealing state until finalized

### DIFF
--- a/node/modules/directdeals.go
+++ b/node/modules/directdeals.go
@@ -60,7 +60,7 @@ func NewDirectDealsProvider(provAddr address.Address, cfg *config.Boost) func(lc
 			RemoteCommp:             cfg.Dealmaking.RemoteCommp,
 		}
 
-		prov := storagemarket.NewDirectDealsProvider(ddpCfg, fullnodeApi, secb, commpc, directDealsDB, dl)
+		prov := storagemarket.NewDirectDealsProvider(ddpCfg, fullnodeApi, secb, commpc, sps, directDealsDB, dl)
 		return prov, nil
 	}
 }

--- a/storagemarket/deal_execution.go
+++ b/storagemarket/deal_execution.go
@@ -685,7 +685,7 @@ func (p *Provider) fireSealingUpdateEvents(dh *dealHandler, dealUuid uuid.UUID, 
 
 	retErr := &dealMakingError{
 		retry: types.DealRetryFatal,
-		error: ErrDealNotSealed,
+		error: ErrDealNotInSector,
 	}
 
 	// Check status immediately

--- a/storagemarket/direct_deals_provider.go
+++ b/storagemarket/direct_deals_provider.go
@@ -427,7 +427,12 @@ func (ddp *DirectDealsProvider) watchSealingUpdates(dealUuid uuid.UUID, sectorNu
 	checkSealingFinalized := func() bool {
 		// Get the sector status
 		si, err := ddp.sps.SectorsStatus(ddp.ctx, sectorNum, false)
-		if err == nil && si.State != lastSealingState {
+		if err != nil {
+			log.Warnw("getting sector sealing state", "sector", sectorNum, "err", err.Error())
+			return false
+		}
+
+		if si.State != lastSealingState {
 			// Sector status has changed
 			lastSealingState = si.State
 			ddp.dealLogger.Infow(dealUuid, "current sealing state", "state", si.State)

--- a/storagemarket/provider.go
+++ b/storagemarket/provider.go
@@ -43,7 +43,7 @@ import (
 var (
 	ErrDealNotFound        = fmt.Errorf("deal not found")
 	ErrDealHandlerNotFound = errors.New("deal handler not found")
-	ErrDealNotSealed       = errors.New("storage failed - deal not found in sector")
+	ErrDealNotInSector     = errors.New("storage failed - deal not found in sector")
 )
 
 var (


### PR DESCRIPTION
Once the deal has been handed off to the sealing subsystem, watch the sealing state until it reaches a final state, then mark the deal as completed.