### PR TITLE
fix: empty IPNI UI due to lack if latest Ad CID

### DIFF
--- a/react/src/Ipni.js
+++ b/react/src/Ipni.js
@@ -75,6 +75,7 @@ function ProviderIpniInfo({peerId}) {
     if (error) return <div>Error: {"Fetching provider info from "+idxHost+": "+error.message}</div>
     if (loading) return <div>Loading...</div>
     if (!data) return null
+    if (!head.data) return null
 
     return <>
         <ProviderIpniInfoRender data={data} idxHost={idxHost} lad={head.data.ipniLatestAdvertisement} />
@@ -573,10 +574,7 @@ export function IpniMenuItem(props) {
         <div className="menu-item" >
             <img className="icon" alt="" src={bezier2Img} />
             <Link key="ipni" to={basePath}>
-                <h3>Network Indexer {durationDisplay && '('+durationDisplay+')'}</h3>
-                <div className="menu-desc">
-                    <b>{count}</b> retrievals
-                </div>
+                <h3>Network Indexer</h3>
             </Link>
         </div>
     )


### PR DESCRIPTION
Without the fix

<img width="1471" alt="Screenshot 2023-10-19 at 4 46 21 PM" src="https://github.com/filecoin-project/boost/assets/88259624/bd19ac91-0df7-4a4f-9a57-3c3a77577a8b">


with the fix
<img width="1471" alt="Screenshot 2023-10-19 at 4 47 17 PM" src="https://github.com/filecoin-project/boost/assets/88259624/64661892-d6d4-41d7-98f1-72c2ec3b5e6a">

Once the data is populated
<img width="1471" alt="Screenshot 2023-10-19 at 4 47 08 PM" src="https://github.com/filecoin-project/boost/assets/88259624/94ffb7ff-e562-4c8b-9f69-4b0342ccabe8">


This PR also removes the retrieval count from indexer menu item