### PR TITLE
feat: show payload CIDs in UI

### DIFF
--- a/docker/devnet/boost/entrypoint.sh
+++ b/docker/devnet/boost/entrypoint.sh
@@ -52,7 +52,7 @@ sed 's|#ServiceApiInfo = ""|ServiceApiInfo = "ws://localhost:8042"|g' $BOOST_PAT
 sed 's|#ExpectedSealDuration = "24h0m0s"|ExpectedSealDuration = "0h0m10s"|g' $BOOST_PATH/config.toml > $BOOST_PATH/config.toml.tmp; cp $BOOST_PATH/config.toml.tmp $BOOST_PATH/config.toml; rm $BOOST_PATH/config.toml.tmp
 
 ## run boostd-data
-boostd-data run leveldb --addr=0.0.0.0:8042 &
+boostd-data run leveldb --repo $BOOST_PATH --addr=0.0.0.0:8042 &
 
 # TODO(anteva): fixme: hack as boostd fails to start without this dir
 mkdir -p /var/lib/boost/deal-staging

--- a/docker/devnet/docker-compose.yaml
+++ b/docker/devnet/docker-compose.yaml
@@ -91,9 +91,6 @@ services:
       - ./data/boost:/var/lib/boost:ro
       - ./data/lotus:/var/lib/lotus:ro
       - ./data/lotus-miner:/var/lib/lotus-miner:ro
-    labels:
-      - "com.docker-tc.enabled=1"
-      - "com.docker-tc.delay=10ms"
 
   booster-bitswap:
     container_name: booster-bitswap
@@ -114,9 +111,6 @@ services:
       - ./data/boost:/var/lib/boost:ro
       - ./data/lotus:/var/lib/lotus:ro
       - ./data/lotus-miner:/var/lib/lotus-miner:ro
-    labels:
-      - "com.docker-tc.enabled=1"
-      - "com.docker-tc.delay=10ms"
 
   demo-http-server:
     container_name: demo-http-server
@@ -126,25 +120,4 @@ services:
     logging: *default-logging
     volumes:
       - ./data/sample:/usr/share/nginx/html:ro
-    labels:
-      - "com.docker-tc.enabled=1"
-      - "com.docker-tc.limit=1mbps"
-      - "com.docker-tc.delay=100ms"
 
-  tc:
-    image: "${DOCKER_IMAGE_TERMINAL:-lukaszlach/docker-tc}"
-    init: true
-    container_name: docker-tc
-    cap_add:
-      - NET_ADMIN
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-      - /var/docker-tc:/var/docker-tc
-    deploy:
-      mode: global
-      restart_policy:
-        condition: any
-    environment:
-      HTTP_BIND: "${HTTP_BIND:-127.0.0.1}"
-      HTTP_PORT: "${HTTP_PORT:-4080}"
-    network_mode: host

--- a/gql/schema.graphql
+++ b/gql/schema.graphql
@@ -485,6 +485,11 @@ input DealFilter {
   IsVerified: Boolean
 }
 
