### PR TITLE
Ivan/http transport upgrades

### DIFF
--- a/node/builder.go
+++ b/node/builder.go
@@ -476,6 +476,10 @@ func ConfigBoost(cfg *config.Boost) Option {
 		return Error(fmt.Errorf("Detected custom DAG store path %s. The DAG store must be at $BOOST_PATH/dagstore", cfg.DAGStore.RootDir))
 	}
 
+	if cfg.HttpDownload.NChunks < 1 || cfg.HttpDownload.NChunks > 16 {
+		return Error(errors.New("HttpDownload.NChunks should be between 1 and 16"))
+	}
+
 	legacyFees := cfg.LotusFees.Legacy()
 
 	return Options(

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -213,6 +213,9 @@ func DefaultBoost() *Boost {
 				Port:           3104,
 			},
 		},
+		HttpDownload: HttpDownloadConfig{
+			NChunks: 5,
+		},
 	}
 	return cfg
 }

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -214,7 +214,8 @@ func DefaultBoost() *Boost {
 			},
 		},
 		HttpDownload: HttpDownloadConfig{
-			NChunks: 5,
+			NChunks:         5,
+			AllowPrivateIPs: false,
 		},
 	}
 	return cfg

--- a/node/config/doc_gen.go
+++ b/node/config/doc_gen.go
@@ -489,6 +489,13 @@ configured in SectorIndexApiInfo.`,
 which improves the overall download speed. NChunks is always equal to 1 for libp2p transport because libp2p server
 doesn't support range requests yet. NChunks must be greater than 0 and less than 16, with the default of 5.`,
 		},
