### PR TITLE
fix LID web UI

### DIFF
--- a/docker/devnet/boost/entrypoint.sh
+++ b/docker/devnet/boost/entrypoint.sh
@@ -79,7 +79,7 @@ sed 's|#ServiceApiInfo = ""|ServiceApiInfo = "ws://localhost:8042"|g' $BOOST_PAT
 sed 's|#ExpectedSealDuration = "24h0m0s"|ExpectedSealDuration = "0h0m10s"|g' $BOOST_PATH/config.toml > $BOOST_PATH/config.toml.tmp; cp $BOOST_PATH/config.toml.tmp $BOOST_PATH/config.toml; rm $BOOST_PATH/config.toml.tmp
 
 ## run boostd-data
-boostd-data run leveldb --repo $BOOST_PATH --addr=0.0.0.0:8042 &
+boostd-data --vv run leveldb --repo $BOOST_PATH --addr=0.0.0.0:8042 > $BOOST_PATH/boostd-data.log &
 
 # TODO(anteva): fixme: hack as boostd fails to start without this dir
 mkdir -p /var/lib/boost/deal-staging

--- a/extern/boostd-data/cmd/main.go
+++ b/extern/boostd-data/cmd/main.go
@@ -40,6 +40,8 @@ func before(cctx *cli.Context) error {
 
 	if cliutil.IsVeryVerbose {
 		_ = logging.SetLogLevel("boostd-data", "DEBUG")
+		_ = logging.SetLogLevel("boostd-data-ldb", "DEBUG")
+		_ = logging.SetLogLevel("boostd-data-yb", "DEBUG")
 	}
 
 	return nil

--- a/extern/boostd-data/ldb/db.go
+++ b/extern/boostd-data/ldb/db.go
@@ -532,8 +532,13 @@ func (db *DB) ScanProgress(ctx context.Context, maddr address.Address) (*types.S
 	}
 	checkedLk.Unlock()
 
+	progress := float64(1.0)
+	if count != 0 {
+		progress = float64(checkedCount) / float64(count)
+	}
+
 	return &types.ScanProgress{
-		Progress: float64(checkedCount) / float64(count),
+		Progress: progress,
 		LastScan: lastScan,
 	}, nil
 }

--- a/extern/boostd-data/yugabyte/piecedoctor.go
+++ b/extern/boostd-data/yugabyte/piecedoctor.go
@@ -286,8 +286,11 @@ func (s *Store) ScanProgress(ctx context.Context, maddr address.Address) (*types
 		return nil, fmt.Errorf("getting time piece tracker was last scanned: %w", err)
 	}
 
-	// Calculate approximate progress
-	progress := float64(scanned) / float64(total)
+	progress := float64(1)
+	if total != 0 {
+		// Calculate approximate progress
+		progress = float64(scanned) / float64(total)
+	}
 
 	// Given that the denominator may be a little inflated, round up to 100% if we're close
 	if progress > 0.95 {

--- a/react/src/LID.js
+++ b/react/src/LID.js
@@ -96,6 +96,9 @@ function LIDContent() {
     var lastScanMsg = ''
     var lastScan = d.ScanProgress.LastScan
     const now = new Date()
+    if (!lastScan) {
+        lastScan = now
+    }
     if (lastScan > now) {
         lastScanMsg = 'just now'
     } else if (now.getTime() - lastScan.getTime() < 60 * 1000) {


### PR DESCRIPTION
Fixed division by zero at two places, which can happen if Boost is installed on a new SP that has 0 deals.

Also small fix for debug level logging from boostd-data service.

We probably need an RC, such as Boost v2.1.1 after this is merged, @LexLuthr, WDYT?

TODO:
- [x] make sure LID Web UI is displayed correctly with 0 deals
- [x] make sure that boostd-data second process is used by boostd, and not an internal leveldb service for LID