### PR TITLE
Ivan/http security fix

### DIFF
--- a/node/config/def.go
+++ b/node/config/def.go
@@ -214,7 +214,8 @@ func DefaultBoost() *Boost {
 			},
 		},
 		HttpDownload: HttpDownloadConfig{
-			NChunks: 5,
+			NChunks:         5,
+			AllowPrivateIPs: false,
 		},
 	}
 	return cfg

--- a/node/config/doc_gen.go
+++ b/node/config/doc_gen.go
@@ -489,6 +489,13 @@ configured in SectorIndexApiInfo.`,
 which improves the overall download speed. NChunks is always equal to 1 for libp2p transport because libp2p server
 doesn't support range requests yet. NChunks must be greater than 0 and less than 16, with the default of 5.`,
 		},
+		{
+			Name: "AllowPrivateIPs",
+			Type: "bool",
+
+			Comment: `AllowPrivateIPs defines whether boost should allow HTTP downloads from private IPs as per https://en.wikipedia.org/wiki/Private_network.
+The default is false.`,
+		},
 	},
 	"IndexProviderAnnounceConfig": []DocField{
 		{

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -428,4 +428,7 @@ type HttpDownloadConfig struct {
 	// which improves the overall download speed. NChunks is always equal to 1 for libp2p transport because libp2p server
 	// doesn't support range requests yet. NChunks must be greater than 0 and less than 16, with the default of 5.
 	NChunks int
+	// AllowPrivateIPs defines whether boost should allow HTTP downloads from private IPs as per https://en.wikipedia.org/wiki/Private_network.
+	// The default is false.
+	AllowPrivateIPs bool
 }

--- a/node/modules/storageminer.go
+++ b/node/modules/storageminer.go
@@ -622,7 +622,7 @@ func NewStorageMarketProvider(provAddr address.Address, cfg *config.Boost) func(
 			SealingPipelineCacheTimeout: time.Duration(cfg.Dealmaking.SealingPipelineCacheTimeout),
 		}
 		dl := logs.NewDealLogger(logsDB)
-		tspt := httptransport.New(h, dl, httptransport.NChunksOpt(cfg.HttpDownload.NChunks), httptransport.AllowProvateIPsOpt(cfg.HttpDownload.AllowPrivateIPs))
+		tspt := httptransport.New(h, dl, httptransport.NChunksOpt(cfg.HttpDownload.NChunks), httptransport.AllowPrivateIPsOpt(cfg.HttpDownload.AllowPrivateIPs))
 		prov, err := storagemarket.NewProvider(prvCfg, sqldb, dealsDB, fundMgr, storageMgr, a, dp, provAddr, secb, commpc,
 			sps, cdm, df, logsSqlDB.db, logsDB, piecedirectory, ip, lp, &signatureVerifier{a}, dl, tspt)
 		if err != nil {

--- a/node/modules/storageminer.go
+++ b/node/modules/storageminer.go
@@ -622,7 +622,7 @@ func NewStorageMarketProvider(provAddr address.Address, cfg *config.Boost) func(
 			SealingPipelineCacheTimeout: time.Duration(cfg.Dealmaking.SealingPipelineCacheTimeout),
 		}
 		dl := logs.NewDealLogger(logsDB)
-		tspt := httptransport.New(h, dl, httptransport.NChunksOpt(cfg.HttpDownload.NChunks))
+		tspt := httptransport.New(h, dl, httptransport.NChunksOpt(cfg.HttpDownload.NChunks), httptransport.AllowProvateIPsOpt(cfg.HttpDownload.AllowPrivateIPs))
 		prov, err := storagemarket.NewProvider(prvCfg, sqldb, dealsDB, fundMgr, storageMgr, a, dp, provAddr, secb, commpc,
 			sps, cdm, df, logsSqlDB.db, logsDB, piecedirectory, ip, lp, &signatureVerifier{a}, dl, tspt)
 		if err != nil {

--- a/transport/httptransport/http_transport.go
+++ b/transport/httptransport/http_transport.go
@@ -61,7 +61,7 @@ func NChunksOpt(nChunks int) Option {
 	}
 }
 
-func AllowProvateIPsOpt(b bool) Option {
+func AllowPrivateIPsOpt(b bool) Option {
 	return func(h *httpTransport) {
 		h.allowPrivateIPs = b
 	}

--- a/transport/httptransport/http_transport.go
+++ b/transport/httptransport/http_transport.go
@@ -126,8 +126,7 @@ func (h *httpTransport) Execute(ctx context.Context, transportInfo []byte, dealI
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse request url: %w", err)
 	}
-	ip := net.ParseIP(pu.Hostname())
-	if ip != nil && ip.IsPrivate() {
+	if ip := net.ParseIP(pu.Hostname()); ip != nil && ip.IsPrivate() {
 		return nil, fmt.Errorf("downloading from private ip addresses is not allowed")
 	}
 

--- a/transport/httptransport/http_transport_test.go
+++ b/transport/httptransport/http_transport_test.go
@@ -332,7 +332,7 @@ func TestDownloadFromPrivateIPs(t *testing.T) {
 	_, err = New(nil, newDealLogger(t, ctx), NChunksOpt(nChunks)).Execute(ctx, bz, dealInfo)
 	require.Error(t, err, "downloading from private addresses is not allowed")
 	// allow download from private addresses if explicitly enabled
-	_, err = New(nil, newDealLogger(t, ctx), NChunksOpt(nChunks), AllowProvateIPsOpt(true)).Execute(ctx, bz, dealInfo)
+	_, err = New(nil, newDealLogger(t, ctx), NChunksOpt(nChunks), AllowPrivateIPsOpt(true)).Execute(ctx, bz, dealInfo)
 	require.NoError(t, err)
 }
 

--- a/transport/httptransport/http_transport_test.go
+++ b/transport/httptransport/http_transport_test.go
@@ -316,7 +316,7 @@ func TestConcurrentTransfers(t *testing.T) {
 	}
 }
 
-func TestDontAllowDownloadingFromPrivateAddresses(t *testing.T) {
+func TestDownloadFromPrivateIPs(t *testing.T) {
 	ctx := context.Background()
 	of := getTempFilePath(t)
 	// deal info is irrelevant in this test
@@ -324,12 +324,16 @@ func TestDontAllowDownloadingFromPrivateAddresses(t *testing.T) {
 		OutputFile: of,
 		DealSize:   1000,
 	}
-	ht := New(nil, newDealLogger(t, ctx), NChunksOpt(nChunks))
+	// ht := New(nil, newDealLogger(t, ctx), NChunksOpt(nChunks))
 	bz, err := json.Marshal(types.HttpRequest{URL: "http://192.168.0.1/blah"})
 	require.NoError(t, err)
 
-	_, err = ht.Execute(ctx, bz, dealInfo)
+	// do not allow download from private IP addresses by default
+	_, err = New(nil, newDealLogger(t, ctx), NChunksOpt(nChunks)).Execute(ctx, bz, dealInfo)
 	require.Error(t, err, "downloading from private addresses is not allowed")
+	// allow download from private addresses if explicitly enabled
+	_, err = New(nil, newDealLogger(t, ctx), NChunksOpt(nChunks), AllowProvateIPsOpt(true)).Execute(ctx, bz, dealInfo)
+	require.NoError(t, err)
 }
 
 func TestDontFollowHttpRedirects(t *testing.T) {

--- a/transport/httptransport/http_transport_test.go
+++ b/transport/httptransport/http_transport_test.go
@@ -316,6 +316,69 @@ func TestConcurrentTransfers(t *testing.T) {
 	}
 }
 
+func TestDontAllowDownloadingFromPrivateAddresses(t *testing.T) {
+	ctx := context.Background()
+	of := getTempFilePath(t)
+	// deal info is irrelevant in this test
+	dealInfo := &types.TransportDealInfo{
+		OutputFile: of,
+		DealSize:   1000,
+	}
+	ht := New(nil, newDealLogger(t, ctx), NChunksOpt(nChunks))
+	bz, err := json.Marshal(types.HttpRequest{URL: "http://192.168.0.1/blah"})
+	require.NoError(t, err)
+
+	_, err = ht.Execute(ctx, bz, dealInfo)
+	require.Error(t, err, "downloading from private addresses is not allowed")
+}
+
+func TestDontFollowHttpRedirects(t *testing.T) {
+	// we should not follow http redirects for security reasons. If the target URL tries to redirect, the client should return 303 response instead.
+	// This test sets up two servers, with one redirecting to the other. Without the redirect check the download would have been completed successfully.
+	rawSize := (100 * readBufferSize) + 30
+	ctx := context.Background()
+	st := newServerTest(t, rawSize)
+	carSize := len(st.carBytes)
+
+	var handler http.HandlerFunc = func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			offset := r.Header.Get("Range")
+
+			startend := strings.Split(strings.TrimPrefix(offset, "bytes="), "-")
+			start, _ := strconv.ParseInt(startend[0], 10, 64)
+			end, _ := strconv.ParseInt(startend[1], 10, 64)
+
+			w.WriteHeader(200)
+			if end == 0 {
+				w.Write(st.carBytes[start:]) //nolint:errcheck
+			} else {
+				w.Write(st.carBytes[start:end]) //nolint:errcheck
+			}
+		case http.MethodHead:
+			addContentLengthHeader(w, len(st.carBytes))
+		}
+	}
+	svr := httptest.NewServer(handler)
+	defer svr.Close()
+
+	var redirectHandler http.HandlerFunc = func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, svr.URL, http.StatusSeeOther)
+	}
+	redirectSvr := httptest.NewServer(redirectHandler)
+	defer redirectSvr.Close()
+
+	of := getTempFilePath(t)
+	th := executeTransfer(t, ctx, New(nil, newDealLogger(t, ctx), NChunksOpt(nChunks)), carSize, types.HttpRequest{URL: redirectSvr.URL}, of)
+	require.NotNil(t, th)
+
+	evts := waitForTransferComplete(th)
+	require.NotEmpty(t, evts)
+	require.Equal(t, 1, len(evts))
+	require.EqualValues(t, 0, evts[0].NBytesReceived)
+	require.Contains(t, evts[0].Error.Error(), "303 See Other")
+}
+
 func TestCompletionOnMultipleAttemptsWithSameFile(t *testing.T) {
 	ctx := context.Background()
 	of := getTempFilePath(t)


### PR DESCRIPTION
* Don't allow download from private IP addresses by default. Add an option to drive that behaviour. 
* Don't follow http redirects.