### PR TITLE
use explicit repo location for boostd-data

### DIFF
--- a/docker/devnet/Dockerfile.source
+++ b/docker/devnet/Dockerfile.source
@@ -107,6 +107,7 @@ LABEL org.opencontainers.image.version=$BUILD_VERSION \
       description="This image is used to host the boost-dev storage provider"
 
 ENV BOOST_PATH /var/lib/boost
+ENV BOOSTD_DATA_PATH /var/lib/boostd-data
 ENV BOOST_CLIENT_REPO /var/lib/boost/boost-client
 env LID_LEVELDB_PATH /var/lib/boost
 VOLUME /var/lib/boost

--- a/docker/devnet/boost/entrypoint.sh
+++ b/docker/devnet/boost/entrypoint.sh
@@ -6,6 +6,7 @@ lotus wait-api
 echo Wait for lotus-miner is ready ...
 lotus-miner wait-api
 echo BOOST_PATH=$BOOST_PATH
+echo BOOSTD_DATA_PATH=$BOOSTD_DATA_PATH
 export DEFAULT_WALLET=`lotus wallet default`
 export FULLNODE_API_INFO=`lotus auth api-info --perm=admin | cut -f2 -d=`
 export MINER_API_INFO=`lotus-miner auth api-info --perm=admin | cut -f2 -d=`
@@ -79,10 +80,10 @@ sed 's|#ServiceApiInfo = ""|ServiceApiInfo = "ws://localhost:8042"|g' $BOOST_PAT
 sed 's|#ExpectedSealDuration = "24h0m0s"|ExpectedSealDuration = "0h0m10s"|g' $BOOST_PATH/config.toml > $BOOST_PATH/config.toml.tmp; cp $BOOST_PATH/config.toml.tmp $BOOST_PATH/config.toml; rm $BOOST_PATH/config.toml.tmp
 
 ## run boostd-data
-boostd-data --vv run leveldb --repo $BOOST_PATH --addr=0.0.0.0:8042 > $BOOST_PATH/boostd-data.log &
+boostd-data -vv run leveldb --repo=$BOOSTD_DATA_PATH --addr=0.0.0.0:8042 &>$BOOSTD_DATA_PATH/boostd-data.log &
 
 # TODO(anteva): fixme: hack as boostd fails to start without this dir
-mkdir -p /var/lib/boost/deal-staging
+mkdir -p $BOOST_PATH/deal-staging
 
 if [ ! -f $BOOST_PATH/.register.boost ]; then
 	echo Temporary starting boost to get maddr...

--- a/docker/devnet/docker-compose.yaml
+++ b/docker/devnet/docker-compose.yaml
@@ -69,6 +69,7 @@ services:
     restart: unless-stopped
     logging: *default-logging
     volumes:
+      - ./data/boostd-data:/var/lib/boostd-data:rw
       - ./data/boost:/var/lib/boost:rw
       - ./data/lotus:/var/lib/lotus:ro
       - ./data/lotus-miner:/var/lib/lotus-miner:ro


### PR DESCRIPTION
At the moment it is confusing that we are re-using the boostd repo for boostd-data, so this PR is changing this, in order to be explicit we are actually running a different process in the devnet.