### PR TITLE
fix: Rename deal data root cid in Boost UI

### DIFF
--- a/react/src/DealDetail.js
+++ b/react/src/DealDetail.js
@@ -147,8 +147,8 @@ export function DealDetail(props) {
                     <td>{deal.SignedProposalCid}</td>
                 </tr>
                 <tr>
-                    <th>Deal Data Root CID</th>
-                    <td><Link to={'/piece-doctor/'+deal.DealDataRoot}>{deal.DealDataRoot}</Link></td>
+                    <th>Label</th>
+                    <td>{deal.DealDataRoot}</td>
                 </tr>
                 <tr>
                     <th>Verified</th>


### PR DESCRIPTION
Fixes
https://github.com/filecoin-project/boost/issues/1715 and remove the link from Label field

<img width="1613" alt="Screenshot 2023-09-26 at 5 43 50 PM" src="https://github.com/filecoin-project/boost/assets/88259624/7ad8a9fa-3319-49d2-8df6-4fbcceda1291">
