### PR TITLE
fix: GS query panic

### DIFF
--- a/retrievalmarket/server/validation.go
+++ b/retrievalmarket/server/validation.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"github.com/filecoin-project/boost-gfm/retrievalmarket"
 	"github.com/filecoin-project/boost-gfm/retrievalmarket/migrations"
 	datatransfer "github.com/filecoin-project/go-data-transfer"
@@ -171,7 +172,7 @@ func (rv *requestValidator) getPiece(payloadCid cid.Cid, pieceCID *cid.Cid) (Pie
 	if piecesErr != nil {
 		return PieceInfo{}, false, piecesErr
 	}
-	return PieceInfo{}, false, fmt.Errorf("unknown pieceCID %s", pieceCID.String())
+	return PieceInfo{}, false, fmt.Errorf("piece cid not found for payload cid %s", payloadCid.String())
 }
 
 func (rv *requestValidator) Subscribe(subscriber retrievalmarket.ProviderValidationSubscriber) retrievalmarket.Unsubscribe {


### PR DESCRIPTION
Fixes a panic caused by nil pieceCID in Graphsync query validation.

```
2023-09-23T12:12:00.968Z        INFO    modules modules/storageminer_idxprov.go:149     Started index provider engine
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x2b6ed78]
goroutine 310 [running]:
[github.com/filecoin-project/boost/retrievalmarket/server.(*requestValidator).getPiece(0xc001d0b270](http://github.com/filecoin-project/boost/retrievalmarket/server.(*requestValidator).getPiece(0xc001d0b270), {{0xc01a45fce0?, 0xc0227e4b00?}}, 0x0)
        /home/andr/boost/retrievalmarket/server/validation.go:174 +0x218
[github.com/filecoin-project/boost/retrievalmarket/server.(*requestValidator).acceptDeal(0xc001d0b270](http://github.com/filecoin-project/boost/retrievalmarket/server.(*requestValidator).acceptDeal(0xc001d0b270), {0xc013c45a70, 0x26}, 0xc028f32050, 0x0, {{0xc01a45fa40?, 0x30?}}, {0x6b2bbe0, 0xc0227e4b00})
        /home/andr/boost/retrievalmarket/server/validation.go:112 +0x271
[github.com/filecoin-project/boost/retrievalmarket/server.(*requestValidator).validatePull(0xc02b4fee70](http://github.com/filecoin-project/boost/retrievalmarket/server.(*requestValidator).validatePull(0xc02b4fee70)?, {0xc013c45a70?, 0x6af0c80?}, 0xc016768690?, 0x90?, {{0xc01a45fa40?, 0x9?}}, {0x6b2bbe0?, 0xc0227e4b00?})
        /home/andr/boost/retrievalmarket/server/validation.go:81 +0x90
[github.com/filecoin-project/boost/retrievalmarket/server.(*requestValidator).validatePullRequest(0xc001d0b270](http://github.com/filecoin-project/boost/retrievalmarket/server.(*requestValidator).validatePullRequest(0xc001d0b270), 0x0, {0xc013c45a70, 0x26}, {0x6aea100?, 0xc028f32050?}, {{0xc01a45fa40?, 0xc01ff89f68?}}, {0x6b2bbe0, 0xc0227e4b00})
        /home/andr/boost/retrievalmarket/server/validation.go:52 +0x306
[github.com/filecoin-project/boost/retrievalmarket/server.(*GraphsyncUnpaidRetrieval).RegisterIncomingRequestHook.func1.1(0xc011330000](http://github.com/filecoin-project/boost/retrievalmarket/server.(*GraphsyncUnpaidRetrieval).RegisterIncomingRequestHook.func1.1(0xc011330000), {0x6b2c8a8, 0xc015cb53b0}, {0x6b131c8, 0xc020bca240}, {0xc013c45a70, 0x26}, {0x6b159b8, 0xc000e15ef0})
        /home/andr/boost/retrievalmarket/server/gsunpaidretrieval.go:395 +0x1e5
```