### PR TITLE
Fix static check issues

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -89,7 +89,7 @@ func NewDataTransferChannel(hostID peer.ID, channelState datatransfer.ChannelSta
 	} else {
 		voucherJSON, err := json.Marshal(channelState.Voucher())
 		if err != nil {
-			channel.Voucher = fmt.Errorf("Voucher Serialization: %w", err).Error()
+			channel.Voucher = fmt.Sprintf("Voucher Serialization: %s", err.Error())
 		} else {
 			channel.Voucher = string(voucherJSON)
 		}

--- a/cmd/boostci/main.go
+++ b/cmd/boostci/main.go
@@ -5,13 +5,11 @@ import (
 	"log"
 	"os"
 
-	llog "log"
-
 	"github.com/urfave/cli/v2"
 )
 
 func init() {
-	llog.SetOutput(io.Discard)
+	log.SetOutput(io.Discard)
 }
 
 func main() {

--- a/protocolproxy/protocolproxy.go
+++ b/protocolproxy/protocolproxy.go
@@ -35,7 +35,7 @@ func NewProtocolProxy(h host.Host, peerConfig map[peer.ID][]protocol.ID) (*Proto
 		for _, protocol := range protocols {
 			_, existing := routesSet[protocol]
 			if existing {
-				return nil, errors.New("Route registered for multiple peers")
+				return nil, errors.New("route registered for multiple peers")
 			}
 			routesSet[protocol] = p
 		}


### PR DESCRIPTION
Address static check issues:
 * remove redundant import
 * lower case error string
 * Use `fmt.Sprintf` to construct string value instead of `fmt.Errorf.Error()`