### PR TITLE
feat: run deal filters in parallel

### DIFF
--- a/docker/devnet/boost/entrypoint.sh
+++ b/docker/devnet/boost/entrypoint.sh
@@ -111,4 +111,4 @@ fi
 
 echo Starting LID service and boost in dev mode...
 trap 'kill %1' SIGINT
-exec boostd -vv run --nosync=true
+exec boostd -vv run --nosync=true &>> $BOOST_PATH/boostd.log

--- a/storagemarket/provider.go
+++ b/storagemarket/provider.go
@@ -96,6 +96,7 @@ type Provider struct {
 	publishedDealChan    chan publishDealReq
 	updateRetryStateChan chan updateRetryStateReq
 	storageSpaceChan     chan storageSpaceDealReq
+	processedDealChan    chan processedDealReq
 
 	// Sealing Pipeline API
 	sps      sealingpipeline.API
@@ -175,6 +176,7 @@ func NewProvider(cfg Config, sqldb *sql.DB, dealsDB *db.DealsDB, fundMgr *fundma
 		publishedDealChan:    make(chan publishDealReq),
 		updateRetryStateChan: make(chan updateRetryStateReq),
 		storageSpaceChan:     make(chan storageSpaceDealReq),
+		processedDealChan:    make(chan processedDealReq),
 
 		Transport:      tspt,
 		xferLimiter:    xferLimiter,

--- a/storagemarket/provider_loop.go
+++ b/storagemarket/provider_loop.go
@@ -278,7 +278,6 @@ func (p *Provider) processDeal(deal *types.ProviderDealState, rsp chan acceptDea
 	case p.processedDealChan <- processedDealReq{deal: deal, err: err, rsp: rsp}:
 	case <-p.ctx.Done():
 	}
-	return
 }
 
 func (p *Provider) processImportOfflineDealData(deal *types.ProviderDealState) *acceptError {

--- a/storagemarket/provider_loop.go
+++ b/storagemarket/provider_loop.go
@@ -406,6 +406,7 @@ func (p *Provider) run() {
 
 				// send an accept response
 				dealReq.rsp <- acceptDealResp{ri: &api.ProviderDealRejectionInfo{Accepted: true}}
+				continue
 			}
 
 			// Send new online and offline deals for processing.

--- a/storagemarket/provider_loop.go
+++ b/storagemarket/provider_loop.go
@@ -393,15 +393,6 @@ func (p *Provider) run() {
 			deal := dealReq.deal
 			p.dealLogger.Infow(deal.DealUuid, "processing deal acceptance request")
 
-			if deal.IsOffline && !dealReq.isImport {
-				// When the client proposes an offline deal, save the deal
-				// to the database but don't execute the deal. The deal
-				// will be executed when the Storage Provider imports the
-				// deal data.
-				go p.processDeal(deal, dealReq.rsp)
-				continue
-			}
-
 			if deal.IsOffline && dealReq.isImport {
 				// The Storage Provider is importing offline deal data, so tag
 				// funds for the deal and execute it
@@ -417,7 +408,11 @@ func (p *Provider) run() {
 				dealReq.rsp <- acceptDealResp{ri: &api.ProviderDealRejectionInfo{Accepted: true}}
 			}
 
-			// Send online deal for processing
+			// Send new online and offline deals for processing.
+			// When the client proposes an offline deal, save the deal
+			// to the database but don't execute the deal. The deal
+			// will be executed when the Storage Provider imports the
+			// deal data.
 			go p.processDeal(deal, dealReq.rsp)
 
 		case storageSpaceDealReq := <-p.storageSpaceChan:

--- a/storagemarket/provider_loop.go
+++ b/storagemarket/provider_loop.go
@@ -414,7 +414,7 @@ func (p *Provider) run() {
 				p.setupHandlerAndStartDeal(deal, dealReq.rsp)
 
 				// send an accept response
-				dealReq.rsp <- acceptDealResp{ri: &api.ProviderDealRejectionInfo{Accepted: true}, err: nil}
+				dealReq.rsp <- acceptDealResp{ri: &api.ProviderDealRejectionInfo{Accepted: true}}
 			}
 
 			// Send online deal for processing
@@ -530,7 +530,7 @@ func (p *Provider) run() {
 			p.setupHandlerAndStartDeal(deal, processedDeal.rsp)
 
 			// send an accept response
-			processedDeal.rsp <- acceptDealResp{ri: &api.ProviderDealRejectionInfo{Accepted: true}, err: nil}
+			processedDeal.rsp <- acceptDealResp{ri: &api.ProviderDealRejectionInfo{Accepted: true}}
 
 		case <-p.ctx.Done():
 			return
@@ -612,7 +612,7 @@ func (p *Provider) setupHandlerAndStartDeal(deal *types.ProviderDealState, rsp c
 	// set up deal handler so that clients can subscribe to deal update events
 	dh, err := p.mkAndInsertDealHandler(deal.DealUuid)
 	if err != nil {
-		p.sendErrorResp(&acceptError{error: err, isSevereError: true, reason: "server error: starting deal thread"}, rsp, deal.DealUuid)
+		p.sendErrorResp(&acceptError{error: err, isSevereError: true, reason: "server error: setting up deal handler"}, rsp, deal.DealUuid)
 		return
 	}
 


### PR DESCRIPTION
Fixes https://github.com/filecoin-project/boost/issues/1733
This PR moves processesOnlineDeals and processOfflineDeals to their own goroutines.
Possible side effects:
1. Multiple CMD execution of custom filters in parallel (High CPU utilisation depending on the number of deal being processed)
2. The deal rejection will not be in order anymore. Say, we get deal A first and deal B later and start processing them. It is possible for deal A to be rejected for lack of resources and deal B to be accepted depending upon which goroutine finishes first. 

DO NOT MERGE