### PR TITLE
Add control file

### DIFF
--- a/transport/httptransport/http_transport.go
+++ b/transport/httptransport/http_transport.go
@@ -609,7 +609,10 @@ func (t *transfer) writeControlFile(cf string, config map[string]string) error {
 	}
 	defer output.Close()
 	for k, v := range config {
-		output.WriteString(fmt.Sprintf("%s=%s\n", k, v))
+		_, err = output.WriteString(fmt.Sprintf("%s=%s\n", k, v))
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/transport/httptransport/http_transport_test.go
+++ b/transport/httptransport/http_transport_test.go
@@ -197,7 +197,8 @@ func TestFirstUpgradeToChunking(t *testing.T) {
 			of := getTempFilePath(t)
 
 			// write some content into the output file to simulate a half-finished download
-			os.WriteFile(of, st.carBytes[:readBufferSize/10], 0644)
+			err := os.WriteFile(of, st.carBytes[:readBufferSize/10], 0644)
+			require.NoError(t, err)
 
 			th := executeTransfer(t, ctx, New(h, newDealLogger(t, ctx)), carSize, reqFn(), of)
 			require.NotNil(t, th)

--- a/transport/httptransport/http_transport_test.go
+++ b/transport/httptransport/http_transport_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"math/rand"
 	"net"
@@ -173,7 +174,7 @@ func TestChangeNumberOfChunksForUnfinishedDownloads(t *testing.T) {
 	// For example if a download has been started with NChunks=3, then
 	// it should finish in 3 chunks even if the node has been restarted in between with the setting changed.
 	of := getTempFilePath(t)
-	err := os.WriteFile(of+"-control", []byte(strconv.Itoa(3)), 0644)
+	err := os.WriteFile(of+"-control", []byte(fmt.Sprintf("nChunks=%s\n", strconv.Itoa(3))), 0644)
 	require.NoError(t, err)
 	// here we start download in 5 chunks while control file has 3 captured in it
 	httpParallelTransferTest(t, of, (100*readBufferSize)+30, 5, 3)

--- a/transport/httptransport/http_transport_test.go
+++ b/transport/httptransport/http_transport_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"math/rand"
 	"net"
@@ -174,7 +173,9 @@ func TestChangeNumberOfChunksForUnfinishedDownloads(t *testing.T) {
 	// For example if a download has been started with NChunks=3, then
 	// it should finish in 3 chunks even if the node has been restarted in between with the setting changed.
 	of := getTempFilePath(t)
-	err := os.WriteFile(of+"-control", []byte(fmt.Sprintf("nChunks=%s\n", strconv.Itoa(3))), 0644)
+	data, err := json.Marshal(transferConfig{NChunks: 3})
+	require.NoError(t, err)
+	err = os.WriteFile(of+"-control", data, 0644)
 	require.NoError(t, err)
 	// here we start download in 5 chunks while control file has 3 captured in it
 	httpParallelTransferTest(t, of, (100*readBufferSize)+30, 5, 3)


### PR DESCRIPTION
* Add control file that captures the number of chunks that a transfer has been started with to ensure that it stays the same across restarts.
* Control file is a set of key-value pairs separated by a newline (`\n`) character. Such format is used to ensure future extensibility without having to implement any migration logic.