### PR TITLE
feat: add multistream http download

### DIFF
--- a/node/builder.go
+++ b/node/builder.go
@@ -476,6 +476,10 @@ func ConfigBoost(cfg *config.Boost) Option {
 		return Error(fmt.Errorf("Detected custom DAG store path %s. The DAG store must be at $BOOST_PATH/dagstore", cfg.DAGStore.RootDir))
 	}
 
+	if cfg.HttpDownload.NChunks < 1 || cfg.HttpDownload.NChunks > 16 {
+		return Error(errors.New("HttpDownload.NChunks should be between 1 and 16"))
+	}
+
 	legacyFees := cfg.LotusFees.Legacy()
 
 	return Options(

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -213,6 +213,9 @@ func DefaultBoost() *Boost {
 				Port:           3104,
 			},
 		},
+		HttpDownload: HttpDownloadConfig{
+			NChunks: 5,
+		},
 	}
 	return cfg
 }

--- a/node/config/doc_gen.go
+++ b/node/config/doc_gen.go
@@ -86,6 +86,12 @@ your node if metadata log is disabled`,
 			Comment: ``,
 		},
 		{
+			Name: "HttpDownload",
+			Type: "HttpDownloadConfig",
+
+			Comment: ``,
+		},
+		{
 			Name: "LotusDealmaking",
 			Type: "lotus_config.DealmakingConfig",
 
@@ -472,6 +478,16 @@ configured in SectorIndexApiInfo.`,
 			Type: "uint64",
 
 			Comment: `The port that the graphql server listens on`,
