### PR TITLE
fix: init with commented config

### DIFF
--- a/cmd/boostd/init.go
+++ b/cmd/boostd/init.go
@@ -112,6 +112,24 @@ var initCmd = &cli.Command{
 			return fmt.Errorf("setting config: %w", err)
 		}
 
+		// Add comments to config
+		c, err := lr.Config()
+		if err != nil {
+			return fmt.Errorf("getting config: %w", err)
+		}
+		curCfg, ok := c.(*config.Boost)
+		if !ok {
+			return fmt.Errorf("parsing config from boost repo")
+		}
+		newCfg, err := config.ConfigUpdate(curCfg, config.DefaultBoost(), true, false)
+		if err != nil {
+			return err
+		}
+		err = os.WriteFile(path.Join(lr.Path(), "config.toml"), newCfg, 0644)
+		if err != nil {
+			return fmt.Errorf("writing config file %s: %w", string(newCfg), err)
+		}
+
 		// Add the miner address to the metadata datastore
 		fmt.Printf("Adding miner address %s to datastore\n", bp.minerActor)
 		err = addMinerAddressToDatastore(ds, bp.minerActor)


### PR DESCRIPTION
fixes #1686 

Tested on filcollins

```
# The version of the config file (used for migrations)
#
# type: int
ConfigVersion = 5

# The connect string for the sealing RPC API (lotus miner)
#
# type: string
SealerApiInfo = "<token>:/ip4/10.2.2.22/tcp/2345/http"

# The connect string for the sector index RPC API (lotus miner)
#
# type: string
SectorIndexApiInfo = "<token>:/ip4/10.2.2.22/tcp/2345/http"


[API]
  # Binding address for the Lotus API
  #
  # type: string
  #ListenAddress = "/ip4/127.0.0.1/tcp/1288/http"

  # type: string
  #RemoteListenAddress = ""

  # type: Duration
  #Timeout = "30s"
```


Start up is processing the commented config correctly.

```
2023-09-11T09:53:30.594-0400	INFO	fxlog	fxevent/zap.go:51	OnStop hook executed	{"callee": "github.com/filecoin-project/lotus/node/modules.OpenFilesystemJournal.func1()", "caller": "github.com/filecoin-project/lotus/node/modules.OpenFilesystemJournal", "runtime": "17.746µs"}
2023-09-11T09:53:30.594-0400	INFO	fxlog	fxevent/zap.go:51	OnStop hook executing	{"callee": "github.com/filecoin-project/lotus/node/modules.LockedRepo.func1.1()", "caller": "github.com/filecoin-project/lotus/node/modules.LockedRepo.func1"}
2023-09-11T09:53:30.596-0400	INFO	fxlog	fxevent/zap.go:51	OnStop hook executed	{"callee": "github.com/filecoin-project/lotus/node/modules.LockedRepo.func1.1()", "caller": "github.com/filecoin-project/lotus/node/modules.LockedRepo.func1", "runtime": "1.650611ms"}
2023-09-11T09:53:30.596-0400	ERROR	fxlog	fxevent/zap.go:59	start failed	{"error": "starting local index directory client: neither yugabyte nor leveldb is enabled in config - you must explicitly configure either LocalIndexDirectory.Yugabyte or LocalIndexDirectory.Leveldb as the local index directory implementation"}
Error: creating node: starting node: starting local index directory client: neither yugabyte nor leveldb is enabled in config - you must explicitly configure either LocalIndexDirectory.Yugabyte or LocalIndexDirectory.Leveldb as the local index directory implementation
```
