### PR TITLE
feat: add cql timeout to boostd-data command

### DIFF
--- a/extern/boostd-data/cmd/run.go
+++ b/extern/boostd-data/cmd/run.go
@@ -91,6 +91,12 @@ var yugabyteCmd = &cli.Command{
 			Name:     "connect-string",
 			Usage:    "postgres connect string eg 'postgresql://postgres:postgres@localhost'",
 			Required: true,
+		},
+		&cli.IntFlag{
+			Name:     "CQLTimeout",
+			Usage:    "client timeout value in seconds for CQL queries",
+			Required: false,
+			Value:    yugabyte.CqlTimeout,
 		}},
 		runFlags...,
 	),
@@ -99,6 +105,7 @@ var yugabyteCmd = &cli.Command{
 		settings := yugabyte.DBSettings{
 			Hosts:         cctx.StringSlice("hosts"),
 			ConnectString: cctx.String("connect-string"),
+			CQLTimeout:    cctx.Int("CQLTimeout"),
 		}
 
 		// One of the migrations requires a miner address. But we don't want to

--- a/extern/boostd-data/svc/setup_yugabyte_test_util.go
+++ b/extern/boostd-data/svc/setup_yugabyte_test_util.go
@@ -20,6 +20,7 @@ var tlog = logging.Logger("ybtest")
 var TestYugabyteSettings = yugabyte.DBSettings{
 	Hosts:         []string{"yugabyte"},
 	ConnectString: "postgresql://postgres:postgres@yugabyte:5433?sslmode=disable",
+	CQLTimeout:    yugabyte.CqlTimeout,
 }
 
 // Used when testing against a local yugabyte instance.
@@ -95,6 +96,7 @@ func dropTestSchema(ctx context.Context) error {
 	// For the cassandra interface, we need to drop all the objects in the
 	// keyspace before we can drop the keyspace itself
 	cluster := gocql.NewCluster(TestYugabyteSettings.Hosts...)
+	cluster.Timeout = time.Duration(TestYugabyteSettings.CQLTimeout) * time.Second
 	session, err := cluster.CreateSession()
 	if err != nil {
 		return err
@@ -144,6 +146,7 @@ func dropTestSchema(ctx context.Context) error {
 func awaitYugabyteUp(t *testing.T, duration time.Duration) {
 	start := time.Now()
 	cluster := gocql.NewCluster(TestYugabyteSettings.Hosts[0])
+	cluster.Timeout = time.Duration(TestYugabyteSettings.CQLTimeout) * time.Second
 	for {
 		_, err := cluster.CreateSession()
 		if err == nil {

--- a/extern/boostd-data/yugabyte/migrator.go
+++ b/extern/boostd-data/yugabyte/migrator.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"time"
+
 	"github.com/filecoin-project/boost/extern/boostd-data/yugabyte/cassmigrate"
 	"github.com/filecoin-project/boost/extern/boostd-data/yugabyte/migrations"
 	"github.com/filecoin-project/go-address"
@@ -49,6 +51,7 @@ func (m *Migrator) Migrate(ctx context.Context) error {
 
 	// Create a cassandra connection to be used only for running migrations.
 	cluster := gocql.NewCluster(m.settings.Hosts...)
+	cluster.Timeout = time.Duration(m.settings.CQLTimeout) * time.Second
 	cluster.Keyspace = m.CassandraKeyspace
 	session, err := cluster.CreateSession()
 	if err != nil {

--- a/extern/boostd-data/yugabyte/service.go
+++ b/extern/boostd-data/yugabyte/service.go
@@ -28,6 +28,8 @@ const pieceMetadataVersion = "1"
 
 const defaultKeyspace = "idx"
 
+const CqlTimeout = 60
+
 type DBSettings struct {
 	// The cassandra hosts to connect to
 	Hosts []string
@@ -35,6 +37,8 @@ type DBSettings struct {
 	ConnectString string
 	// The number of threads to use when inserting into the PayloadToPieces index
 	PayloadPiecesParallelism int
+	// CQL timeout in seconds
+	CQLTimeout int
 }
 
 type StoreOpt func(*Store)
@@ -63,6 +67,7 @@ func NewStore(settings DBSettings, migrator *Migrator, opts ...StoreOpt) *Store 
 	}
 
 	cluster := gocql.NewCluster(settings.Hosts...)
+	cluster.Timeout = time.Duration(settings.CQLTimeout) * time.Second
 	cluster.Keyspace = defaultKeyspace
 	s := &Store{
 		settings: settings,

--- a/extern/boostd-data/yugabyte/setup.go
+++ b/extern/boostd-data/yugabyte/setup.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
-	"github.com/yugabyte/gocql"
 	"strings"
+	"time"
+
+	"github.com/yugabyte/gocql"
 )
 
 //go:embed create.cql
@@ -19,6 +21,7 @@ func (s *Store) CreateKeyspace(ctx context.Context) error {
 	// the new keyspace
 	log.Infow("creating cassandra keyspace " + s.cluster.Keyspace)
 	cluster := gocql.NewCluster(s.settings.Hosts...)
+	cluster.Timeout = time.Duration(s.settings.CQLTimeout) * time.Second
 	session, err := cluster.CreateSession()
 	if err != nil {
 		return fmt.Errorf("creating yugabyte cluster: %w", err)


### PR DESCRIPTION
The default timeout was 6 seconds. It has been updated to 60 seconds. User can modify this with the below flag.

--CQLTimeout value               client timeout value in seconds for CQL queries (default: 60)

- [ ] Test with SPs seeing CQL timeouts