### PR TITLE
Depend on commit from main for boostd-data dependency

### DIFF
--- a/extern/boostd-data/go.mod
+++ b/extern/boostd-data/go.mod
@@ -58,7 +58,7 @@ require (
 	github.com/go-stack/stack v1.8.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
-	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed // indirect

--- a/extern/boostd-data/go.sum
+++ b/extern/boostd-data/go.sum
@@ -558,8 +558,9 @@ github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QD
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
-github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
+github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
+github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=

--- a/go.mod
+++ b/go.mod
@@ -320,7 +320,7 @@ require (
 require (
 	github.com/filecoin-project/boost-gfm v1.26.7
 	github.com/filecoin-project/boost-graphsync v0.13.9
-	github.com/filecoin-project/boost/extern/boostd-data v0.0.0-20231009154452-ca8daa2870f3
+	github.com/filecoin-project/boost/extern/boostd-data v0.0.0-20231101173716-1622d0ce2581
 	github.com/filecoin-project/go-data-transfer/v2 v2.0.0-rc7
 	github.com/filecoin-project/go-fil-markets v1.28.3
 	github.com/filecoin-project/lotus v1.25.0-rc1

--- a/go.sum
+++ b/go.sum
@@ -313,8 +313,8 @@ github.com/filecoin-project/boost-gfm v1.26.7 h1:ENJEqx1OzY072QnUP37YrGVmUiCewRw
 github.com/filecoin-project/boost-gfm v1.26.7/go.mod h1:OhG2y7WeDx3KU9DPjgWllS+3/ospPjm8/XDrvN6uOfk=
 github.com/filecoin-project/boost-graphsync v0.13.9 h1:RQepfTlffLGUmp3Ff7VosYrWUKPLiz++GGV2D/gIfuw=
 github.com/filecoin-project/boost-graphsync v0.13.9/go.mod h1:bc2M5ZLZJtXHl8kjnqtn4L1MsdEqpJErDaIeY0bJ9wk=
-github.com/filecoin-project/boost/extern/boostd-data v0.0.0-20231009154452-ca8daa2870f3 h1:TBGSXb9eXvJcoVNmoE1dmqL4UtJSyItjx8xjhBb8ols=
-github.com/filecoin-project/boost/extern/boostd-data v0.0.0-20231009154452-ca8daa2870f3/go.mod h1:vHUM62fb82DpsBSXptQjpvcysjoV2Guc1MVJiIYccfQ=
+github.com/filecoin-project/boost/extern/boostd-data v0.0.0-20231101173716-1622d0ce2581 h1:a2rhYL8QBTxmP1/E2VhfsvUB6CoCuS4/jEvSpOl68tU=
+github.com/filecoin-project/boost/extern/boostd-data v0.0.0-20231101173716-1622d0ce2581/go.mod h1:/d9yXj2CqhPPtM+m8GiH7rQHSGRqXYFg3V82Qsk34NA=
 github.com/filecoin-project/dagstore v0.7.0 h1:IS0R+69za8dguYWeqz/MI+nb7ONpk03tAkxPCBXEKm0=
 github.com/filecoin-project/dagstore v0.7.0/go.mod h1:YKn4qXih+/2xQWpfJsaKGOi4POw5vH5grDmfPCCnx8g=
 github.com/filecoin-project/filecoin-ffi v0.30.4-0.20200910194244-f640612a1a1f/go.mod h1:+If3s2VxyjZn+KGGZIoRXBDSFQ9xL404JBJGf4WhEj0=


### PR DESCRIPTION
When boost is built from source without cloning boostd-data extern folder the go module will pull the version in go.mod which used to point to a branch commit.

The changes here changes to commit to point to a commit from main, head of `v2.1.0-rc3`. This is done by executing:

`go get github.com/filecoin-project/boost/extern/boostd-data@1622d0ce2581bcaba6c1d1c6c46d2576576fa716`

Run `go mod tidy` on root and nested modules.

Fixes #1813