+		},
+	},
+	"HttpDownloadConfig": []DocField{
+		{
+			Name: "NChunks",
+			Type: "int",
+
+			Comment: `NChunks is a number of chunks to split HTTP downloads into. Each chunk is downloaded in the goroutine of its own
+which improves the overall download speed. NChunks is always equal to 1 for libp2p transport because libp2p server
+doesn't support range requests yet. NChunks must be greater than 0 and less than 16, with the default of 5.`,
 		},
 	},
 	"IndexProviderAnnounceConfig": []DocField{

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -47,6 +47,7 @@ type Boost struct {
 	Tracing             TracingConfig
 	LocalIndexDirectory LocalIndexDirectoryConfig
 	ContractDeals       ContractDealsConfig
+	HttpDownload        HttpDownloadConfig
 
 	// Lotus configs
 	LotusDealmaking lotus_config.DealmakingConfig
@@ -420,4 +421,11 @@ type LocalIndexDirectoryConfig struct {
 
 type LocalIndexDirectoryLeveldbConfig struct {
 	Enabled bool
+}
+
+type HttpDownloadConfig struct {
+	// NChunks is a number of chunks to split HTTP downloads into. Each chunk is downloaded in the goroutine of its own
+	// which improves the overall download speed. NChunks is always equal to 1 for libp2p transport because libp2p server
+	// doesn't support range requests yet. NChunks must be greater than 0 and less than 16, with the default of 5.
+	NChunks int
 }

--- a/node/modules/storageminer.go
+++ b/node/modules/storageminer.go
@@ -622,7 +622,7 @@ func NewStorageMarketProvider(provAddr address.Address, cfg *config.Boost) func(
 			SealingPipelineCacheTimeout: time.Duration(cfg.Dealmaking.SealingPipelineCacheTimeout),
 		}
 		dl := logs.NewDealLogger(logsDB)
-		tspt := httptransport.New(h, dl)
+		tspt := httptransport.New(h, dl, httptransport.NChunksOpt(cfg.HttpDownload.NChunks))
 		prov, err := storagemarket.NewProvider(prvCfg, sqldb, dealsDB, fundMgr, storageMgr, a, dp, provAddr, secb, commpc,
 			sps, cdm, df, logsSqlDB.db, logsDB, piecedirectory, ip, lp, &signatureVerifier{a}, dl, tspt)
 		if err != nil {

--- a/testutil/httptestfileservers.go
+++ b/testutil/httptestfileservers.go
@@ -53,6 +53,11 @@ func HttpTestUnstartedFileServer(t *testing.T, dir string) *HttpTestServer {
 	return tsrv
 }
 
+func addContentLengthHeader(w http.ResponseWriter, l int) {
+	w.Header().Add("Content-Length", strconv.Itoa(l))
+	w.WriteHeader(200)
+}
+
 type unblockInfo struct {
 	ch        chan struct{}
 	closeOnce sync.Once
@@ -73,22 +78,37 @@ func NewBlockingHttpTestServer(t *testing.T, dir string) *BlockingHttpTestServer
 	}
 
 	svc := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// wait till serving the file is unblocked
-		name := path.Clean(strings.TrimPrefix(r.URL.Path, "/"))
-		b.mu.Lock()
-		ubi := b.unblock[name]
-		b.mu.Unlock()
-		<-ubi.ch
-
-		// serve the file
-		upath := r.URL.Path
-		if !strings.HasPrefix(upath, "/") {
-			upath = "/" + upath
-			r.URL.Path = upath
-		}
 		fp := path.Clean(r.URL.Path)
 		absPath := filepath.Join(dir, fp)
-		http.ServeFile(w, r, absPath)
+
+		switch r.Method {
+		case http.MethodGet:
+			// wait till serving the file is unblocked
+			name := path.Clean(strings.TrimPrefix(r.URL.Path, "/"))
+			b.mu.Lock()
+			ubi := b.unblock[name]
+			b.mu.Unlock()
+			<-ubi.ch
+
+			// serve the file
+			upath := r.URL.Path
+			if !strings.HasPrefix(upath, "/") {
+				upath = "/" + upath
+				r.URL.Path = upath
+			}
+			http.ServeFile(w, r, absPath)
+		case http.MethodHead:
+			fp := path.Clean(r.URL.Path)
+			absPath := filepath.Join(dir, fp)
+			stat, err := os.Stat(absPath)
+			if err != nil {
+				t.Logf("failed to get file stat: %s", err.Error())
+				w.WriteHeader(500)
+				return
+			}
+			addContentLengthHeader(w, int(stat.Size()))
+		}
+
 	}))
 
 	b.svc = svc
@@ -146,64 +166,77 @@ func GetConn(r *http.Request) net.Conn {
 // starting at the start offset mentioned in the Range request.
 func HttpTestDisconnectingServer(t *testing.T, dir string, afterEvery int64) *httptest.Server {
 	svr := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// process the start offset
-		offset := r.Header.Get("Range")
-		startend := strings.Split(strings.TrimPrefix(offset, "bytes="), "-")
-		start, _ := strconv.ParseInt(startend[0], 10, 64)
-		// only send `afterEvery` bytes and then disconnect
-		end := start + afterEvery
-
-		// open the file to serve
-		upath := r.URL.Path
-		if !strings.HasPrefix(upath, "/") {
-			upath = "/" + upath
-			r.URL.Path = upath
-		}
 		fp := path.Clean(r.URL.Path)
 		absPath := filepath.Join(dir, fp)
-		f, err := os.Open(absPath)
-		if err != nil {
-			t.Logf("failed to open file to serve: %s", err)
-			w.WriteHeader(500)
-			return
-		}
-		defer f.Close()
 
-		// prevent buffer overflow
-		fi, err := f.Stat()
-		if err != nil {
-			t.Logf("failed to stat file: %s", err)
-			w.WriteHeader(500)
-			return
-		}
-		if end > fi.Size() {
-			end = fi.Size()
+		switch r.Method {
+		case http.MethodGet:
+			// process the start offset
+			offset := r.Header.Get("Range")
+			startend := strings.Split(strings.TrimPrefix(offset, "bytes="), "-")
+			start, _ := strconv.ParseInt(startend[0], 10, 64)
+			// only send `afterEvery` bytes and then disconnect
+			end := start + afterEvery
+
+			// open the file to serve
+			upath := r.URL.Path
+			if !strings.HasPrefix(upath, "/") {
+				upath = "/" + upath
+				r.URL.Path = upath
+			}
+			f, err := os.Open(absPath)
+			if err != nil {
+				t.Logf("failed to open file to serve: %s", err)
+				w.WriteHeader(500)
+				return
+			}
+			defer f.Close()
+
+			// prevent buffer overflow
+			fi, err := f.Stat()
+			if err != nil {
+				t.Logf("failed to stat file: %s", err)
+				w.WriteHeader(500)
+				return
+			}
+			if end > fi.Size() {
+				end = fi.Size()
+			}
+
+			// read (end-start) bytes from the file starting at the given offset and write them to the response
+			bz := make([]byte, end-start)
+			n, err := f.ReadAt(bz, start)
+			if err != nil {
+				t.Logf("failed to read file: %s", err)
+				w.WriteHeader(500)
+				return
+			}
+			if int64(n) != (end - start) {
+				w.WriteHeader(500)
+				return
+			}
+
+			w.WriteHeader(200)
+			_, err = w.Write(bz)
+			if err != nil {
+				t.Logf("failed to write file: %s", err)
+				w.WriteHeader(500)
+				return
+			}
+
+			// close the connection so client sees an error while reading the response
+			c := GetConn(r)
+			c.Close() //nolint:errcheck
+		case http.MethodHead:
+			stat, err := os.Stat(absPath)
+			if err != nil {
+				t.Logf("failed to get file stat: %s", err)
+				w.WriteHeader(500)
+				return
+			}
+			addContentLengthHeader(w, int(stat.Size()))
 		}
 
-		// read (end-start) bytes from the file starting at the given offset and write them to the response
-		bz := make([]byte, end-start)
-		n, err := f.ReadAt(bz, start)
-		if err != nil {
-			t.Logf("failed to read file: %s", err)
-			w.WriteHeader(500)
-			return
-		}
-		if int64(n) != (end - start) {
-			w.WriteHeader(500)
-			return
-		}
-
-		w.WriteHeader(200)
-		_, err = w.Write(bz)
-		if err != nil {
-			t.Logf("failed to write file: %s", err)
-			w.WriteHeader(500)
-			return
-		}
-
-		// close the connection so client sees an error while reading the response
-		c := GetConn(r)
-		c.Close() //nolint:errcheck
 	}))
 	svr.Config.ConnContext = SaveConnInContext
 

--- a/testutil/httptestfileservers.go
+++ b/testutil/httptestfileservers.go
@@ -148,8 +148,8 @@ func HttpTestDisconnectingServer(t *testing.T, dir string, afterEvery int64) *ht
 	svr := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// process the start offset
 		offset := r.Header.Get("Range")
-		finalOffset := strings.TrimSuffix(strings.TrimPrefix(offset, "bytes="), "-")
-		start, _ := strconv.ParseInt(finalOffset, 10, 64)
+		startend := strings.Split(strings.TrimPrefix(offset, "bytes="), "-")
+		start, _ := strconv.ParseInt(startend[0], 10, 64)
 		// only send `afterEvery` bytes and then disconnect
 		end := start + afterEvery
 

--- a/transport/httptransport/http_downloader.go
+++ b/transport/httptransport/http_downloader.go
@@ -62,7 +62,7 @@ func (d *downloader) doHttp() error {
 	// send http request and validate response
 	resp, err := d.transfer.client.Do(req)
 	if err != nil {
-		return &httpError{error: fmt.Errorf("failed to send  http req: %w", err)}
+		return &httpError{error: fmt.Errorf("failed to send http req: %w", err)}
 	}
 	// we should either get back a 200 or a 206 -> anything else means something has gone wrong and we return an error.
 	defer resp.Body.Close() // nolint

--- a/transport/httptransport/http_downloader.go
+++ b/transport/httptransport/http_downloader.go
@@ -7,9 +7,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"sync/atomic"
-
-	"github.com/filecoin-project/boost/transport/types"
 )
 
 type downloader struct {
@@ -20,6 +17,7 @@ type downloader struct {
 	rangeStart int64
 	rangeEnd   int64
 	chunkNo    int
+	dealSize   int64
 }
 
 func (d *downloader) doHttp() error {
@@ -37,7 +35,7 @@ func (d *downloader) doHttp() error {
 	// calculate range boundaries taking into account bytes that have been already downloaded
 	fi, err := os.Stat(d.chunkFile)
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
-		return &httpError{error: fmt.Errorf("failed to read file size: %w", err)}
+		return &httpError{error: fmt.Errorf("failed to read size of chunk file %s: %w", d.chunkFile, err)}
 	}
 	var offset int64
 	if fi != nil {
@@ -79,7 +77,7 @@ func (d *downloader) doHttp() error {
 	// create chunk file if it doesn't exist
 	of, err := os.OpenFile(d.chunkFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
-		return &httpError{error: fmt.Errorf("failed to open chunk file for write: %w", err)}
+		return &httpError{error: fmt.Errorf("failed to open chunk file %s for write: %w", d.chunkFile, err)}
 	}
 	defer of.Close()
 
@@ -101,19 +99,16 @@ func (d *downloader) doHttp() error {
 			// if the number of read and written bytes don't match -> something has gone wrong, abort the http req.
 			if nw < 0 || nr != nw {
 				if writeErr != nil {
-					return &httpError{error: fmt.Errorf("failed to the chunk file: %w", writeErr)}
+					return &httpError{error: fmt.Errorf("failed to write the chunk file %s: %w", d.chunkFile, writeErr)}
 				}
-				return &httpError{error: fmt.Errorf("read-write mismatch writing to the chunk file, read=%d, written=%d", nr, nw)}
+				return &httpError{error: fmt.Errorf("read-write mismatch writing to the chunk file %s: read=%d, written=%d", d.chunkFile, nr, nw)}
 			}
 			chunkBytesReceived += int64(nw)
-			totalBytesReceived := atomic.AddInt64(&d.transfer.nBytesReceived, int64(nw))
-
-			// emit event updating the number of bytes received
-			d.transfer.emitEvent(types.TransportEvent{NBytesReceived: totalBytesReceived})
+			d.transfer.addBytesReceived(int64(nw))
 		}
 		// the http stream we're reading from has sent us an EOF, nothing to do here.
 		if readErr == io.EOF {
-			d.transfer.dl.Infow(duid, "http server sent EOF", "toRead", toRead, "received", chunkBytesReceived, "deal-size", d.transfer.dealInfo.DealSize)
+			d.transfer.dl.Infow(duid, "http server sent EOF", "toRead", toRead, "received", chunkBytesReceived, "deal-size", d.dealSize)
 			return nil
 		}
 		if readErr != nil {
@@ -125,25 +120,25 @@ func (d *downloader) doHttp() error {
 func (d *downloader) appendChunkToTheOutput() error {
 	chunk, err := os.OpenFile(d.chunkFile, os.O_RDONLY, 0644)
 	if err != nil {
-		return fmt.Errorf("error opening chunk file: %w", err)
+		return fmt.Errorf("error opening chunk file %s: %w", d.chunkFile, err)
 	}
 	defer chunk.Close()
 
 	output, err := os.OpenFile(d.outputFile, os.O_APPEND|os.O_WRONLY, 0644)
 	if err != nil {
-		return fmt.Errorf("error appending chunk to the output file: %w", err)
+		return fmt.Errorf("error opening output file %s: %w", d.outputFile, err)
 	}
 	defer output.Close()
 
 	outputStats, err := output.Stat()
 	if err != nil {
-		return fmt.Errorf("error getting output file stats: %w", err)
+		return fmt.Errorf("error getting output file stats %s: %w", d.outputFile, err)
 	}
 
 	outputSize := outputStats.Size()
 
 	if outputSize < d.rangeStart {
-		return fmt.Errorf("output file does not have enough bytes for the chunk to be written into it, outputSize: %d rangeStart: %d", outputSize, d.rangeStart)
+		return fmt.Errorf("output file does not have enough bytes for the chunk to be written into it: chunkFile: %s, outputSize: %d rangeStart: %d", d.chunkFile, outputSize, d.rangeStart)
 	}
 
 	// the chunk must have been already appended to the output - nothing to do here
@@ -156,7 +151,7 @@ func (d *downloader) appendChunkToTheOutput() error {
 
 	_, err = chunk.Seek(offset, 0)
 	if err != nil {
-		return fmt.Errorf("error setting chunk offset: %w", err)
+		return fmt.Errorf("error setting chunk file offset %s: %w", d.chunkFile, err)
 	}
 
 	buf := make([]byte, readBufferSize)
@@ -172,9 +167,9 @@ func (d *downloader) appendChunkToTheOutput() error {
 
 			if nw < 0 || nr != nw {
 				if writeErr != nil {
-					return fmt.Errorf("failed to write to the output file from the chunk: %w", writeErr)
+					return fmt.Errorf("failed to write to the output file from the chunk %s: %w", d.chunkFile, writeErr)
 				}
-				return fmt.Errorf("read-write mismatch writing to the output file from the chunk, read=%d, written=%d", nr, nw)
+				return fmt.Errorf("read-write mismatch writing to the output file from the chunk %s: read=%d, written=%d", d.chunkFile, nr, nw)
 			}
 		}
 		if readErr == io.EOF {
@@ -189,18 +184,18 @@ func (d *downloader) appendChunkToTheOutput() error {
 func (d *downloader) verify() error {
 	chunk, err := os.OpenFile(d.chunkFile, os.O_RDONLY, 0644)
 	if err != nil {
-		return fmt.Errorf("error opening chunk file: %w", err)
+		return fmt.Errorf("error opening chunk file %s: %w", d.chunkFile, err)
 	}
 	defer chunk.Close()
 
 	chunkStats, err := chunk.Stat()
 	if err != nil {
-		return fmt.Errorf("error getting chunk file stats: %w", err)
+		return fmt.Errorf("error getting chunk file stats %s: %w", d.chunkFile, err)
 	}
 
 	expSize := d.rangeEnd - d.rangeStart
 	if expSize != chunkStats.Size() {
-		return fmt.Errorf("incomlete chunk, expected: %d actual: %d", expSize, chunkStats.Size())
+		return fmt.Errorf("incomplete chunk file %s: expected: %d actual: %d", d.chunkFile, expSize, chunkStats.Size())
 	}
 
 	return nil

--- a/transport/httptransport/http_downloader.go
+++ b/transport/httptransport/http_downloader.go
@@ -1,0 +1,207 @@
+package httptransport
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"sync/atomic"
+
+	"github.com/filecoin-project/boost/transport/types"
+)
+
+type downloader struct {
+	ctx        context.Context
+	transfer   *transfer
+	outputFile string
+	chunkFile  string
+	rangeStart int64
+	rangeEnd   int64
+	chunkNo    int
+}
+
+func (d *downloader) doHttp() error {
+	// construct request
+	req, err := http.NewRequest("GET", d.transfer.tInfo.URL, nil)
+	if err != nil {
+		return &httpError{error: fmt.Errorf("failed to create http req: %w", err)}
+	}
+
+	// add request headers
+	for name, val := range d.transfer.tInfo.Headers {
+		req.Header.Set(name, val)
+	}
+
+	// calculate range boundaries taking into account bytes that have been already downloaded
+	fi, err := os.Stat(d.chunkFile)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return &httpError{error: fmt.Errorf("failed to read file size: %w", err)}
+	}
+	var offset int64
+	if fi != nil {
+		offset = fi.Size()
+	}
+
+	rangeStart := d.rangeStart + offset
+
+	// the file might have been already fully downloaded, nothing to do here
+	if rangeStart >= d.rangeEnd {
+		return nil
+	}
+
+	toRead := d.rangeEnd - rangeStart
+
+	// add range req to start reading from the last byte we have in the output file
+	req.Header.Set("Range", fmt.Sprintf("bytes=%d-%d", rangeStart, d.rangeEnd))
+	// init the request with the transfer context
+	req = req.WithContext(d.ctx)
+
+	duid := d.transfer.dealInfo.DealUuid
+	d.transfer.dl.Infow(duid, "sending http request", "toRead", toRead, "range-rq", req.Header.Get("Range"))
+
+	// send http request and validate response
+	resp, err := d.transfer.client.Do(req)
+	if err != nil {
+		return &httpError{error: fmt.Errorf("failed to send  http req: %w", err)}
+	}
+	// we should either get back a 200 or a 206 -> anything else means something has gone wrong and we return an error.
+	defer resp.Body.Close() // nolint
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusPartialContent {
+		return &httpError{
+			error: fmt.Errorf("http req failed: code: %d, status: %s", resp.StatusCode, resp.Status),
+			code:  resp.StatusCode,
+		}
+	}
+
+	// create chunk file if it doesn't exist
+	of, err := os.OpenFile(d.chunkFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return &httpError{error: fmt.Errorf("failed to open chunk file for write: %w", err)}
+	}
+	defer of.Close()
+
+	//  start reading the response stream `readBufferSize` at a time using a limit reader so we only read as many bytes as we need to.
+	buf := make([]byte, readBufferSize)
+	limitR := io.LimitReader(resp.Body, toRead)
+	var chunkBytesReceived int64
+	for {
+		if d.ctx.Err() != nil {
+			d.transfer.dl.LogError(duid, "stopped reading http response: context canceled", d.ctx.Err())
+			return &httpError{error: d.ctx.Err()}
+		}
+		nr, readErr := limitR.Read(buf)
+
+		// if we read more than zero bytes, write whatever read.
+		if nr > 0 {
+			nw, writeErr := of.Write(buf[0:nr])
+
+			// if the number of read and written bytes don't match -> something has gone wrong, abort the http req.
+			if nw < 0 || nr != nw {
+				if writeErr != nil {
+					return &httpError{error: fmt.Errorf("failed to the chunk file: %w", writeErr)}
+				}
+				return &httpError{error: fmt.Errorf("read-write mismatch writing to the chunk file, read=%d, written=%d", nr, nw)}
+			}
+			chunkBytesReceived += int64(nw)
+			totalBytesReceived := atomic.AddInt64(&d.transfer.nBytesReceived, int64(nw))
+
+			// emit event updating the number of bytes received
+			d.transfer.emitEvent(types.TransportEvent{NBytesReceived: totalBytesReceived})
+		}
+		// the http stream we're reading from has sent us an EOF, nothing to do here.
+		if readErr == io.EOF {
+			d.transfer.dl.Infow(duid, "http server sent EOF", "toRead", toRead, "received", chunkBytesReceived, "deal-size", d.transfer.dealInfo.DealSize)
+			return nil
+		}
+		if readErr != nil {
+			return &httpError{error: fmt.Errorf("error reading from http response stream: %w", readErr)}
+		}
+	}
+}
+
+func (d *downloader) appendChunkToTheOutput() error {
+	chunk, err := os.OpenFile(d.chunkFile, os.O_RDONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("error opening chunk file: %w", err)
+	}
+	defer chunk.Close()
+
+	output, err := os.OpenFile(d.outputFile, os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("error appending chunk to the output file: %w", err)
+	}
+	defer output.Close()
+
+	outputStats, err := output.Stat()
+	if err != nil {
+		return fmt.Errorf("error getting output file stats: %w", err)
+	}
+
+	outputSize := outputStats.Size()
+
+	if outputSize < d.rangeStart {
+		return fmt.Errorf("output file does not have enough bytes for the chunk to be written into it, outputSize: %d rangeStart: %d", outputSize, d.rangeStart)
+	}
+
+	// the chunk must have been already appended to the output - nothing to do here
+	if outputSize >= d.rangeEnd {
+		return nil
+	}
+
+	// move the write cursor in the case if appending chunk has failed half way through
+	offset := outputSize - d.rangeStart
+
+	_, err = chunk.Seek(offset, 0)
+	if err != nil {
+		return fmt.Errorf("error setting chunk offset: %w", err)
+	}
+
+	buf := make([]byte, readBufferSize)
+	reader := io.Reader(chunk)
+	for {
+		if d.ctx.Err() != nil {
+			return d.ctx.Err()
+		}
+		nr, readErr := reader.Read(buf)
+
+		if nr > 0 {
+			nw, writeErr := output.Write(buf[0:nr])
+
+			if nw < 0 || nr != nw {
+				if writeErr != nil {
+					return fmt.Errorf("failed to write to the output file from the chunk: %w", writeErr)
+				}
+				return fmt.Errorf("read-write mismatch writing to the output file from the chunk, read=%d, written=%d", nr, nw)
+			}
+		}
+		if readErr == io.EOF {
+			return nil
+		}
+		if readErr != nil {
+			return readErr
+		}
+	}
+}
+
+func (d *downloader) verify() error {
+	chunk, err := os.OpenFile(d.chunkFile, os.O_RDONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("error opening chunk file: %w", err)
+	}
+	defer chunk.Close()
+
+	chunkStats, err := chunk.Stat()
+	if err != nil {
+		return fmt.Errorf("error getting chunk file stats: %w", err)
+	}
+
+	expSize := d.rangeEnd - d.rangeStart
+	if expSize != chunkStats.Size() {
+		return fmt.Errorf("incomlete chunk, expected: %d actual: %d", expSize, chunkStats.Size())
+	}
+
+	return nil
+}

--- a/transport/httptransport/http_transport.go
+++ b/transport/httptransport/http_transport.go
@@ -126,8 +126,7 @@ func (h *httpTransport) Execute(ctx context.Context, transportInfo []byte, dealI
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse request url: %w", err)
 	}
-	ip := net.ParseIP(pu.Hostname())
-	if ip != nil && ip.IsPrivate() {
+	if ip := net.ParseIP(pu.Hostname()); ip != nil && ip.IsPrivate() {
 		return nil, fmt.Errorf("downloading from private ip addresses is not allowed")
 	}
 

--- a/transport/httptransport/http_transport.go
+++ b/transport/httptransport/http_transport.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"sync"
@@ -19,6 +18,7 @@ import (
 	"github.com/jpillora/backoff"
 	p2phttp "github.com/libp2p/go-libp2p-http"
 	"github.com/libp2p/go-libp2p/core/host"
+	"golang.org/x/sync/errgroup"
 )
 
 const (
@@ -30,6 +30,8 @@ const (
 	maxBackOff           = 10 * time.Minute
 	factor               = 1.5
 	maxReconnectAttempts = 15
+
+	nChunks = 5
 )
 
 type httpError struct {
@@ -50,6 +52,12 @@ func BackOffRetryOpt(minBackoff, maxBackoff time.Duration, factor, maxReconnectA
 	}
 }
 
+func NChunksOpt(nChunks int) Option {
+	return func(h *httpTransport) {
+		h.nChunks = nChunks
+	}
+}
+
 type httpTransport struct {
 	libp2pHost   host.Host
 	libp2pClient *http.Client
@@ -58,6 +66,8 @@ type httpTransport struct {
 	maxBackoffWait       time.Duration
 	backOffFactor        float64
 	maxReconnectAttempts float64
+
+	nChunks int
 
 	dl *logs.DealLogger
 }
@@ -69,6 +79,7 @@ func New(host host.Host, dealLogger *logs.DealLogger, opts ...Option) *httpTrans
 		maxBackoffWait:       maxBackOff,
 		backOffFactor:        factor,
 		maxReconnectAttempts: maxReconnectAttempts,
+		nChunks:              nChunks,
 		dl:                   dealLogger.Subsystem("http-transport"),
 	}
 	for _, o := range opts {
@@ -120,6 +131,12 @@ func (h *httpTransport) Execute(ctx context.Context, transportInfo []byte, dealI
 	}
 	h.dl.Infow(duuid, "existing file size", "file size", fileSize, "deal size", dealInfo.DealSize)
 
+	// default to a single stream for libp2p urls as libp2p server doesn't support range requests
+	nChunks := h.nChunks
+	if u.Scheme == "libp2p" {
+		nChunks = 1
+	}
+
 	// construct the transfer instance that will act as the transfer handler
 	tctx, cancel := context.WithCancel(ctx)
 	t := &transfer{
@@ -136,6 +153,7 @@ func (h *httpTransport) Execute(ctx context.Context, transportInfo []byte, dealI
 		},
 		maxReconnectAttempts: h.maxReconnectAttempts,
 		dl:                   h.dl,
+		nChunks:              nChunks,
 	}
 
 	cleanupFns := []func(){
@@ -216,52 +234,113 @@ type transfer struct {
 
 	client *http.Client
 	dl     *logs.DealLogger
+
+	nChunks int
 }
 
 func (t *transfer) execute(ctx context.Context) error {
 	duuid := t.dealInfo.DealUuid
+
+	// create downloaders. Each downloader must be initialised with the same byte range across restarts in order to resume previous downloads.
+	// if the output file contains some data in it already, do not create a downloader for it again
+	outputStats, err := os.Stat(t.dealInfo.OutputFile)
+	if err != nil {
+		return &httpError{error: fmt.Errorf("failed to get stats of the output file: %w", err)}
+	}
+
+	chunkSize := t.dealInfo.DealSize / int64(t.nChunks)
+	lastAppendedChunk := int(outputStats.Size() / chunkSize)
+
+	downloaders := make([]*downloader, 0, t.nChunks-lastAppendedChunk)
+
+	for i := lastAppendedChunk; i < t.nChunks; i++ {
+		rangeStart := int64(i) * chunkSize
+		var rangeEnd int64
+		if i == t.nChunks-1 {
+			rangeEnd = t.dealInfo.DealSize
+		} else {
+			rangeEnd = rangeStart + chunkSize
+		}
+		// write first chunk directly to the output file
+		var chunkFile string
+		if i == 0 {
+			chunkFile = t.dealInfo.OutputFile
+		} else {
+			chunkFile = t.dealInfo.OutputFile + "-" + fmt.Sprint(i)
+		}
+		d := downloader{
+			ctx:        ctx,
+			transfer:   t,
+			chunkFile:  chunkFile,
+			outputFile: t.dealInfo.OutputFile,
+			rangeStart: rangeStart,
+			rangeEnd:   rangeEnd,
+			chunkNo:    i,
+		}
+		downloaders = append(downloaders, &d)
+
+		// if some chunks have been partially downloaded - add their sizes to nBytesReceived.
+		// that doesn't need to be done for the very first chunk as it's already included into the number
+		if i == 0 {
+			continue
+		}
+		st, err := os.Stat(d.chunkFile)
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
+			return &httpError{error: fmt.Errorf("failed to get stats of the chunk file: %w", err)}
+		}
+		if st != nil {
+			t.nBytesReceived += st.Size()
+		}
+	}
+
 	for {
-		// construct request
-		req, err := http.NewRequest("GET", t.tInfo.URL, nil)
-		if err != nil {
-			return fmt.Errorf("failed to create http req: %w", err)
+
+		nBytesReceived := t.nBytesReceived
+
+		group := errgroup.Group{}
+
+		// download chunks into temporary files
+		for _, d := range downloaders {
+			group.Go(d.doHttp)
 		}
 
-		// get the number of bytes already received (the size of the output file)
-		st, err := os.Stat(t.dealInfo.OutputFile)
-		if err != nil {
-			return fmt.Errorf("failed to stat output file: %w", err)
-		}
-		t.nBytesReceived = st.Size()
-
-		// add request headers
-		for name, val := range t.tInfo.Headers {
-			req.Header.Set(name, val)
+		var reqErr *httpError
+		if err := group.Wait(); err != nil {
+			reqErr = err.(*httpError)
 		}
 
-		// add range req to start reading from the last byte we have in the output file
-		req.Header.Set("Range", fmt.Sprintf("bytes=%d-", t.nBytesReceived))
-		// init the request with the transfer context
-		req = req.WithContext(ctx)
-		// open output file in append-only mode for writing
-		of, err := os.OpenFile(t.dealInfo.OutputFile, os.O_APPEND|os.O_WRONLY, 0644)
-		if err != nil {
-			return fmt.Errorf("failed to open output file: %w", err)
-		}
-		defer of.Close()
-
-		// start the http transfer
-		remaining := t.dealInfo.DealSize - t.nBytesReceived
-		reqErr := t.doHttp(ctx, req, of, remaining)
 		if reqErr == nil {
-			t.dl.Infow(duuid, "http transfer completed successfully")
+			// append chunks one by one to the output file
+			// * minimize space overhead by removing the chunk file once it has been appended ot the output successfully
+			// * keep in mind restarts, resume writing from the correct chunk / offset
+			t.dl.Infow(duuid, "http transfer completed successfully, joining chunks")
+
+			for i := 0; i < len(downloaders); i++ {
+				d := downloaders[i]
+
+				if err := d.verify(); err != nil {
+					return &httpError{error: err}
+				}
+
+				// this is the first chunk, no more job to do as it has already been written to the output file
+				if d.chunkNo == 0 {
+					continue
+				}
+
+				err := d.appendChunkToTheOutput()
+				if err != nil {
+					return &httpError{error: fmt.Errorf("failed to append chunk to the output: %w", err)}
+				}
+				err = os.Remove(d.chunkFile)
+				if err != nil {
+					return &httpError{error: fmt.Errorf("failed to remove the chunk file: %w", err)}
+				}
+			}
 			// if there's no error, transfer was successful
 			break
 		}
 
 		t.dl.Infow(duuid, "http request error", "http code", reqErr.code, "outputErr", reqErr.Error())
-
-		_ = of.Close()
 
 		// check if the error is a 4xx error, meaning there is a problem with
 		// the request (eg 401 Unauthorized)
@@ -272,16 +351,16 @@ func (t *transfer) execute(ctx context.Context) error {
 		}
 
 		// do not resume transfer if context has been cancelled or if the context deadline has exceeded
-		err = reqErr.error
+		err := reqErr.error
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			t.dl.LogError(duuid, "terminating http transfer: context cancelled or deadline exceeded", err)
 			return fmt.Errorf("transfer context canceled err: %w", err)
 		}
 
 		// If some data was transferred, reset the back-off count to zero
-		if t.nBytesReceived > st.Size() {
+		if t.nBytesReceived > nBytesReceived {
 			t.dl.Infow(duuid, "some data was transferred before connection error, so resetting backoff to zero",
-				"transferred", t.nBytesReceived-st.Size())
+				"transferred", t.nBytesReceived-nBytesReceived)
 			t.backoff.Reset()
 		}
 
@@ -324,63 +403,6 @@ func (t *transfer) execute(ctx context.Context) error {
 		"file size", st.Size())
 
 	return nil
-}
-
-func (t *transfer) doHttp(ctx context.Context, req *http.Request, dst io.Writer, toRead int64) *httpError {
-	duid := t.dealInfo.DealUuid
-	t.dl.Infow(duid, "sending http request", "received", t.nBytesReceived, "remaining",
-		toRead, "range-rq", req.Header.Get("Range"))
-
-	// send http request and validate response
-	resp, err := t.client.Do(req)
-	if err != nil {
-		return &httpError{error: fmt.Errorf("failed to send  http req: %w", err)}
-	}
-	// we should either get back a 200 or a 206 -> anything else means something has gone wrong and we return an error.
-	defer resp.Body.Close() // nolint
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusPartialContent {
-		return &httpError{
-			error: fmt.Errorf("http req failed: code: %d, status: %s", resp.StatusCode, resp.Status),
-			code:  resp.StatusCode,
-		}
-	}
-
-	//  start reading the response stream `readBufferSize` at a time using a limit reader so we only read as many bytes as we need to.
-	buf := make([]byte, readBufferSize)
-	limitR := io.LimitReader(resp.Body, toRead)
-	for {
-		if ctx.Err() != nil {
-			t.dl.LogError(duid, "stopped reading http response: context canceled", ctx.Err())
-			return &httpError{error: ctx.Err()}
-		}
-		nr, readErr := limitR.Read(buf)
-
-		// if we read more than zero bytes, write whatever read.
-		if nr > 0 {
-			nw, writeErr := dst.Write(buf[0:nr])
-
-			// if the number of read and written bytes don't match -> something has gone wrong, abort the http req.
-			if nw < 0 || nr != nw {
-				if writeErr != nil {
-					return &httpError{error: fmt.Errorf("failed to write to output file: %w", writeErr)}
-				}
-				return &httpError{error: fmt.Errorf("read-write mismatch writing to the output file, read=%d, written=%d", nr, nw)}
-			}
-
-			t.nBytesReceived = t.nBytesReceived + int64(nw)
-
-			// emit event updating the number of bytes received
-			t.emitEvent(types.TransportEvent{NBytesReceived: t.nBytesReceived})
-		}
-		// the http stream we're reading from has sent us an EOF, nothing to do here.
-		if readErr == io.EOF {
-			t.dl.Infow(duid, "http server sent EOF", "received", t.nBytesReceived, "deal-size", t.dealInfo.DealSize)
-			return nil
-		}
-		if readErr != nil {
-			return &httpError{error: fmt.Errorf("error reading from http response stream: %w", readErr)}
-		}
-	}
 }
 
 // Close shuts down the transfer for the given deal. It is the caller's responsibility to call Close after it no longer needs the transfer.

--- a/transport/httptransport/http_transport_test.go
+++ b/transport/httptransport/http_transport_test.go
@@ -316,6 +316,69 @@ func TestConcurrentTransfers(t *testing.T) {
 	}
 }
 
+func TestDontAllowDownloadingFromPrivateAddresses(t *testing.T) {
+	ctx := context.Background()
+	of := getTempFilePath(t)
+	// deal info is irrelevant in this test
+	dealInfo := &types.TransportDealInfo{
+		OutputFile: of,
+		DealSize:   1000,
+	}
+	ht := New(nil, newDealLogger(t, ctx), NChunksOpt(nChunks))
+	bz, err := json.Marshal(types.HttpRequest{URL: "http://192.168.0.1/blah"})
+	require.NoError(t, err)
+
+	_, err = ht.Execute(ctx, bz, dealInfo)
+	require.Error(t, err, "downloading from private addresses is not allowed")
+}
+
+func TestDontFollowHttpRedirects(t *testing.T) {
+	// we should not follow http redirects for security reasons. If the target URL tries to redirect, the client should return 303 response instead.
+	// This test sets up two servers, with one redirecting to the other. Without the redirect check the download would have been completed successfully.
+	rawSize := (100 * readBufferSize) + 30
+	ctx := context.Background()
+	st := newServerTest(t, rawSize)
+	carSize := len(st.carBytes)
+
+	var handler http.HandlerFunc = func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			offset := r.Header.Get("Range")
+
+			startend := strings.Split(strings.TrimPrefix(offset, "bytes="), "-")
+			start, _ := strconv.ParseInt(startend[0], 10, 64)
+			end, _ := strconv.ParseInt(startend[1], 10, 64)
+
+			w.WriteHeader(200)
+			if end == 0 {
+				w.Write(st.carBytes[start:]) //nolint:errcheck
+			} else {
+				w.Write(st.carBytes[start:end]) //nolint:errcheck
+			}
+		case http.MethodHead:
+			addContentLengthHeader(w, len(st.carBytes))
+		}
+	}
+	svr := httptest.NewServer(handler)
+	defer svr.Close()
+
+	var redirectHandler http.HandlerFunc = func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, svr.URL, http.StatusSeeOther)
+	}
+	redirectSvr := httptest.NewServer(redirectHandler)
+	defer redirectSvr.Close()
+
+	of := getTempFilePath(t)
+	th := executeTransfer(t, ctx, New(nil, newDealLogger(t, ctx), NChunksOpt(nChunks)), carSize, types.HttpRequest{URL: redirectSvr.URL}, of)
+	require.NotNil(t, th)
+
+	evts := waitForTransferComplete(th)
+	require.NotEmpty(t, evts)
+	require.Equal(t, 1, len(evts))
+	require.EqualValues(t, 0, evts[0].NBytesReceived)
+	require.Contains(t, evts[0].Error.Error(), "303 See Other")
+}
+
 func TestCompletionOnMultipleAttemptsWithSameFile(t *testing.T) {
 	ctx := context.Background()
 	of := getTempFilePath(t)

--- a/transport/httptransport/http_transport_test.go
+++ b/transport/httptransport/http_transport_test.go
@@ -145,7 +145,6 @@ func httpParallelTransferTest(t *testing.T, rawSize int, nChunks, expectedChunks
 		case http.MethodHead:
 			addContentLengthHeader(w, len(st.carBytes))
 		}
-
 	}
 
 	svr := httptest.NewServer(handler)
@@ -194,7 +193,6 @@ func TestDealSizeIsZero(t *testing.T) {
 		case http.MethodHead:
 			addContentLengthHeader(w, len(st.carBytes))
 		}
-
 	}
 
 	svr := httptest.NewServer(handler)
@@ -222,7 +220,6 @@ func TestFailIfDealSizesDontMatch(t *testing.T) {
 		case http.MethodHead:
 			addContentLengthHeader(w, carSize)
 		}
-
 	}
 
 	svr := httptest.NewServer(handler)
@@ -599,7 +596,6 @@ func serversWithRangeHandler(st *serverTest) map[string]func(t *testing.T) (req 
 		case http.MethodHead:
 			addContentLengthHeader(w, len(st.carBytes))
 		}
-
 	}
 
 	svcs := serversWithCustomHandler(handler)


### PR DESCRIPTION
* Add a feature to split http download into multiple chunks. Chunks are downloaded into temporary files, which then get merged into one;
* Downnloads over libp2p are always done in one chunk only;
* Add NChunks configuration parameter;
* Fix tests to handle not just open-ended range requests;
* Don't allow private ip addresses and redirects.

Fixes https://github.com/filecoin-project/boost/issues/1593