### PR TITLE
`boost wallet list` humanize display datacap

### DIFF
--- a/cmd/boost/wallet_cmd.go
+++ b/cmd/boost/wallet_cmd.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/dustin/go-humanize"
 	"github.com/filecoin-project/boost/cli/node"
 	"github.com/filecoin-project/boost/cmd"
 	"github.com/filecoin-project/go-address"
@@ -203,6 +204,8 @@ var walletList = &cli.Command{
 					wallet[dataCapKey] = dcap
 					if !cctx.Bool("json") && dcap == nil {
 						wallet[dataCapKey] = "X"
+					} else if dcap != nil {
+						wallet[dataCapKey] = humanize.IBytes(dcap.Int.Uint64())
 					}
 				} else {
 					wallet[dataCapKey] = "n/a"


### PR DESCRIPTION
Before
```bash
$ ./boost wallet list                                     
Address                                                                                 Balance                   Market(Avail)  Market(Locked)  Nonce  DataCap  
f1nsxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx                                               0.182258588264391056 FIL  0 FIL          0 FIL           64     X        
f1pdxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx                                               0 FIL                     0 FIL          0 FIL           0      24739011625   
f1tbxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx                                               0 FIL                     0 FIL          0 FIL           0      19310172962816   
f1wzxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx                                               9.750737718435487189 FIL  0 FIL          0 FIL           54     6253472382976  
f3vxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx          0 FIL                                                    0      n/a 
```
After
```bash
$ ./boost wallet list                                     
Address                                                                                 Balance                   Market(Avail)  Market(Locked)  Nonce  DataCap  
f1nsxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx                                               0.182258588264391056 FIL  0 FIL          0 FIL           64     X        
f1pdxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx                                               0 FIL                     0 FIL          0 FIL           0      23 GiB   
f1tbxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx                                               0 FIL                     0 FIL          0 FIL           0      18 TiB   
f1wzxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx                                               9.750737718435487189 FIL  0 FIL          0 FIL           54     5.7 TiB  
f3vxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx          0 FIL                                                    0      n/a 
```