### PR TITLE
fix: refactor connect-string for YB specific postgres parameters

### DIFF
--- a/extern/boostd-data/svc/setup_yugabyte_test_util.go
+++ b/extern/boostd-data/svc/setup_yugabyte_test_util.go
@@ -19,14 +19,14 @@ var tlog = logging.Logger("ybtest")
 
 var TestYugabyteSettings = yugabyte.DBSettings{
 	Hosts:         []string{"yugabyte"},
-	ConnectString: "postgresql://postgres:postgres@yugabyte:5433?sslmode=disable",
+	ConnectString: "postgresql://postgres:postgres@yugabyte:5433?sslmode=disable&load_balance=true",
 	CQLTimeout:    yugabyte.CqlTimeout,
 }
 
 // Used when testing against a local yugabyte instance.
 var TestYugabyteSettingsLocal = yugabyte.DBSettings{
 	Hosts:         []string{"localhost"},
-	ConnectString: "postgresql://postgres:postgres@localhost:5433?sslmode=disable",
+	ConnectString: "postgresql://postgres:postgres@localhost:5433?sslmode=disable&load_balance=true",
 }
 
 func init() {
@@ -74,7 +74,11 @@ func RecreateTables(ctx context.Context, t *testing.T, store *yugabyte.Store) {
 }
 
 func createTestSchema(ctx context.Context) error {
-	db, err := sql.Open("postgres", TestYugabyteSettings.ConnectString)
+	c, err := yugabyte.StripLoadBalance(TestYugabyteSettings.ConnectString)
+	if err != nil {
+		return err
+	}
+	db, err := sql.Open("postgres", c)
 	if err != nil {
 		return err
 	}
@@ -84,7 +88,11 @@ func createTestSchema(ctx context.Context) error {
 }
 
 func dropTestSchema(ctx context.Context) error {
-	db, err := sql.Open("postgres", TestYugabyteSettings.ConnectString)
+	c, err := yugabyte.StripLoadBalance(TestYugabyteSettings.ConnectString)
+	if err != nil {
+		return err
+	}
+	db, err := sql.Open("postgres", c)
 	if err != nil {
 		return err
 	}

--- a/extern/boostd-data/yugabyte/migrator.go
+++ b/extern/boostd-data/yugabyte/migrator.go
@@ -92,6 +92,10 @@ func StripLoadBalance(connectString string) (string, error) {
 	}
 	q := u.Query()
 	q.Del("load_balance")
+	q.Del("statement_cache_capacity")
+	q.Del("statement_cache_mode")
+	q.Del("prefer_simple_protocol")
+	q.Del("topology_keys")
 	u.RawQuery = q.Encode()
 	return u.String(), nil
 }

--- a/extern/boostd-data/yugabyte/migrator.go
+++ b/extern/boostd-data/yugabyte/migrator.go
@@ -92,9 +92,9 @@ func StripLoadBalance(connectString string) (string, error) {
 	}
 	q := u.Query()
 	q.Del("load_balance")
-	q.Del("statement_cache_capacity")
-	q.Del("statement_cache_mode")
-	q.Del("prefer_simple_protocol")
+	q.Del("yb_servers_refresh_interval")
+	q.Del("failed-host-reconnect-delay-secs")
+	q.Del("fallback-to-topology-keys-only")
 	q.Del("topology_keys")
 	u.RawQuery = q.Encode()
 	return u.String(), nil


### PR DESCRIPTION
Fixes https://github.com/filecoin-project/boost/issues/1808

- [x] Test on filcollins

```
$ boostd-data run yugabyte --hosts 127.0.0.1 --connect-string="postgres://postgres:postgres@127.0.0.1:5433?load_balance=true&sslmode=disable" --addr 0.0.0.0:8044 
2023/11/08 03:56:47 goose: no migrations to run. current version: 20230828111523
2023-11-08T03:56:47.934-0500    INFO    boostd-data     cmd/run.go:179  Started boostd-data yugabyte service on address 0.0.0.0:8044
```