+		{
+			Name: "AllowPrivateIPs",
+			Type: "bool",
+
+			Comment: `AllowPrivateIPs defines whether boost should allow HTTP downloads from private IPs as per https://en.wikipedia.org/wiki/Private_network.
+The default is false.`,
+		},
 	},
 	"IndexProviderAnnounceConfig": []DocField{
 		{

--- a/node/config/doc_gen.go
+++ b/node/config/doc_gen.go
@@ -86,6 +86,12 @@ your node if metadata log is disabled`,
 			Comment: ``,
 		},
 		{
+			Name: "HttpDownload",
+			Type: "HttpDownloadConfig",
+
+			Comment: ``,
+		},
+		{
 			Name: "LotusDealmaking",
 			Type: "lotus_config.DealmakingConfig",
 
@@ -472,6 +478,16 @@ configured in SectorIndexApiInfo.`,
 			Type: "uint64",
 
 			Comment: `The port that the graphql server listens on`,
+		},
+	},
+	"HttpDownloadConfig": []DocField{
+		{
+			Name: "NChunks",
+			Type: "int",
+
+			Comment: `NChunks is a number of chunks to split HTTP downloads into. Each chunk is downloaded in the goroutine of its own
+which improves the overall download speed. NChunks is always equal to 1 for libp2p transport because libp2p server
+doesn't support range requests yet. NChunks must be greater than 0 and less than 16, with the default of 5.`,
 		},
 	},
 	"IndexProviderAnnounceConfig": []DocField{

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -47,6 +47,7 @@ type Boost struct {
 	Tracing             TracingConfig
 	LocalIndexDirectory LocalIndexDirectoryConfig
 	ContractDeals       ContractDealsConfig
+	HttpDownload        HttpDownloadConfig
 
 	// Lotus configs
 	LotusDealmaking lotus_config.DealmakingConfig
@@ -420,4 +421,11 @@ type LocalIndexDirectoryConfig struct {
 
 type LocalIndexDirectoryLeveldbConfig struct {
 	Enabled bool
+}
+
+type HttpDownloadConfig struct {
+	// NChunks is a number of chunks to split HTTP downloads into. Each chunk is downloaded in the goroutine of its own
+	// which improves the overall download speed. NChunks is always equal to 1 for libp2p transport because libp2p server
+	// doesn't support range requests yet. NChunks must be greater than 0 and less than 16, with the default of 5.
+	NChunks int
 }

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -428,4 +428,7 @@ type HttpDownloadConfig struct {
 	// which improves the overall download speed. NChunks is always equal to 1 for libp2p transport because libp2p server
 	// doesn't support range requests yet. NChunks must be greater than 0 and less than 16, with the default of 5.
 	NChunks int
+	// AllowPrivateIPs defines whether boost should allow HTTP downloads from private IPs as per https://en.wikipedia.org/wiki/Private_network.
+	// The default is false.
+	AllowPrivateIPs bool
 }

--- a/node/modules/storageminer.go
+++ b/node/modules/storageminer.go
@@ -622,7 +622,7 @@ func NewStorageMarketProvider(provAddr address.Address, cfg *config.Boost) func(
 			SealingPipelineCacheTimeout: time.Duration(cfg.Dealmaking.SealingPipelineCacheTimeout),
 		}
 		dl := logs.NewDealLogger(logsDB)
-		tspt := httptransport.New(h, dl)
+		tspt := httptransport.New(h, dl, httptransport.NChunksOpt(cfg.HttpDownload.NChunks))
 		prov, err := storagemarket.NewProvider(prvCfg, sqldb, dealsDB, fundMgr, storageMgr, a, dp, provAddr, secb, commpc,
 			sps, cdm, df, logsSqlDB.db, logsDB, piecedirectory, ip, lp, &signatureVerifier{a}, dl, tspt)
 		if err != nil {

--- a/node/modules/storageminer.go
+++ b/node/modules/storageminer.go
@@ -622,7 +622,7 @@ func NewStorageMarketProvider(provAddr address.Address, cfg *config.Boost) func(
 			SealingPipelineCacheTimeout: time.Duration(cfg.Dealmaking.SealingPipelineCacheTimeout),
 		}
 		dl := logs.NewDealLogger(logsDB)
-		tspt := httptransport.New(h, dl, httptransport.NChunksOpt(cfg.HttpDownload.NChunks))
+		tspt := httptransport.New(h, dl, httptransport.NChunksOpt(cfg.HttpDownload.NChunks), httptransport.AllowPrivateIPsOpt(cfg.HttpDownload.AllowPrivateIPs))
 		prov, err := storagemarket.NewProvider(prvCfg, sqldb, dealsDB, fundMgr, storageMgr, a, dp, provAddr, secb, commpc,
 			sps, cdm, df, logsSqlDB.db, logsDB, piecedirectory, ip, lp, &signatureVerifier{a}, dl, tspt)
 		if err != nil {

--- a/transport/httptransport/http_downloader.go
+++ b/transport/httptransport/http_downloader.go
@@ -1,0 +1,202 @@
+package httptransport
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+)
+
+type downloader struct {
+	ctx        context.Context
+	transfer   *transfer
+	outputFile string
+	chunkFile  string
+	rangeStart int64
+	rangeEnd   int64
+	chunkNo    int
+	dealSize   int64
+}
+
+func (d *downloader) doHttp() error {
+	// construct request
+	req, err := http.NewRequest("GET", d.transfer.tInfo.URL, nil)
+	if err != nil {
+		return &httpError{error: fmt.Errorf("failed to create http req: %w", err)}
+	}
+
+	// add request headers
+	for name, val := range d.transfer.tInfo.Headers {
+		req.Header.Set(name, val)
+	}
+
+	// calculate range boundaries taking into account bytes that have been already downloaded
+	fi, err := os.Stat(d.chunkFile)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return &httpError{error: fmt.Errorf("failed to read size of chunk file %s: %w", d.chunkFile, err)}
+	}
+	var offset int64
+	if fi != nil {
+		offset = fi.Size()
+	}
+
+	rangeStart := d.rangeStart + offset
+
+	// the file might have been already fully downloaded, nothing to do here
+	if rangeStart >= d.rangeEnd {
+		return nil
+	}
+
+	toRead := d.rangeEnd - rangeStart
+
+	// add range req to start reading from the last byte we have in the output file
+	req.Header.Set("Range", fmt.Sprintf("bytes=%d-%d", rangeStart, d.rangeEnd))
+	// init the request with the transfer context
+	req = req.WithContext(d.ctx)
+
+	duid := d.transfer.dealInfo.DealUuid
+	d.transfer.dl.Infow(duid, "sending http request", "toRead", toRead, "range-rq", req.Header.Get("Range"))
+
+	// send http request and validate response
+	resp, err := d.transfer.client.Do(req)
+	if err != nil {
+		return &httpError{error: fmt.Errorf("failed to send http req: %w", err)}
+	}
+	// we should either get back a 200 or a 206 -> anything else means something has gone wrong and we return an error.
+	defer resp.Body.Close() // nolint
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusPartialContent {
+		return &httpError{
+			error: fmt.Errorf("http req failed: code: %d, status: %s", resp.StatusCode, resp.Status),
+			code:  resp.StatusCode,
+		}
+	}
+
+	// create chunk file if it doesn't exist
+	of, err := os.OpenFile(d.chunkFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return &httpError{error: fmt.Errorf("failed to open chunk file %s for write: %w", d.chunkFile, err)}
+	}
+	defer of.Close()
+
+	//  start reading the response stream `readBufferSize` at a time using a limit reader so we only read as many bytes as we need to.
+	buf := make([]byte, readBufferSize)
+	limitR := io.LimitReader(resp.Body, toRead)
+	var chunkBytesReceived int64
+	for {
+		if d.ctx.Err() != nil {
+			d.transfer.dl.LogError(duid, "stopped reading http response: context canceled", d.ctx.Err())
+			return &httpError{error: d.ctx.Err()}
+		}
+		nr, readErr := limitR.Read(buf)
+
+		// if we read more than zero bytes, write whatever read.
+		if nr > 0 {
+			nw, writeErr := of.Write(buf[0:nr])
+
+			// if the number of read and written bytes don't match -> something has gone wrong, abort the http req.
+			if nw < 0 || nr != nw {
+				if writeErr != nil {
+					return &httpError{error: fmt.Errorf("failed to write the chunk file %s: %w", d.chunkFile, writeErr)}
+				}
+				return &httpError{error: fmt.Errorf("read-write mismatch writing to the chunk file %s: read=%d, written=%d", d.chunkFile, nr, nw)}
+			}
+			chunkBytesReceived += int64(nw)
+			d.transfer.addBytesReceived(int64(nw))
+		}
+		// the http stream we're reading from has sent us an EOF, nothing to do here.
+		if readErr == io.EOF {
+			d.transfer.dl.Infow(duid, "http server sent EOF", "toRead", toRead, "received", chunkBytesReceived, "deal-size", d.dealSize)
+			return nil
+		}
+		if readErr != nil {
+			return &httpError{error: fmt.Errorf("error reading from http response stream: %w", readErr)}
+		}
+	}
+}
+
+func (d *downloader) appendChunkToTheOutput() error {
+	chunk, err := os.OpenFile(d.chunkFile, os.O_RDONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("error opening chunk file %s: %w", d.chunkFile, err)
+	}
+	defer chunk.Close()
+
+	output, err := os.OpenFile(d.outputFile, os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("error opening output file %s: %w", d.outputFile, err)
+	}
+	defer output.Close()
+
+	outputStats, err := output.Stat()
+	if err != nil {
+		return fmt.Errorf("error getting output file stats %s: %w", d.outputFile, err)
+	}
+
+	outputSize := outputStats.Size()
+
+	if outputSize < d.rangeStart {
+		return fmt.Errorf("output file does not have enough bytes for the chunk to be written into it: chunkFile: %s, outputSize: %d rangeStart: %d", d.chunkFile, outputSize, d.rangeStart)
+	}
+
+	// the chunk must have been already appended to the output - nothing to do here
+	if outputSize >= d.rangeEnd {
+		return nil
+	}
+
+	// move the write cursor in the case if appending chunk has failed half way through
+	offset := outputSize - d.rangeStart
+
+	_, err = chunk.Seek(offset, 0)
+	if err != nil {
+		return fmt.Errorf("error setting chunk file offset %s: %w", d.chunkFile, err)
+	}
+
+	buf := make([]byte, readBufferSize)
+	reader := io.Reader(chunk)
+	for {
+		if d.ctx.Err() != nil {
+			return d.ctx.Err()
+		}
+		nr, readErr := reader.Read(buf)
+
+		if nr > 0 {
+			nw, writeErr := output.Write(buf[0:nr])
+
+			if nw < 0 || nr != nw {
+				if writeErr != nil {
+					return fmt.Errorf("failed to write to the output file from the chunk %s: %w", d.chunkFile, writeErr)
+				}
+				return fmt.Errorf("read-write mismatch writing to the output file from the chunk %s: read=%d, written=%d", d.chunkFile, nr, nw)
+			}
+		}
+		if readErr == io.EOF {
+			return nil
+		}
+		if readErr != nil {
+			return readErr
+		}
+	}
+}
+
+func (d *downloader) verify() error {
+	chunk, err := os.OpenFile(d.chunkFile, os.O_RDONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("error opening chunk file %s: %w", d.chunkFile, err)
+	}
+	defer chunk.Close()
+
+	chunkStats, err := chunk.Stat()
+	if err != nil {
+		return fmt.Errorf("error getting chunk file stats %s: %w", d.chunkFile, err)
+	}
+
+	expSize := d.rangeEnd - d.rangeStart
+	if expSize != chunkStats.Size() {
+		return fmt.Errorf("incomplete chunk file %s: expected: %d actual: %d", d.chunkFile, expSize, chunkStats.Size())
+	}
+
+	return nil
+}

--- a/transport/httptransport/http_transport.go
+++ b/transport/httptransport/http_transport.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -282,6 +283,37 @@ func (t *transfer) getBytesReceived() int64 {
 func (t *transfer) execute(ctx context.Context) error {
 	duuid := t.dealInfo.DealUuid
 
+	outputStats, err := os.Stat(t.dealInfo.OutputFile)
+	if err != nil {
+		return &httpError{error: fmt.Errorf("failed to get stats of the output file %s: %w", t.dealInfo.OutputFile, err)}
+	}
+	controlFile := t.dealInfo.OutputFile + "-control"
+	controlStats, err := os.Stat(controlFile)
+
+	// Check if the control file exists and create it if it doesn't. Control file captures the number of chunks that the transfer has been started with.
+	// If the number of chunks changes half way through, the transfer should continue with the same chunking setting.
+	nChunks := t.nChunks
+	if errors.Is(err, os.ErrNotExist) {
+		// if the output file is not empty, but there is no control file then that must be a continuation of a transfer from before chunking was introduced.
+		// in that case set nChunks to one.
+		if outputStats.Size() > 0 && controlStats == nil {
+			nChunks = 1
+		}
+
+		err := t.writeControlFile(controlFile, transferConfig{nChunks})
+		if err != nil {
+			return &httpError{error: fmt.Errorf("failed to create control file %s: %w", controlFile, err)}
+		}
+	} else if err != nil {
+		return &httpError{error: fmt.Errorf("failed to get stats of control file %s: %w", controlFile, err)}
+	} else {
+		conf, err := t.readControlFile(controlFile)
+		if err != nil {
+			return &httpError{error: fmt.Errorf("failed to read control file %s: %w", controlFile, err)}
+		}
+		nChunks = conf.NChunks
+	}
+
 	// Create downloaders. Each downloader must be initialised with the same byte range across restarts in order to resume previous downloads.
 	// If the output file contains some data in it already - do not create a downloader for it again.
 	// Consider the following scenarios:
@@ -290,10 +322,6 @@ func (t *transfer) execute(ctx context.Context) error {
 	// 2. some chunks have been fully downloaded, some just partially. Some of the fully downloaded chunks have been merged into the main
 	//    file and their temp files have been deleted. We should not re-download the merged chunks again, finish downloading
 	//    the partial ones and proceed with merging.
-	outputStats, err := os.Stat(t.dealInfo.OutputFile)
-	if err != nil {
-		return &httpError{error: fmt.Errorf("failed to get stats of the output file: %w", err)}
-	}
 
 	// determine deal size from HEAD request and make sure that it matches up with the one from the deal info
 	var dealSize int64
@@ -337,15 +365,15 @@ func (t *transfer) execute(ctx context.Context) error {
 		}
 	}
 
-	chunkSize := dealSize / int64(t.nChunks)
+	chunkSize := dealSize / int64(nChunks)
 	lastAppendedChunk := int(outputStats.Size() / chunkSize)
 
-	downloaders := make([]*downloader, 0, t.nChunks-lastAppendedChunk)
+	downloaders := make([]*downloader, 0, nChunks-lastAppendedChunk)
 
-	for i := lastAppendedChunk; i < t.nChunks; i++ {
+	for i := lastAppendedChunk; i < nChunks; i++ {
 		rangeStart := int64(i) * chunkSize
 		var rangeEnd int64
-		if i == t.nChunks-1 {
+		if i == nChunks-1 {
 			rangeEnd = dealSize
 		} else {
 			rangeEnd = rangeStart + chunkSize
@@ -425,6 +453,11 @@ func (t *transfer) execute(ctx context.Context) error {
 				if err != nil {
 					return &httpError{error: fmt.Errorf("failed to remove the chunk file: %w", err)}
 				}
+			}
+			// delete control file once all chunks have been merged in successfully
+			err = os.Remove(controlFile)
+			if err != nil {
+				t.dl.Infow(duuid, "error deleteing control file %s: %w", controlFile, err)
 			}
 			// if there's no error, transfer was successful
 			break
@@ -537,4 +570,48 @@ func (t *transfer) closeEventChannel(ctx context.Context) {
 		}
 	}
 	close(t.eventCh)
+}
+
+type transferConfig struct {
+	NChunks int
+}
+
+func (t *transfer) readControlFile(cf string) (*transferConfig, error) {
+	input, err := os.OpenFile(cf, os.O_RDONLY, 0644)
+	if err != nil {
+		return nil, fmt.Errorf("error opening control file for read %s: %w", cf, err)
+	}
+	defer input.Close()
+
+	data, err := io.ReadAll(input)
+	if err != nil {
+		return nil, fmt.Errorf("error reading control file %s: %w", cf, err)
+	}
+	var conf transferConfig
+	err = json.Unmarshal(data, &conf)
+	if err != nil {
+		return nil, fmt.Errorf("error unmarshalling control file %s: %w", cf, err)
+	}
+
+	return &conf, nil
+}
+
+func (t *transfer) writeControlFile(cf string, conf transferConfig) error {
+	output, err := os.OpenFile(cf, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("error opening control file for write %s: %w", cf, err)
+	}
+	defer output.Close()
+
+	data, err := json.Marshal(&conf)
+	if err != nil {
+		return fmt.Errorf("error marshalling transfer config: %w", err)
+	}
+
+	_, err = output.Write(data)
+	if err != nil {
+		return fmt.Errorf("error writing into control file %s: %w", cf, err)
+	}
+
+	return nil
 }

--- a/transport/httptransport/http_transport.go
+++ b/transport/httptransport/http_transport.go
@@ -5,9 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
+	"strconv"
 	"sync"
 	"time"
 
@@ -19,6 +19,7 @@ import (
 	"github.com/jpillora/backoff"
 	p2phttp "github.com/libp2p/go-libp2p-http"
 	"github.com/libp2p/go-libp2p/core/host"
+	"golang.org/x/sync/errgroup"
 )
 
 const (
@@ -30,6 +31,8 @@ const (
 	maxBackOff           = 10 * time.Minute
 	factor               = 1.5
 	maxReconnectAttempts = 15
+
+	nChunks = 5
 )
 
 type httpError struct {
@@ -50,6 +53,12 @@ func BackOffRetryOpt(minBackoff, maxBackoff time.Duration, factor, maxReconnectA
 	}
 }
 
+func NChunksOpt(nChunks int) Option {
+	return func(h *httpTransport) {
+		h.nChunks = nChunks
+	}
+}
+
 type httpTransport struct {
 	libp2pHost   host.Host
 	libp2pClient *http.Client
@@ -58,6 +67,8 @@ type httpTransport struct {
 	maxBackoffWait       time.Duration
 	backOffFactor        float64
 	maxReconnectAttempts float64
+
+	nChunks int
 
 	dl *logs.DealLogger
 }
@@ -69,6 +80,7 @@ func New(host host.Host, dealLogger *logs.DealLogger, opts ...Option) *httpTrans
 		maxBackoffWait:       maxBackOff,
 		backOffFactor:        factor,
 		maxReconnectAttempts: maxReconnectAttempts,
+		nChunks:              nChunks,
 		dl:                   dealLogger.Subsystem("http-transport"),
 	}
 	for _, o := range opts {
@@ -120,6 +132,12 @@ func (h *httpTransport) Execute(ctx context.Context, transportInfo []byte, dealI
 	}
 	h.dl.Infow(duuid, "existing file size", "file size", fileSize, "deal size", dealInfo.DealSize)
 
+	// default to a single stream for libp2p urls as libp2p server doesn't support range requests
+	nChunks := h.nChunks
+	if u.Scheme == "libp2p" {
+		nChunks = 1
+	}
+
 	// construct the transfer instance that will act as the transfer handler
 	tctx, cancel := context.WithCancel(ctx)
 	t := &transfer{
@@ -136,6 +154,7 @@ func (h *httpTransport) Execute(ctx context.Context, transportInfo []byte, dealI
 		},
 		maxReconnectAttempts: h.maxReconnectAttempts,
 		dl:                   h.dl,
+		nChunks:              nChunks,
 	}
 
 	cleanupFns := []func(){
@@ -175,7 +194,8 @@ func (h *httpTransport) Execute(ctx context.Context, transportInfo []byte, dealI
 
 	// is the transfer already complete ? we check this by comparing the number of bytes
 	// in the output file with the deal size.
-	if fileSize == dealInfo.DealSize {
+	// DealSize might be passed as zero for offline deals.
+	if dealInfo.DealSize != 0 && fileSize == dealInfo.DealSize {
 		defer cleanup()
 
 		t.emitEvent(types.TransportEvent{NBytesReceived: fileSize})
@@ -216,52 +236,176 @@ type transfer struct {
 
 	client *http.Client
 	dl     *logs.DealLogger
+
+	nChunks int
+	lock    sync.RWMutex
+}
+
+func (t *transfer) addBytesReceived(n int64) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	t.nBytesReceived += n
+	t.emitEvent(types.TransportEvent{NBytesReceived: t.nBytesReceived})
+}
+
+func (t *transfer) getBytesReceived() int64 {
+	t.lock.RLock()
+	defer t.lock.RUnlock()
+	return t.nBytesReceived
 }
 
 func (t *transfer) execute(ctx context.Context) error {
 	duuid := t.dealInfo.DealUuid
+
+	// Create downloaders. Each downloader must be initialised with the same byte range across restarts in order to resume previous downloads.
+	// If the output file contains some data in it already - do not create a downloader for it again.
+	// Consider the following scenarios:
+	// 1. some chunks have been fully downloaded, some just partially. No chunks have been merged to the main file yet. We need to do nothing for the downloaded chunks
+	// 	  and finish downloading for the partial ones;
+	// 2. some chunks have been fully downloaded, some just partially. Some of the fully downloaded chunks have been merged into the main
+	//    file and their temp files have been deleted. We should not re-download the merged chunks again, finish downloading
+	//    the partial ones and proceed with merging.
+	outputStats, err := os.Stat(t.dealInfo.OutputFile)
+	if err != nil {
+		return &httpError{error: fmt.Errorf("failed to get stats of the output file: %w", err)}
+	}
+
+	// determine deal size from HEAD request and make sure that it matches up with the one from the deal info
+	var dealSize int64
+	req, err := http.NewRequest("HEAD", t.tInfo.URL, nil)
+	if err != nil {
+		return &httpError{error: fmt.Errorf("failed to create http HEAD req: %w", err)}
+	}
+	// add request headers
+	for name, val := range t.tInfo.Headers {
+		req.Header.Set(name, val)
+	}
+
+	resp, err := t.client.Do(req)
+	if err != nil {
+		return &httpError{error: fmt.Errorf("failed to send HEAD http req: %w", err)}
+	}
+	defer resp.Body.Close() // nolint
+
+	if resp.StatusCode != http.StatusOK {
+		return &httpError{
+			error: fmt.Errorf("http HEAD req failed: code: %d, status: %s", resp.StatusCode, resp.Status),
+			code:  resp.StatusCode,
+		}
+	}
+	if s := resp.Header.Get("Content-Length"); len(s) > 0 {
+		dealSize, err = strconv.ParseInt(s, 10, 64)
+		if err != nil {
+			return &httpError{
+				error: fmt.Errorf("error parsing content-length header: %w", err),
+			}
+		}
+	} else {
+		return &httpError{
+			error: fmt.Errorf("can't determine deal size from the head request, no header"),
+		}
+	}
+
+	if t.dealInfo.DealSize != 0 && dealSize != t.dealInfo.DealSize {
+		return &httpError{
+			error: fmt.Errorf("deal size mismatch: head: %d, dealInfo: %d", dealSize, t.dealInfo.DealSize),
+		}
+	}
+
+	chunkSize := dealSize / int64(t.nChunks)
+	lastAppendedChunk := int(outputStats.Size() / chunkSize)
+
+	downloaders := make([]*downloader, 0, t.nChunks-lastAppendedChunk)
+
+	for i := lastAppendedChunk; i < t.nChunks; i++ {
+		rangeStart := int64(i) * chunkSize
+		var rangeEnd int64
+		if i == t.nChunks-1 {
+			rangeEnd = dealSize
+		} else {
+			rangeEnd = rangeStart + chunkSize
+		}
+		// write first chunk directly to the output file
+		var chunkFile string
+		if i == 0 {
+			chunkFile = t.dealInfo.OutputFile
+		} else {
+			chunkFile = t.dealInfo.OutputFile + "-" + fmt.Sprint(i)
+		}
+		d := downloader{
+			ctx:        ctx,
+			transfer:   t,
+			chunkFile:  chunkFile,
+			outputFile: t.dealInfo.OutputFile,
+			rangeStart: rangeStart,
+			rangeEnd:   rangeEnd,
+			chunkNo:    i,
+			dealSize:   dealSize,
+		}
+		downloaders = append(downloaders, &d)
+
+		// if some chunks have been partially downloaded - add their sizes to nBytesReceived.
+		// that doesn't need to be done for the very first chunk as it's already included into the number
+		if i == 0 {
+			continue
+		}
+		st, err := os.Stat(d.chunkFile)
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
+			return &httpError{error: fmt.Errorf("failed to get stats of the chunk file: %w", err)}
+		}
+		if st != nil {
+			t.nBytesReceived += st.Size()
+		}
+	}
+
 	for {
-		// construct request
-		req, err := http.NewRequest("GET", t.tInfo.URL, nil)
-		if err != nil {
-			return fmt.Errorf("failed to create http req: %w", err)
+
+		nBytesReceived := t.getBytesReceived()
+
+		group := errgroup.Group{}
+
+		// download chunks into temporary files
+		for _, d := range downloaders {
+			group.Go(d.doHttp)
 		}
 
-		// get the number of bytes already received (the size of the output file)
-		st, err := os.Stat(t.dealInfo.OutputFile)
-		if err != nil {
-			return fmt.Errorf("failed to stat output file: %w", err)
-		}
-		t.nBytesReceived = st.Size()
-
-		// add request headers
-		for name, val := range t.tInfo.Headers {
-			req.Header.Set(name, val)
+		var reqErr *httpError
+		if err := group.Wait(); err != nil {
+			reqErr = err.(*httpError)
 		}
 
-		// add range req to start reading from the last byte we have in the output file
-		req.Header.Set("Range", fmt.Sprintf("bytes=%d-", t.nBytesReceived))
-		// init the request with the transfer context
-		req = req.WithContext(ctx)
-		// open output file in append-only mode for writing
-		of, err := os.OpenFile(t.dealInfo.OutputFile, os.O_APPEND|os.O_WRONLY, 0644)
-		if err != nil {
-			return fmt.Errorf("failed to open output file: %w", err)
-		}
-		defer of.Close()
-
-		// start the http transfer
-		remaining := t.dealInfo.DealSize - t.nBytesReceived
-		reqErr := t.doHttp(ctx, req, of, remaining)
 		if reqErr == nil {
-			t.dl.Infow(duuid, "http transfer completed successfully")
+			// append chunks one by one to the output file
+			// * minimize space overhead by removing the chunk file once it has been appended ot the output successfully
+			// * keep in mind restarts, resume writing from the correct chunk / offset
+			t.dl.Infow(duuid, "http transfer completed successfully, joining chunks")
+
+			for i := 0; i < len(downloaders); i++ {
+				d := downloaders[i]
+
+				if err := d.verify(); err != nil {
+					return &httpError{error: err}
+				}
+
+				// this is the first chunk, no more job to do as it has already been written to the output file
+				if d.chunkNo == 0 {
+					continue
+				}
+
+				err := d.appendChunkToTheOutput()
+				if err != nil {
+					return &httpError{error: fmt.Errorf("failed to append chunk to the output: %w", err)}
+				}
+				err = os.Remove(d.chunkFile)
+				if err != nil {
+					return &httpError{error: fmt.Errorf("failed to remove the chunk file: %w", err)}
+				}
+			}
 			// if there's no error, transfer was successful
 			break
 		}
 
 		t.dl.Infow(duuid, "http request error", "http code", reqErr.code, "outputErr", reqErr.Error())
-
-		_ = of.Close()
 
 		// check if the error is a 4xx error, meaning there is a problem with
 		// the request (eg 401 Unauthorized)
@@ -272,16 +416,16 @@ func (t *transfer) execute(ctx context.Context) error {
 		}
 
 		// do not resume transfer if context has been cancelled or if the context deadline has exceeded
-		err = reqErr.error
+		err := reqErr.error
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			t.dl.LogError(duuid, "terminating http transfer: context cancelled or deadline exceeded", err)
 			return fmt.Errorf("transfer context canceled err: %w", err)
 		}
 
 		// If some data was transferred, reset the back-off count to zero
-		if t.nBytesReceived > st.Size() {
+		if n := t.getBytesReceived(); n > nBytesReceived {
 			t.dl.Infow(duuid, "some data was transferred before connection error, so resetting backoff to zero",
-				"transferred", t.nBytesReceived-st.Size())
+				"transferred", n-nBytesReceived)
 			t.backoff.Reset()
 		}
 
@@ -307,80 +451,25 @@ func (t *transfer) execute(ctx context.Context) error {
 
 	// --- http request finished successfully. see if we got the number of bytes we expected.
 
+	nBytesReceived := t.getBytesReceived()
+
 	// if the number of bytes we've received is not the same as the deal size, we have a failure.
-	if t.nBytesReceived != t.dealInfo.DealSize {
-		return fmt.Errorf("mismatch in dealSize vs received bytes, dealSize=%d, received=%d", t.dealInfo.DealSize, t.nBytesReceived)
+	if nBytesReceived != dealSize {
+		return fmt.Errorf("mismatch in dealSize vs received bytes, dealSize=%d, received=%d", dealSize, nBytesReceived)
 	}
 	// if the file size is not equal to the number of bytes received, something has gone wrong
 	st, err := os.Stat(t.dealInfo.OutputFile)
 	if err != nil {
 		return fmt.Errorf("failed to stat output file: %w", err)
 	}
-	if t.nBytesReceived != st.Size() {
-		return fmt.Errorf("mismtach in output file size vs received bytes, fileSize=%d, receivedBytes=%d", st.Size(), t.nBytesReceived)
+	if nBytesReceived != st.Size() {
+		return fmt.Errorf("mismtach in output file size vs received bytes, fileSize=%d, receivedBytes=%d", st.Size(), nBytesReceived)
 	}
 
-	t.dl.Infow(duuid, "http request finished successfully", "nBytesReceived", t.nBytesReceived,
+	t.dl.Infow(duuid, "http request finished successfully", "nBytesReceived", nBytesReceived,
 		"file size", st.Size())
 
 	return nil
-}
-
-func (t *transfer) doHttp(ctx context.Context, req *http.Request, dst io.Writer, toRead int64) *httpError {
-	duid := t.dealInfo.DealUuid
-	t.dl.Infow(duid, "sending http request", "received", t.nBytesReceived, "remaining",
-		toRead, "range-rq", req.Header.Get("Range"))
-
-	// send http request and validate response
-	resp, err := t.client.Do(req)
-	if err != nil {
-		return &httpError{error: fmt.Errorf("failed to send  http req: %w", err)}
-	}
-	// we should either get back a 200 or a 206 -> anything else means something has gone wrong and we return an error.
-	defer resp.Body.Close() // nolint
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusPartialContent {
-		return &httpError{
-			error: fmt.Errorf("http req failed: code: %d, status: %s", resp.StatusCode, resp.Status),
-			code:  resp.StatusCode,
-		}
-	}
-
-	//  start reading the response stream `readBufferSize` at a time using a limit reader so we only read as many bytes as we need to.
-	buf := make([]byte, readBufferSize)
-	limitR := io.LimitReader(resp.Body, toRead)
-	for {
-		if ctx.Err() != nil {
-			t.dl.LogError(duid, "stopped reading http response: context canceled", ctx.Err())
-			return &httpError{error: ctx.Err()}
-		}
-		nr, readErr := limitR.Read(buf)
-
-		// if we read more than zero bytes, write whatever read.
-		if nr > 0 {
-			nw, writeErr := dst.Write(buf[0:nr])
-
-			// if the number of read and written bytes don't match -> something has gone wrong, abort the http req.
-			if nw < 0 || nr != nw {
-				if writeErr != nil {
-					return &httpError{error: fmt.Errorf("failed to write to output file: %w", writeErr)}
-				}
-				return &httpError{error: fmt.Errorf("read-write mismatch writing to the output file, read=%d, written=%d", nr, nw)}
-			}
-
-			t.nBytesReceived = t.nBytesReceived + int64(nw)
-
-			// emit event updating the number of bytes received
-			t.emitEvent(types.TransportEvent{NBytesReceived: t.nBytesReceived})
-		}
-		// the http stream we're reading from has sent us an EOF, nothing to do here.
-		if readErr == io.EOF {
-			t.dl.Infow(duid, "http server sent EOF", "received", t.nBytesReceived, "deal-size", t.dealInfo.DealSize)
-			return nil
-		}
-		if readErr != nil {
-			return &httpError{error: fmt.Errorf("error reading from http response stream: %w", readErr)}
-		}
-	}
 }
 
 // Close shuts down the transfer for the given deal. It is the caller's responsibility to call Close after it no longer needs the transfer.

--- a/transport/httptransport/http_transport_perf_test.go
+++ b/transport/httptransport/http_transport_perf_test.go
@@ -1,0 +1,117 @@
+package httptransport
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/filecoin-project/boost/transport/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHttpTransportMultistreamPerformance(t *testing.T) {
+	// this test runs a tcp proxy in front of the http web server that adds a latency to each tcp packet.
+	// This is done to simulate network latency and ensure that multistream transfer is reasonably faster than singlestream.
+	// rawSize and latency need to be big enough so that data transfer takes a reasonable proportion of time comparing to writing to the disk.
+	ctx := context.Background()
+	latency := 100 * time.Millisecond
+	rawSize := 100 * readBufferSize // 100 Mib
+	st := newServerTest(t, rawSize)
+	carSize := len(st.carBytes)
+
+	var handler http.HandlerFunc = func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			offset := r.Header.Get("Range")
+
+			startend := strings.Split(strings.TrimPrefix(offset, "bytes="), "-")
+			start, _ := strconv.ParseInt(startend[0], 10, 64)
+			end, _ := strconv.ParseInt(startend[1], 10, 64)
+
+			w.WriteHeader(200)
+			if end == 0 {
+				w.Write(st.carBytes[start:]) //nolint:errcheck
+			} else {
+				w.Write(st.carBytes[start:end]) //nolint:errcheck
+			}
+		case http.MethodHead:
+			addContentLengthHeader(w, len(st.carBytes))
+		}
+	}
+
+	svr := httptest.NewServer(handler)
+
+	defer svr.Close()
+
+	localAddr := "localhost:26379"
+	listener, err := net.Listen("tcp", localAddr)
+	require.NoError(t, err)
+
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			require.NoError(t, err)
+			go handleConnection(t, conn, strings.TrimPrefix(svr.URL, "http://"), latency)
+		}
+	}()
+
+	runTransfer := func(chunks int) time.Duration {
+		start := time.Now()
+		of := getTempFilePath(t)
+		th := executeTransfer(t, ctx, New(nil, newDealLogger(t, ctx), NChunksOpt(chunks)), 0, types.HttpRequest{URL: "http://" + localAddr}, of)
+		require.NotNil(t, th)
+
+		evts := waitForTransferComplete(th)
+		require.NotEmpty(t, evts)
+		require.EqualValues(t, carSize, evts[len(evts)-1].NBytesReceived)
+		assertFileContents(t, of, st.carBytes)
+		return time.Since(start)
+	}
+
+	singleStreamTime := runTransfer(1)
+	multiStreamTime := runTransfer(5)
+	t.Logf("Single stream: %s", singleStreamTime)
+	t.Logf("Multi stream: %s", multiStreamTime)
+	// the larger the payload and latency - the faster multistream becomes comparing to singlestream.
+	require.True(t, float64(singleStreamTime.Milliseconds())/float64(multiStreamTime.Milliseconds()) > 3)
+}
+
+func handleConnection(t *testing.T, localConn net.Conn, remoteAddr string, latency time.Duration) {
+	remoteConn, err := net.Dial("tcp", remoteAddr)
+	require.NoError(t, err)
+	defer remoteConn.Close()
+
+	proxyFunc := func(from, to net.Conn) {
+		buf := make([]byte, readBufferSize)
+		for {
+			// ensures that we don't get blocked on reading multi-chunked payloads
+			rerr := from.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
+			require.NoError(t, rerr)
+			numBytesRead, rerr := from.Read(buf)
+			if numBytesRead > 0 {
+				_, werr := to.Write(buf[0:numBytesRead])
+				require.NoError(t, werr)
+				time.Sleep(latency)
+			}
+			if errors.Is(rerr, io.EOF) || errors.Is(rerr, os.ErrDeadlineExceeded) {
+				break
+			}
+			if rerr != nil {
+				break
+			}
+		}
+	}
+
+	for {
+		proxyFunc(localConn, remoteConn)
+		proxyFunc(remoteConn, localConn)
+	}
+}

--- a/transport/httptransport/http_transport_test.go
+++ b/transport/httptransport/http_transport_test.go
@@ -5,13 +5,13 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"math/rand"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -53,6 +53,11 @@ type serverTest struct {
 	bs       bstore.Blockstore
 	root     format.Node
 	carBytes []byte
+}
+
+func addContentLengthHeader(w http.ResponseWriter, length int) {
+	w.Header().Add("Content-Length", strconv.Itoa(length))
+	w.WriteHeader(200)
 }
 
 func newDealLogger(t *testing.T, ctx context.Context) *logs.DealLogger {
@@ -105,8 +110,129 @@ func TestSimpleTransfer(t *testing.T) {
 			require.NotEmpty(t, evts)
 			require.EqualValues(t, carSize, evts[len(evts)-1].NBytesReceived)
 			assertFileContents(t, of, st.carBytes)
+
+			// verify that the output folder contains just a single output file, no temporary chunks
+			dir, _ := os.Open(filepath.Dir(of))
+			files, _ := dir.Readdir(0)
+			require.Equal(t, 1, len(files))
+			require.Equal(t, filepath.Base(of), files[0].Name())
 		})
 	}
+}
+
+func httpParallelTransferTest(t *testing.T, rawSize int, nChunks, expectedChunks int) {
+	ctx := context.Background()
+	st := newServerTest(t, rawSize)
+	carSize := len(st.carBytes)
+	var cnt atomic.Int32
+
+	var handler http.HandlerFunc = func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			offset := r.Header.Get("Range")
+
+			startend := strings.Split(strings.TrimPrefix(offset, "bytes="), "-")
+			start, _ := strconv.ParseInt(startend[0], 10, 64)
+			end, _ := strconv.ParseInt(startend[1], 10, 64)
+
+			w.WriteHeader(200)
+			if end == 0 {
+				w.Write(st.carBytes[start:]) //nolint:errcheck
+			} else {
+				w.Write(st.carBytes[start:end]) //nolint:errcheck
+			}
+			cnt.Inc()
+		case http.MethodHead:
+			addContentLengthHeader(w, len(st.carBytes))
+		}
+	}
+
+	svr := httptest.NewServer(handler)
+	defer svr.Close()
+
+	of := getTempFilePath(t)
+	th := executeTransfer(t, ctx, New(nil, newDealLogger(t, ctx), NChunksOpt(nChunks)), carSize, types.HttpRequest{URL: svr.URL}, of)
+	require.NotNil(t, th)
+
+	evts := waitForTransferComplete(th)
+	require.NotEmpty(t, evts)
+	require.EqualValues(t, carSize, evts[len(evts)-1].NBytesReceived)
+	assertFileContents(t, of, st.carBytes)
+	require.Equal(t, expectedChunks, int(cnt.Load()))
+}
+
+func TestHttpTransferShouldBeDoneInOneChunk(t *testing.T) {
+	httpParallelTransferTest(t, (100*readBufferSize)+30, 1, 1)
+}
+
+func TestHttpTransferShouldBeDoneInMultipleChunks(t *testing.T) {
+	httpParallelTransferTest(t, (100*readBufferSize)+30, 5, 5)
+}
+
+func TestDealSizeIsZero(t *testing.T) {
+	// if deal size from deal info is zero then the actual size should be taken from HEAD request
+	ctx := context.Background()
+	st := newServerTest(t, 100*readBufferSize+30)
+	carSize := len(st.carBytes)
+
+	var handler http.HandlerFunc = func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			offset := r.Header.Get("Range")
+
+			startend := strings.Split(strings.TrimPrefix(offset, "bytes="), "-")
+			start, _ := strconv.ParseInt(startend[0], 10, 64)
+			end, _ := strconv.ParseInt(startend[1], 10, 64)
+
+			w.WriteHeader(200)
+			if end == 0 {
+				w.Write(st.carBytes[start:]) //nolint:errcheck
+			} else {
+				w.Write(st.carBytes[start:end]) //nolint:errcheck
+			}
+		case http.MethodHead:
+			addContentLengthHeader(w, len(st.carBytes))
+		}
+	}
+
+	svr := httptest.NewServer(handler)
+	defer svr.Close()
+
+	of := getTempFilePath(t)
+	th := executeTransfer(t, ctx, New(nil, newDealLogger(t, ctx), NChunksOpt(nChunks)), 0, types.HttpRequest{URL: svr.URL}, of)
+	require.NotNil(t, th)
+
+	evts := waitForTransferComplete(th)
+	require.NotEmpty(t, evts)
+	require.EqualValues(t, carSize, evts[len(evts)-1].NBytesReceived)
+	assertFileContents(t, of, st.carBytes)
+}
+
+func TestFailIfDealSizesDontMatch(t *testing.T) {
+	ctx := context.Background()
+	st := newServerTest(t, 100*readBufferSize+30)
+	carSize := len(st.carBytes)
+
+	var handler http.HandlerFunc = func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			require.Fail(t, "should never happen")
+		case http.MethodHead:
+			addContentLengthHeader(w, carSize)
+		}
+	}
+
+	svr := httptest.NewServer(handler)
+	defer svr.Close()
+
+	of := getTempFilePath(t)
+	th := executeTransfer(t, ctx, New(nil, newDealLogger(t, ctx), NChunksOpt(nChunks)), carSize/2, types.HttpRequest{URL: svr.URL}, of)
+	require.NotNil(t, th)
+
+	evts := waitForTransferComplete(th)
+	require.NotEmpty(t, evts)
+
+	require.Contains(t, evts[len(evts)-1].Error.Error(), "deal size mismatch")
 }
 
 func TestTransportRespectsContext(t *testing.T) {
@@ -204,7 +330,12 @@ func TestCompletionOnMultipleAttemptsWithSameFile(t *testing.T) {
 			if rangeEnd > size {
 				rangeEnd = size
 			}
-			http.ServeContent(w, r, "", time.Time{}, strings.NewReader(str[:rangeEnd]))
+			switch r.Method {
+			case http.MethodGet:
+				http.ServeContent(w, r, "", time.Time{}, strings.NewReader(str[:rangeEnd]))
+			case http.MethodHead:
+				addContentLengthHeader(w, len(str))
+			}
 		}
 	}
 
@@ -227,7 +358,6 @@ func TestCompletionOnMultipleAttemptsWithSameFile(t *testing.T) {
 
 	for name, s := range svcs {
 		t.Run(name, func(t *testing.T) {
-			end := readBufferSize
 			for i := 1; ; i++ {
 				url, closer, h := s.init(t, i)
 
@@ -240,14 +370,18 @@ func TestCompletionOnMultipleAttemptsWithSameFile(t *testing.T) {
 					require.EqualValues(t, size, evts[0].NBytesReceived)
 					break
 				}
-				require.Contains(t, evts[len(evts)-1].Error.Error(), "mismatch")
 
-				assertFileContents(t, of, []byte(str[:end]))
+				// there ar 2 scenarios why the transfer might fail
+				// 1. a requested range is outside of the payload boundaries. For example if the total payload length is 10 and the requested range is 15-20, the server will
+				// 	  return 416: Requested Range Not Satisfiable
+				// 2. all but the last chunk have been fully downloaded. In that case appending the last chunk to the output will result into "incomlete chunk" error.
+				errMsg := evts[len(evts)-1].Error.Error()
+				require.True(t, strings.Contains(errMsg, "incomplete chunk") || strings.Contains(errMsg, "Requested Range Not Satisfiable"))
+
+				s, err := os.Stat(of)
+				require.NoError(t, err)
+				assertFileContents(t, of, []byte(str[:s.Size()]))
 				closer()
-				end = end + readBufferSize
-				if end > size {
-					end = size
-				}
 			}
 
 			// ensure file contents are correct in the end
@@ -262,9 +396,13 @@ func TestTransferCancellation(t *testing.T) {
 	size := (100 * readBufferSize) + 30
 
 	closing := make(chan struct{}, 2)
-	svcs := serversWithCustomHandler(func(http.ResponseWriter, *http.Request) {
-		fmt.Println("Hello")
-		<-closing
+	svcs := serversWithCustomHandler(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			<-closing
+		case http.MethodHead:
+			addContentLengthHeader(w, size)
+		}
 	})
 
 	for name, s := range svcs {
@@ -308,21 +446,27 @@ func TestTransferResumption(t *testing.T) {
 
 	// start http server that always sends 500Kb and disconnects (total file size is greater than 100 Mb)
 	svr := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		nAttempts.Inc()
-		offset := r.Header.Get("Range")
-		finalOffset := strings.TrimSuffix(strings.TrimPrefix(offset, "bytes="), "-")
-		start, _ := strconv.ParseInt(finalOffset, 10, 64)
+		switch r.Method {
+		case http.MethodGet:
+			nAttempts.Inc()
+			offset := r.Header.Get("Range")
+			finalOffset := strings.TrimSuffix(strings.TrimPrefix(offset, "bytes="), "-")
+			start, _ := strconv.ParseInt(finalOffset, 10, 64)
 
-		end := int(start + (readBufferSize + 70))
-		if end > size {
-			end = size
+			end := int(start + (readBufferSize + 70))
+			if end > size {
+				end = size
+			}
+
+			w.WriteHeader(200)
+			w.Write([]byte(str[start:end])) //nolint:errcheck
+			// close the connection so user sees an error while reading the response
+			c := GetConn(r)
+			c.Close() //nolint:errcheck
+		case http.MethodHead:
+			addContentLengthHeader(w, len(str))
 		}
 
-		w.WriteHeader(200)
-		w.Write([]byte(str[start:end])) //nolint:errcheck
-		// close the connection so user sees an error while reading the response
-		c := GetConn(r)
-		c.Close() //nolint:errcheck
 	}))
 	svr.Config.ConnContext = SaveConnInContext
 	svr.Start()
@@ -353,21 +497,26 @@ func TestLibp2pTransferResumption(t *testing.T) {
 
 	// start http server that always sends 500Kb and disconnects (total file size is greater than 100 Mb)
 	svr := newTestLibp2pHttpServer(t, func(w http.ResponseWriter, r *http.Request) {
-		nAttempts.Inc()
-		offset := r.Header.Get("Range")
-		finalOffset := strings.TrimSuffix(strings.TrimPrefix(offset, "bytes="), "-")
-		start, _ := strconv.ParseInt(finalOffset, 10, 64)
+		switch r.Method {
+		case http.MethodGet:
+			nAttempts.Inc()
+			offset := r.Header.Get("Range")
+			finalOffset := strings.TrimSuffix(strings.TrimPrefix(offset, "bytes="), "-")
+			start, _ := strconv.ParseInt(finalOffset, 10, 64)
 
-		end := int(start + (readBufferSize + 70))
-		if end > size {
-			end = size
+			end := int(start + (readBufferSize + 70))
+			if end > size {
+				end = size
+			}
+
+			w.WriteHeader(200)
+			w.Write([]byte(str[start:end])) //nolint:errcheck
+			// close the connection so user sees an error while reading the response
+			c := GetConn(r)
+			c.Close() //nolint:errcheck
+		case http.MethodHead:
+			addContentLengthHeader(w, len(str))
 		}
-
-		w.WriteHeader(200)
-		w.Write([]byte(str[start:end])) //nolint:errcheck
-		// close the connection so user sees an error while reading the response
-		c := GetConn(r)
-		c.Close() //nolint:errcheck
 	})
 
 	defer svr.Close()
@@ -406,7 +555,8 @@ func assertFileContents(t *testing.T, file string, expected []byte) {
 	bz, err := os.ReadFile(file)
 	require.NoError(t, err)
 	require.Equal(t, len(expected), len(bz))
-	require.Equal(t, expected, bz)
+	// use require.True to prevent long errors in logs when bytes aren't the same
+	require.True(t, bytes.Equal(expected, bz))
 }
 
 func getTempFilePath(t *testing.T) string {
@@ -429,11 +579,23 @@ func waitForTransferComplete(th transport.Handler) []types.TransportEvent {
 
 func serversWithRangeHandler(st *serverTest) map[string]func(t *testing.T) (req func() types.HttpRequest, close func(), h host.Host) {
 	handler := func(w http.ResponseWriter, r *http.Request) {
-		offset := r.Header.Get("Range")
-		finalOffset := strings.TrimSuffix(strings.TrimPrefix(offset, "bytes="), "-")
-		start, _ := strconv.ParseInt(finalOffset, 10, 64)
-		w.WriteHeader(200)
-		w.Write(st.carBytes[start:]) //nolint:errcheck
+		switch r.Method {
+		case http.MethodGet:
+			offset := r.Header.Get("Range")
+
+			startend := strings.Split(strings.TrimPrefix(offset, "bytes="), "-")
+			start, _ := strconv.ParseInt(startend[0], 10, 64)
+			end, _ := strconv.ParseInt(startend[1], 10, 64)
+
+			w.WriteHeader(200)
+			if end == 0 {
+				w.Write(st.carBytes[start:]) //nolint:errcheck
+			} else {
+				w.Write(st.carBytes[start:end]) //nolint:errcheck
+			}
+		case http.MethodHead:
+			addContentLengthHeader(w, len(st.carBytes))
+		}
 	}
 
 	svcs := serversWithCustomHandler(handler)

--- a/transport/httptransport/http_transport_test.go
+++ b/transport/httptransport/http_transport_test.go
@@ -120,7 +120,7 @@ func TestSimpleTransfer(t *testing.T) {
 	}
 }
 
-func httpParallelTransferTest(t *testing.T, rawSize int, nChunks, expectedChunks int) {
+func httpParallelTransferTest(t *testing.T, of string, rawSize int, nChunks, expectedChunks int) {
 	ctx := context.Background()
 	st := newServerTest(t, rawSize)
 	carSize := len(st.carBytes)
@@ -150,7 +150,6 @@ func httpParallelTransferTest(t *testing.T, rawSize int, nChunks, expectedChunks
 	svr := httptest.NewServer(handler)
 	defer svr.Close()
 
-	of := getTempFilePath(t)
 	th := executeTransfer(t, ctx, New(nil, newDealLogger(t, ctx), NChunksOpt(nChunks)), carSize, types.HttpRequest{URL: svr.URL}, of)
 	require.NotNil(t, th)
 
@@ -162,11 +161,62 @@ func httpParallelTransferTest(t *testing.T, rawSize int, nChunks, expectedChunks
 }
 
 func TestHttpTransferShouldBeDoneInOneChunk(t *testing.T) {
-	httpParallelTransferTest(t, (100*readBufferSize)+30, 1, 1)
+	httpParallelTransferTest(t, getTempFilePath(t), (100*readBufferSize)+30, 1, 1)
 }
 
 func TestHttpTransferShouldBeDoneInMultipleChunks(t *testing.T) {
-	httpParallelTransferTest(t, (100*readBufferSize)+30, 5, 5)
+	httpParallelTransferTest(t, getTempFilePath(t), (100*readBufferSize)+30, 5, 5)
+}
+
+func TestChangeNumberOfChunksForUnfinishedDownloads(t *testing.T) {
+	// This test ensures that downloads complete with the same chunking setting that they have been started with.
+	// For example if a download has been started with NChunks=3, then
+	// it should finish in 3 chunks even if the node has been restarted in between with the setting changed.
+	of := getTempFilePath(t)
+	data, err := json.Marshal(transferConfig{NChunks: 3})
+	require.NoError(t, err)
+	err = os.WriteFile(of+"-control", data, 0644)
+	require.NoError(t, err)
+	// here we start download in 5 chunks while control file has 3 captured in it
+	httpParallelTransferTest(t, of, (100*readBufferSize)+30, 5, 3)
+}
+
+func TestFirstUpgradeToChunking(t *testing.T) {
+	// verify that users can finish their existsing downloads when they upgrade to chunking for the first time,
+	// regardless of what their new chunking setting is. This test ensures that the number of chunks is set to one
+	// for all previously unnfinished downloads
+
+	ctx := context.Background()
+	rawSize := (100 * readBufferSize) + 30
+	st := newServerTest(t, rawSize)
+	carSize := len(st.carBytes)
+	svcs := serversWithRangeHandler(st)
+
+	for name, init := range svcs {
+		t.Run(name, func(t *testing.T) {
+			reqFn, closer, h := init(t)
+			defer closer()
+			of := getTempFilePath(t)
+
+			// write some content into the output file to simulate a half-finished download
+			err := os.WriteFile(of, st.carBytes[:readBufferSize/10], 0644)
+			require.NoError(t, err)
+
+			th := executeTransfer(t, ctx, New(h, newDealLogger(t, ctx)), carSize, reqFn(), of)
+			require.NotNil(t, th)
+
+			evts := waitForTransferComplete(th)
+			require.NotEmpty(t, evts)
+			require.EqualValues(t, carSize, evts[len(evts)-1].NBytesReceived)
+			assertFileContents(t, of, st.carBytes)
+
+			// verify that the output folder contains just a single output file, no temporary chunks
+			dir, _ := os.Open(filepath.Dir(of))
+			files, _ := dir.Readdir(0)
+			require.Equal(t, 1, len(files))
+			require.Equal(t, filepath.Base(of), files[0].Name())
+		})
+	}
 }
 
 func TestDealSizeIsZero(t *testing.T) {


### PR DESCRIPTION
This branch has a series of reviewed PRs merged into it. The code introduces the following changes:

* **Feature**: Add `NChunks` property that defines the number of concurrent streams for each http download with the minimum of 1, maximum of 15 and the default of 5. That will speed up how fast car files get downloaded up to the factor of the `NChunks` value. Libp2p over http is always defaulted to 1 stream only;
* **Feature**: Http downloads persist parameters that they have been started with into the control file. That will allow boost to consistently resume downloads even if the configuration changes between node restarts;
* **Test**: Add performance test that simulates network latency and ensures that multi-stream http downloads are reasonably faster than single-stream;

Multistream downloads have been tested on the main net. With `NChunks=5` the overall download speed averaged at 448MBps, while with `NChunks=1` at 169MBps (approx 2.6x improvement). It's expected that the speed-up should be proportional to the `NChunks` value if enough bandwidth / IOPs is available as the chunks are downloaded concurrently without blocking each other. 

After download is complete chunks need to be glued up into the main output file. In our testing that process took approx. 4 minutes to complete for a 32GB car file on HDD. We expect that to be much faster for SSDs. However, even with 4 minutes of extra overhead the performance boost of parallelising HTTP download is still significant. 

Fixes https://github.com/filecoin-project/boost/issues/1593

