### PR TITLE
fix: add parallelisation to migrate-lid and improve logging

### DIFF
--- a/cmd/migrate-lid/migrate_lid.go
+++ b/cmd/migrate-lid/migrate_lid.go
@@ -295,12 +295,12 @@ func migrateIndices(ctx context.Context, logger *zap.SugaredLogger, bar *progres
 					if indexed {
 						atomic.AddInt64(&count, 1)
 						atomic.AddInt64(&processed, 1)
-						logger.Infow("migrated index", "piece cid", p.name, "processed", processed, "total", len(idxPaths),
-							"took", took.String(), "average", (indexTime.t / time.Duration(count)).String())
+						logger.Infow("migrated index", "piece cid", p.name, "processed", atomic.LoadInt64(&processed), "total", len(idxPaths),
+							"took", took.String(), "average", (indexTime.t / time.Duration(atomic.LoadInt64(&count))).String())
 
 					} else {
 						atomic.AddInt64(&processed, 1)
-						logger.Infow("index already migrated", "piece cid", p.name, "processed", processed, "total", len(idxPaths))
+						logger.Infow("index already migrated", "piece cid", p.name, "processed", atomic.LoadInt64(&processed), "total", len(idxPaths))
 					}
 				}
 			}
@@ -312,7 +312,7 @@ func migrateIndices(ctx context.Context, logger *zap.SugaredLogger, bar *progres
 	logger.Errorw("waiting for indexing threads to finish", err)
 
 	logger.Infow("migrated indices", "total", len(idxPaths), "took", time.Since(indicesStart).String())
-	return errCount, nil
+	return atomic.LoadInt64(&errCount), nil
 }
 
 type migrateIndexResult struct {

--- a/cmd/migrate-lid/migrate_lid.go
+++ b/cmd/migrate-lid/migrate_lid.go
@@ -285,6 +285,7 @@ func migrateIndices(ctx context.Context, logger *zap.SugaredLogger, bar *progres
 					took := time.Since(start)
 					indexTime.lck.Lock()
 					indexTime.t += took
+					indexTime.lck.Unlock()
 
 					if perr != nil {
 						logger.Errorw("migrate index failed", "piece cid", p.name, "took", took.String(), "err", perr)
@@ -301,7 +302,6 @@ func migrateIndices(ctx context.Context, logger *zap.SugaredLogger, bar *progres
 						atomic.AddInt64(&processed, 1)
 						logger.Infow("index already migrated", "piece cid", p.name, "processed", processed, "total", len(idxPaths))
 					}
-					indexTime.lck.Unlock()
 				}
 			}
 			return ctx.Err()

--- a/cmd/migrate-lid/migrate_lid.go
+++ b/cmd/migrate-lid/migrate_lid.go
@@ -8,6 +8,7 @@ import (
 	"path"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/filecoin-project/boost-gfm/piecestore"
@@ -32,6 +33,7 @@ import (
 	"github.com/schollz/progressbar/v3"
 	"github.com/urfave/cli/v2"
 	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
 )
 
 // The methods on the store that are used for migration
@@ -64,6 +66,12 @@ var commonFlags = []cli.Flag{
 		Name:     "force",
 		Usage:    "if the index has already been migrated, overwrite it",
 		Required: false,
+	},
+	&cli.IntFlag{
+		Name:     "parallel",
+		Usage:    "the number of indexes to be processed in parallel",
+		Required: false,
+		Value:    4,
 	},
 }
 
@@ -198,7 +206,7 @@ func migrate(cctx *cli.Context, dbType string, store StoreMigrationApi, migrateT
 	if migrateType == "dagstore" {
 		// Migrate the indices
 		bar.Describe("Migrating indices...")
-		errCount, err := migrateIndices(ctx, logger, bar, repoDir, store, cctx.Bool("force"))
+		errCount, err := migrateIndices(ctx, logger, bar, repoDir, store, cctx.Bool("force"), cctx.Int("parallel"))
 		if errCount > 0 {
 			msg := fmt.Sprintf("Warning: there were errors migrating %d indices.", errCount)
 			msg += " See the log for details:\n" + logPath
@@ -227,7 +235,17 @@ func migrate(cctx *cli.Context, dbType string, store StoreMigrationApi, migrateT
 	return nil
 }
 
-func migrateIndices(ctx context.Context, logger *zap.SugaredLogger, bar *progressbar.ProgressBar, repoDir string, store StoreMigrationApi, force bool) (int, error) {
+type idxCount struct {
+	num int
+	lck sync.Mutex
+}
+
+type idxTime struct {
+	t   time.Duration
+	lck sync.Mutex
+}
+
+func migrateIndices(ctx context.Context, logger *zap.SugaredLogger, bar *progressbar.ProgressBar, repoDir string, store StoreMigrationApi, force bool, parallel int) (int, error) {
 	indicesPath := path.Join(repoDir, "dagstore", "index")
 	logger.Infof("migrating dagstore indices at %s", indicesPath)
 
@@ -240,44 +258,72 @@ func migrateIndices(ctx context.Context, logger *zap.SugaredLogger, bar *progres
 	bar.ChangeMax(len(idxPaths))
 
 	indicesStart := time.Now()
-	var count int
-	var errCount int
-	var indexTime time.Duration
-	for i, ipath := range idxPaths {
-		if ctx.Err() != nil {
-			return errCount, fmt.Errorf("index migration cancelled")
-		}
+	var count idxCount
+	var errCount idxCount
+	var indexTime idxTime
+	var processed idxCount
 
-		start := time.Now()
+	queue := make(chan idxPath, len(idxPaths))
+	for _, ipath := range idxPaths {
+		queue <- ipath
+	}
+	close(queue)
 
-		timeoutCtx, timeoutCancel := context.WithTimeout(ctx, 60*time.Second)
-		defer timeoutCancel()
+	var eg errgroup.Group
+	for i := 0; i < parallel; i++ {
+		eg.Go(func() error {
+			for ctx.Err() == nil {
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case p, ok := <-queue:
+					if !ok {
+						// Finished adding all the queued items, exit the thread
+						return nil
+					}
+					start := time.Now()
 
-		indexed, err := migrateIndexWithTimeout(timeoutCtx, ipath, store, force)
-		bar.Add(1) //nolint:errcheck
-		if err != nil {
-			took := time.Since(start)
-			indexTime += took
+					indexed, perr := migrateIndexWithTimeout(ctx, p, store, force)
+					bar.Add(1) //nolint:errcheck
 
-			logger.Errorw("migrate index failed", "piece cid", ipath.name, "took", took.String(), "err", err)
+					took := time.Since(start)
+					indexTime.lck.Lock()
+					indexTime.t += took
+					indexTime.lck.Unlock()
 
-			errCount++
-			continue
-		}
+					if perr != nil {
+						logger.Errorw("migrate index failed", "piece cid", p.name, "took", took.String(), "err", perr)
+						errCount.lck.Lock()
+						errCount.num++
+						errCount.lck.Unlock()
+					}
 
-		if indexed {
-			count++
-			took := time.Since(start)
-			indexTime += took
-			logger.Infow("migrated index", "piece cid", ipath.name, "processed", i+1, "total", len(idxPaths),
-				"took", took.String(), "average", (indexTime / time.Duration(count)).String())
-		} else {
-			logger.Infow("index already migrated", "piece cid", ipath.name, "processed", i+1, "total", len(idxPaths))
-		}
+					if indexed {
+						count.lck.Lock()
+						processed.lck.Lock()
+						count.num++
+						processed.num++
+						logger.Infow("migrated index", "piece cid", p.name, "processed", processed.num, "total", len(idxPaths),
+							"took", took.String(), "average", (indexTime.t / time.Duration(count.num)).String())
+						processed.lck.Unlock()
+						count.lck.Unlock()
+					} else {
+						processed.lck.Lock()
+						processed.num++
+						logger.Infow("index already migrated", "piece cid", p.name, "processed", processed.num, "total", len(idxPaths))
+						processed.lck.Unlock()
+					}
+				}
+			}
+			return ctx.Err()
+		})
 	}
 
+	err = eg.Wait()
+	logger.Errorw("waiting for indexing threads to finish", err)
+
 	logger.Infow("migrated indices", "total", len(idxPaths), "took", time.Since(indicesStart).String())
-	return errCount, nil
+	return errCount.num, nil
 }
 
 type migrateIndexResult struct {
@@ -286,13 +332,20 @@ type migrateIndexResult struct {
 }
 
 func migrateIndexWithTimeout(ctx context.Context, ipath idxPath, store StoreMigrationApi, force bool) (bool, error) {
+	timeoutCtx, timeoutCancel := context.WithTimeout(ctx, 60*time.Second)
+	defer timeoutCancel()
+
+	return execMigrateIndexWithTimeout(timeoutCtx, ipath, store, force)
+}
+
+func execMigrateIndexWithTimeout(ctx context.Context, ipath idxPath, store StoreMigrationApi, force bool) (bool, error) {
 	result := make(chan migrateIndexResult, 1)
 	go func() {
 		result <- doMigrateIndex(ctx, ipath, store, force)
 	}()
 	select {
-	case <-time.After(75 * time.Second):
-		return false, errors.New("index migration timed out after 75 seconds")
+	case <-ctx.Done():
+		return false, errors.New("index migration timed out after 60 seconds")
 	case result := <-result:
 		return result.Indexed, result.Error
 	}
@@ -324,10 +377,12 @@ func migrateIndex(ctx context.Context, ipath idxPath, store StoreMigrationApi, f
 	}
 
 	// Load the index file
+	readStart := time.Now()
 	idx, err := loadIndex(ipath.path)
 	if err != nil {
 		return false, fmt.Errorf("loading index %s from disk: %w", ipath.path, err)
 	}
+	log.Debugw("ReadIndex", "took", time.Since(readStart).String())
 
 	itidx, ok := idx.(index.IterableIndex)
 	if !ok {
@@ -335,10 +390,12 @@ func migrateIndex(ctx context.Context, ipath idxPath, store StoreMigrationApi, f
 	}
 
 	// Convert from IterableIndex to an array of records
+	convStart := time.Now()
 	records, err := getRecords(itidx)
 	if err != nil {
 		return false, fmt.Errorf("getting records for index %s: %w", ipath.path, err)
 	}
+	log.Debugw("ConvertIndex", "took", time.Since(convStart).String())
 
 	// Add the index to the store
 	addStart := time.Now()
@@ -550,10 +607,6 @@ func getIndexPaths(pathDir string) ([]idxPath, error) {
 }
 
 func loadIndex(path string) (index.Index, error) {
-	defer func(now time.Time) {
-		log.Debugw("loadindex", "took", time.Since(now))
-	}(time.Now())
-
 	idxf, err := os.Open(path)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Tested on filcollins:

```
./migrate-lid --boost-repo ~/boost-test-migrate --vv leveldb --parallel 10 dagstore
Setting up connection and creating data structures... this might take a minute...
Migrating to leveldb Local Index Directory. See detailed logs of the migration at
migrate-leveldb.log
Migrating indices...   0% [                                                                                                                                                                                                                                                                                                                               ] (0/468) [0s:0s]2023-09-11T07:26:32.598-0400	DEBUG	migrate	migrate-lid/migrate_lid.go:385	ReadIndex	{"took": "2.184337ms"}
2023-09-11T07:26:32.598-0400	DEBUG	migrate	migrate-lid/migrate_lid.go:385	ReadIndex	{"took": "2.12958ms"}
2023-09-11T07:26:32.599-0400	DEBUG	migrate	migrate-lid/migrate_lid.go:385	ReadIndex	{"took": "3.414967ms"}
2023-09-11T07:26:32.599-0400	DEBUG	migrate	migrate-lid/migrate_lid.go:385	ReadIndex	{"took": "3.626186ms"}
2023-09-11T07:26:32.599-0400	DEBUG	migrate	migrate-lid/migrate_lid.go:385	ReadIndex	{"took": "3.767945ms"}
2023-09-11T07:26:32.600-0400	DEBUG	migrate	migrate-lid/migrate_lid.go:385	ReadIndex	{"took": "2.302942ms"}
2023-09-11T07:26:32.600-0400	DEBUG	migrate	migrate-lid/migrate_lid.go:385	ReadIndex	{"took": "2.362373ms"}
2023-09-11T07:26:32.601-0400	DEBUG	migrate	migrate-lid/migrate_lid.go:385	ReadIndex	{"took": "2.80938ms"}
2023-09-11T07:26:32.604-0400	DEBUG	migrate	migrate-lid/migrate_lid.go:385	ReadIndex	{"took": "8.288777ms"}
2023-09-11T07:26:32.605-0400	DEBUG	migrate	migrate-lid/migrate_lid.go:385	ReadIndex	{"took": "7.588953ms"}
2023-09-11T07:26:32.610-0400	DEBUG	migrate	migrate-lid/migrate_lid.go:398	ConvertIndex	{"took": "10.152786ms"}
2023-09-11T07:26:32.621-0400	DEBUG	migrate	migrate-lid/migrate_lid.go:398	ConvertIndex	{"took": "20.614302ms"}
2023-09-11T07:26:32.622-0400	DEBUG	migrate	migrate-lid/migrate_lid.go:398	ConvertIndex	{"took": "22.467042ms"}
2023-09-11T07:26:32.623-0400	DEBUG	migrate	migrate-lid/migrate_lid.go:398	ConvertIndex	{"took": "25.195107ms"}
2023-09-11T07:26:32.624-0400	DEBUG	migrate	migrate-lid/migrate_lid.go:398	ConvertIndex	{"took": "23.350412ms"}
```




```
Migrating indices...   0% [                                                                                                                                                                                                                                                                                                                            ] (1/468) [0s:1m44s]2023-09-11T07:26:33.446-0400	DEBUG	migrate	migrate-lid/migrate_lid.go:408	AddIndex	{"took": "824.429865ms"}
Migrating indices...   0% [                                                                                                                                                                                                                                                                                                                            ] (2/468) [0s:3m18s]2023-09-11T07:26:34.058-0400	DEBUG	migrate	migrate-lid/migrate_lid.go:408	AddIndex	{"took": "1.43635134s"}
Migrating indices...   0% [                                                                                                                                                                                                                                                                                                                            ] (3/468) [1s:3m53s]2023-09-11T07:26:34.663-0400	DEBUG	migrate	migrate-lid/migrate_lid.go:408	AddIndex	{"took": "2.03988041s"}
Migrating indices...   0% [                                                                                                                                                                                                                                                                                                                             ] (4/468) [2s:4m7s]2023-09-11T07:26:35.394-0400	DEBUG	migrate	migrate-lid/migrate_lid.go:408	AddIndex	{"took": "2.769649578s"}
Migrating indices...   1% [==>                                                                                                                                                                                                                                                                                                                         ] (5/468) [2s:4m24s]2023-09-11T07:26:36.075-0400	DEBUG	migrate	migrate-lid/migrate_lid.go:408	AddIndex	{"took": "3.450320056s"}
Migrating indices...   1% [==>                                                                                                                                                                                                                                                                                                                         ] (6/468) [3s:4m32s]2023-09-11T07:26:36.773-0400	DEBUG	migrate	migrate-lid/migrate_lid.go:408	AddIndex	{"took": "4.148041261s"}
Migrating indices...   1% [==>                                                                                                                                                                                                                                                                                                                         ] (7/468) [4s:4m39s]2023-09-11T07:26:37.618-0400	DEBUG	migrate	migrate-lid/migrate_lid.go:408	AddIndex	{"took": "4.993020253s"}
Migrating indices...   1% [==>                                                                                                                                                                                                                                                                                                                         ] (8/468) [5s:4m50s]2023-09-11T07:26:38.385-0400	DEBUG	migrate	migrate-lid/migrate_lid.go:408	AddIndex	{"took": "5.759071721s"}
Migrating indices...   1% [==>                                                                                                                                                                                                                                                                                                                         ] (9/468) [5s:4m56s]2023-09-11T07:26:39.408-0400	DEBUG	migrate	migrate-lid/migrate_lid.go:408	AddIndex	{"took": "6.782559442s"}
Migrating indices...   2% [=====>
```


Resumption works with a higher number of parallelisation:
```
./migrate-lid --boost-repo ~/boost-test-migrate --vv leveldb --parallel 25 dagstore
Setting up connection and creating data structures... this might take a minute...
Migrating to leveldb Local Index Directory. See detailed logs of the migration at
migrate-leveldb.log
2023-09-11T07:31:19.503-0400    DEBUG   migrate migrate-lid/migrate_lid.go:385  ReadIndex       {"took": "1.024511ms"}                                                                                                                                                                                                                                                     
Migrating indices...  18% [========================================================>
```

