### PR TITLE
fix: docker devnet entrypoint

### DIFF
--- a/docker/devnet/boost/entrypoint.sh
+++ b/docker/devnet/boost/entrypoint.sh
@@ -39,8 +39,8 @@ if [ ! -f $BOOST_PATH/.init.boost ]; then
 	# echo exit code: $?
 
 	echo Setting port in boost config...
-	sed 's|ip4/0.0.0.0/tcp/0|ip4/0.0.0.0/tcp/50000|g' $BOOST_PATH/config.toml > $BOOST_PATH/config.toml.tmp; cp $BOOST_PATH/config.toml.tmp $BOOST_PATH/config.toml; rm $BOOST_PATH/config.toml.tmp
-	sed 's|127.0.0.1|0.0.0.0|g' $BOOST_PATH/config.toml > $BOOST_PATH/config.toml.tmp; cp $BOOST_PATH/config.toml.tmp $BOOST_PATH/config.toml; rm $BOOST_PATH/config.toml.tmp
+	sed 's|#ListenAddresses = \["/ip4/0.0.0.0/tcp/0", "/ip6/::/tcp/0"\]|ListenAddresses = \["/ip4/0.0.0.0/tcp/50000", "/ip6/::/tcp/0"\]|g' $BOOST_PATH/config.toml > $BOOST_PATH/config.toml.tmp; cp $BOOST_PATH/config.toml.tmp $BOOST_PATH/config.toml; rm $BOOST_PATH/config.toml.tmp
+	sed 's|#ListenAddress = "127.0.0.1"|ListenAddress = "0.0.0.0"|g' $BOOST_PATH/config.toml > $BOOST_PATH/config.toml.tmp; cp $BOOST_PATH/config.toml.tmp $BOOST_PATH/config.toml; rm $BOOST_PATH/config.toml.tmp
 
 	echo Done
 	touch $BOOST_PATH/.init.boost


### PR DESCRIPTION
Update the `entrypoint.sh` script to ensure Graphql and libp2p listen address are set correctly

- [x] Test in devnet

```
root@a0bd633a88f7:/app# cat /var/lib/boost/config.toml | grep Listen
  ListenAddress = "/dns/boost/tcp/1288/http"
  #RemoteListenAddress = ""
  ListenAddresses = ["/ip4/0.0.0.0/tcp/50000", "/ip6/::/tcp/0"]
  ListenAddress = "0.0.0.0"
```