+type PiecePayload {
+  PayloadCid: String!
+  Multihash: String!
+}
+
 type RootQuery {
   """Get height of chain"""
   epoch: EpochInfo!
@@ -593,6 +598,9 @@ type RootQuery {
 
   """Get storage ask (price of doing a storage deal)"""
   storageAsk: StorageAsk!
+
+  """Get the payload CIDs and corresponding multihashes for a particular piece CID"""
+  piecePayloadCids(pieceCid: String!): [PiecePayload]!
 }
 
 type RootMutation {

--- a/react/src/App.js
+++ b/react/src/App.js
@@ -18,7 +18,14 @@ import {LegacyDealDetail} from "./LegacyDealDetail"
 import {SettingsPage} from "./Settings";
 import {Banner} from "./Banner";
 import {ProposalLogsPage} from "./ProposalLogs";
-import {PieceDoctorPage, InspectPiecePage, LIDPage, NoUnsealedSectorPieces, NoUnsealedSectorPage} from "./LID";
+import {
+    PieceDoctorPage,
+    InspectPiecePage,
+    LIDPage,
+    NoUnsealedSectorPieces,
+    NoUnsealedSectorPage,
+    PiecePayloadCids,
+} from "./LID";
 import {RetrievalLogsPage} from "./RetrievalLogs";
 import {RetrievalLogDetail} from "./RetrievalLogDetail";
 import {MonitoringAlert} from "./MonitoringAlert";
@@ -68,6 +75,7 @@ function App(props) {
                                         <Route path="/piece-doctor/from/:cursor/page/:pageNum" element={<PieceDoctorPage />} />
                                         <Route path="/piece-doctor/:query" element={<PieceDoctorPage />} />
                                         <Route path="/piece-doctor/piece/:pieceCID" element={<InspectPiecePage />} />
+                                        <Route path="/piece-doctor/piece-payload/:pieceCID" element={<PiecePayloadCids />} />
                                         <Route path="/no-unsealed" element={<NoUnsealedSectorPage />} />
                                         <Route path="/no-unsealed/from/:cursor/page/:pageNum" element={<NoUnsealedSectorPage />} />
                                         <Route path="/" element={<StorageDealsPage />} />

--- a/react/src/Ipni.js
+++ b/react/src/Ipni.js
@@ -483,7 +483,17 @@ export function IpniAdEntries() {
     })
 
     if (error) {
-        return <div>Error: {error.message}</div>
+        return <div className="ad-detail modal" id={params.adCid}>
+            <div className="content">
+                <div className="close" onClick={() => navigate(-1)}>
+                    <img className="icon" alt="" src={closeImg} />
+                </div>
+                <div className="title">
+                    <span>Advertisement {'…'+params.adCid.slice(-8)} Entries</span>
+                </div>
+                <div><span>Error: {error.message}</span></div>
+            </div>
+        </div>
     }
 
     if (loading) {

--- a/react/src/LID.css
+++ b/react/src/LID.css
@@ -84,3 +84,41 @@
 .sectors-list-link a, .flagged-pieces-link a {
     margin-left: 1em;
 }
+
+.payload-icon {
+    background-image: url("./bootstrap-icons/icons/list.svg");
+    background-position: left;
+    background-repeat: no-repeat;
+    padding-left: 1.25em;
+    margin-left: 1em;
+}
+
+.payloads {
+    padding-top: 1em;
+    margin: auto;
+}
+
+.payloads .title {
+    margin:  1em auto;
+    text-align: center;
+    font-size: 1.25em;
+    color: #a61e4d;
+}
+
+.payloads table{
+    font-size: 1em;
+}
+
+.payloads td, .payloads th {
+    vertical-align: top;
+    text-align: left;
+    padding: 0.5em 1em;
+}
+
+.payloads .download {
+    background-image: url("./bootstrap-icons/icons/download.svg");
+    background-position: left;
+    background-repeat: no-repeat;
+    padding-left: 1.25em;
+    margin-left: 1em;
+}

--- a/react/src/LID.js
+++ b/react/src/LID.js
@@ -3,12 +3,12 @@ import {useMutation, useQuery} from "@apollo/react-hooks";
 import {
     LIDQuery,
     FlaggedPiecesQuery, PieceBuildIndexMutation,
-    PieceStatusQuery, PiecesWithPayloadCidQuery, FlaggedPiecesCountQuery
+    PieceStatusQuery, PiecesWithPayloadCidQuery, FlaggedPiecesCountQuery, PiecePayloadCidsQuery,
 } from "./gql";
 import moment from "moment";
 import {DebounceInput} from 'react-debounce-input';
-import React, {useState} from "react";
-import {PageContainer, ShortDealLink} from "./Components";
+import React, {useState, useEffect} from "react";
+import {PageContainer, ShortCID, ShortDealLink} from "./Components";
 import {Link, useNavigate, useParams} from "react-router-dom";
 import {dateFormat} from "./util-date";
 import xImg from './bootstrap-icons/icons/x-lg.svg'
@@ -19,6 +19,7 @@ import {Pagination} from "./Pagination";
 import {Info, InfoListItem} from "./Info";
 import {CumulativeBarChart, CumulativeBarLabels} from "./CumulativeBarChart";
 import {addCommas, humanFileSize} from "./util";
+import closeImg from "./bootstrap-icons/icons/x-circle.svg";
 
 const lidBasePath = '/piece-doctor'
 
@@ -624,9 +625,20 @@ function PieceStatus({pieceCid, pieceStatus, searchQuery}) {
                 <tr key="piece cid">
                     <th>Piece CID</th>
                     {searchIsPieceCid ? (
-                      <td><strong>{pieceCid}</strong></td>
+                      <td>
+                          <strong>{pieceCid}</strong>
+                          &nbsp;
+                          <a className="payload-icon" href={"/piece-doctor/piece-payload/"+searchQuery}>
+                              Payload CIDs
+                          </a>
+                      </td>
                     ) : (
-                      <td>{pieceCid}</td>
+                      <td>{pieceCid}
+                          &nbsp;
+                          <a className="payload-icon" href={"/piece-doctor/piece-payload/"+searchQuery}>
+                              Payload CIDs
+                          </a>
+                      </td>
                     )}
                 </tr>
                 <tr key="index status">
@@ -781,4 +793,86 @@ const RowsPerPage = {
 
 function scrollTop() {
     window.scrollTo({ top: 0, behavior: "smooth" })
+}
+
+export function PiecePayloadCids() {
+    const params = useParams()
+    const navigate = useNavigate()
+
+    // Add a class to the document body when showing the ad detail page
+    useEffect(() => {
+        document.body.classList.add('modal-open')
+
+        return function () {
+            document.body.classList.remove('modal-open')
+        }
+    })
+
+    const {loading, error, data} = useQuery(PiecePayloadCidsQuery, {
+        variables: {pieceCid: params.pieceCID},
+    })
+
+    if (error) {
+        return <div className="payloads modal" id={params.pieceCID}>
+            <div className="content">
+                <div className="close" onClick={() => navigate(-1)}>
+                    <img className="icon" alt="" src={closeImg} />
+                </div>
+                <div className="title">
+                    <span>Payloads CIDs for {params.pieceCID}</span>
+                </div>
+                <div><span>Error: {error.message}</span></div>
+            </div>
+        </div>
+    }
+
+    if (loading) {
+        return <div>Loading ...</div>
+    }
+
+    console.log(data)
+
+    var payload = data.piecePayloadCids
+    return <div className="payloads modal" id={params.pieceCID}>
+        <div className="content">
+            <div className="close" onClick={() => navigate(-1)}>
+                <img className="icon" alt="" src={closeImg} />
+            </div>
+            <div className="title">
+                <span>Payloads CIDs for {params.pieceCID}</span>
+            </div>
+            <div>
+                { payload.length === 0 ? (
+                    <span>Piece {params.pieceCID} either has no payload CIDs or is not indexed</span>
+                ) : (
+                    <table>
+                        <tbody>
+                        <tr>
+                            <th>Number</th>
+                            <th>Payload CID</th>
+                            <th>Multihash (Hexadecimal)</th>
+                            <th>Download Link</th>
+                        </tr>
+                        {payload.map((payload, i) => {
+                            return <tr key={payload.PayloadCid}>
+                                <td>{i+1}.</td>
+                                <td>
+                                    {payload.PayloadCid}
+                                </td>
+                                <td>
+                                    {payload.Multihash}
+                                </td>
+                                <td>
+                                    <a className="download" target="_blank" href={"/download/block/"+payload.PayloadCid}>
+                                        Download block
+                                    </a>
+                                </td>
+                            </tr>
+                        })}
+                        </tbody>
+                    </table>
+                )}
+            </div>
+        </div>
+    </div>
 }

--- a/react/src/LID.js
+++ b/react/src/LID.js
@@ -628,14 +628,14 @@ function PieceStatus({pieceCid, pieceStatus, searchQuery}) {
                       <td>
                           <strong>{pieceCid}</strong>
                           &nbsp;
-                          <a className="payload-icon" href={"/piece-doctor/piece-payload/"+searchQuery}>
+                          <a className="payload-icon" href={"/piece-doctor/piece-payload/"+pieceCid}>
                               Payload CIDs
                           </a>
                       </td>
                     ) : (
                       <td>{pieceCid}
                           &nbsp;
-                          <a className="payload-icon" href={"/piece-doctor/piece-payload/"+searchQuery}>
+                          <a className="payload-icon" href={"/piece-doctor/piece-payload/"+pieceCid}>
                               Payload CIDs
                           </a>
                       </td>

--- a/react/src/LID.js
+++ b/react/src/LID.js
@@ -830,8 +830,6 @@ export function PiecePayloadCids() {
         return <div>Loading ...</div>
     }
 
-    console.log(data)
-
     var payload = data.piecePayloadCids
     return <div className="payloads modal" id={params.pieceCID}>
         <div className="content">

--- a/react/src/gql.js
+++ b/react/src/gql.js
@@ -783,6 +783,15 @@ const PublishPendingDealsMutation = gql`
     }
 `;
 
+const PiecePayloadCidsQuery = gql`
+    query AppPiecePayloadCidsQuery($pieceCid: String!) {
+        piecePayloadCids(pieceCid: $pieceCid) {
+            PayloadCid
+            Multihash
+        }
+    }
+`;
+
 export {
     gqlClient,
     EpochQuery,
@@ -829,4 +838,5 @@ export {
     Libp2pAddrInfoQuery,
     StorageAskQuery,
     PublishPendingDealsMutation,
+    PiecePayloadCidsQuery,
 }


### PR DESCRIPTION
Fixes https://github.com/filecoin-project/boost/issues/1717
This PR handles the following:
1. Create a new GQL resolver to get list of all payload CIDs for a piece CID
2. Display the above list in UI
3. Fixes the error return for payload CIDs and index entries
<img width="2539" alt="Screenshot 2023-09-27 at 7 04 31 PM" src="https://github.com/filecoin-project/boost/assets/88259624/aab5a6c0-d6e6-4f76-87b0-958abb7032be">
<img width="1211" alt="Screenshot 2023-09-27 at 7 25 52 PM" src="https://github.com/filecoin-project/boost/assets/88259624/ea38f316-1749-4fe5-ae68-6720df9e2e23">

4. Fixes a small bug in devnet script to allow LID to retain data across restarts
5. Removed RC container in docker devnet as the image used is not suitable for MacOS.

# **The new UI looks Like below:**
## When searched using payload CID
<img width="1211" alt="Screenshot 2023-09-27 at 7 18 25 PM" src="https://github.com/filecoin-project/boost/assets/88259624/0c2bade3-a723-4723-a065-07c254834667">

## When searched using piece CID
<img width="1211" alt="Screenshot 2023-09-27 at 7 18 09 PM" src="https://github.com/filecoin-project/boost/assets/88259624/582265fb-c89c-453f-9b17-cee14481839c">

## New section with payload CID list
<img width="2539" alt="Screenshot 2023-09-27 at 6 17 19 PM" src="https://github.com/filecoin-project/boost/assets/88259624/4d720d74-6686-4462-87d1-2eecc28a96df">

## Error is displayed within the modal
<img width="1211" alt="Screenshot 2023-09-27 at 7 25 16 PM" src="https://github.com/filecoin-project/boost/assets/88259624/d083ac95-0e64-4abc-b3a6-e562edcd3496">
