### PR TITLE
fix: parametrise add index parallelism

### DIFF
--- a/cmd/boostd/recover.go
+++ b/cmd/boostd/recover.go
@@ -18,6 +18,7 @@ import (
 	"github.com/filecoin-project/boost/db"
 	bdclient "github.com/filecoin-project/boost/extern/boostd-data/client"
 	"github.com/filecoin-project/boost/extern/boostd-data/model"
+	"github.com/filecoin-project/boost/node/config"
 	"github.com/filecoin-project/boost/piecedirectory"
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-commp-utils/writer"
@@ -106,7 +107,7 @@ var lidCmd = &cli.Command{
 		&cli.IntFlag{
 			Name:  "add-index-concurrency",
 			Usage: "the maximum number of parallel tasks that a single add index operation can be split into",
-			Value: 4,
+			Value: config.DefaultAddIndexConcurrency,
 		},
 		&cli.BoolFlag{
 			Name:  "ignore-commp",

--- a/cmd/boostd/recover.go
+++ b/cmd/boostd/recover.go
@@ -103,6 +103,11 @@ var lidCmd = &cli.Command{
 			Usage: "",
 			Value: 4,
 		},
+		&cli.IntFlag{
+			Name:  "add-index-concurrency",
+			Usage: "the maximum number of parallel tasks that a single add index operation can be split into",
+			Value: 4,
+		},
 		&cli.BoolFlag{
 			Name:  "ignore-commp",
 			Usage: "whether we should ignore sanity check of local data vs chain data",
@@ -203,7 +208,7 @@ func action(cctx *cli.Context) error {
 			return fmt.Errorf("connecting to local index directory service: %w", err)
 		}
 		pr := &piecedirectory.SectorAccessorAsPieceReader{SectorAccessor: sa}
-		pd = piecedirectory.NewPieceDirectory(cl, pr, cctx.Int("add-index-throttle"))
+		pd = piecedirectory.NewPieceDirectory(cl, pr, cctx.Int("add-index-throttle"), piecedirectory.WithAddIndexConcurrency(cctx.Int("add-index-concurrency")))
 		pd.Start(ctx)
 	}
 

--- a/cmd/booster-bitswap/run.go
+++ b/cmd/booster-bitswap/run.go
@@ -13,6 +13,7 @@ import (
 	bdclient "github.com/filecoin-project/boost/extern/boostd-data/client"
 	"github.com/filecoin-project/boost/extern/boostd-data/shared/tracing"
 	"github.com/filecoin-project/boost/metrics"
+	"github.com/filecoin-project/boost/node/config"
 	"github.com/filecoin-project/boost/piecedirectory"
 	lcli "github.com/filecoin-project/lotus/cli"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -70,7 +71,7 @@ var runCmd = &cli.Command{
 		&cli.IntFlag{
 			Name:  "add-index-concurrency",
 			Usage: "the maximum number of parallel tasks that a single add index operation can be split into",
-			Value: 4,
+			Value: config.DefaultAddIndexConcurrency,
 		},
 		&cli.StringFlag{
 			Name:  "proxy",

--- a/cmd/booster-bitswap/run.go
+++ b/cmd/booster-bitswap/run.go
@@ -67,6 +67,11 @@ var runCmd = &cli.Command{
 			Usage: "the maximum number of add index operations that can run in parallel",
 			Value: 4,
 		},
+		&cli.IntFlag{
+			Name:  "add-index-concurrency",
+			Usage: "the maximum number of parallel tasks that a single add index operation can be split into",
+			Value: 4,
+		},
 		&cli.StringFlag{
 			Name:  "proxy",
 			Usage: "the multiaddr of the libp2p proxy that this node connects through",
@@ -234,7 +239,8 @@ var runCmd = &cli.Command{
 		if err != nil {
 			return fmt.Errorf("starting block filter: %w", err)
 		}
-		pd := piecedirectory.NewPieceDirectory(cl, sa, cctx.Int("add-index-throttle"))
+		pd := piecedirectory.NewPieceDirectory(cl, sa, cctx.Int("add-index-throttle"),
+			piecedirectory.WithAddIndexConcurrency(cctx.Int("add-index-concurrency")))
 		remoteStore := remoteblockstore.NewRemoteBlockstore(pd, &bitswapBlockMetrics)
 		server := NewBitswapServer(remoteStore, host, multiFilter)
 

--- a/cmd/booster-http/run.go
+++ b/cmd/booster-http/run.go
@@ -18,6 +18,7 @@ import (
 	"github.com/filecoin-project/boost/extern/boostd-data/model"
 	"github.com/filecoin-project/boost/extern/boostd-data/shared/tracing"
 	"github.com/filecoin-project/boost/metrics"
+	"github.com/filecoin-project/boost/node/config"
 	"github.com/filecoin-project/boost/piecedirectory"
 	"github.com/filecoin-project/dagstore/mount"
 	"github.com/filecoin-project/go-address"
@@ -78,7 +79,7 @@ var runCmd = &cli.Command{
 		&cli.IntFlag{
 			Name:  "add-index-concurrency",
 			Usage: "the maximum number of parallel tasks that a single add index operation can be split into",
-			Value: 4,
+			Value: config.DefaultAddIndexConcurrency,
 		},
 		&cli.StringFlag{
 			Name:     "api-fullnode",

--- a/cmd/booster-http/run.go
+++ b/cmd/booster-http/run.go
@@ -75,6 +75,11 @@ var runCmd = &cli.Command{
 			Usage: "the maximum number of add index operations that can run in parallel",
 			Value: 4,
 		},
+		&cli.IntFlag{
+			Name:  "add-index-concurrency",
+			Usage: "the maximum number of parallel tasks that a single add index operation can be split into",
+			Value: 4,
+		},
 		&cli.StringFlag{
 			Name:     "api-fullnode",
 			Usage:    "the endpoint for the full node API",
@@ -242,7 +247,8 @@ var runCmd = &cli.Command{
 		defer sa.Close()
 
 		// Create the server API
-		pd := piecedirectory.NewPieceDirectory(cl, sa, cctx.Int("add-index-throttle"))
+		pd := piecedirectory.NewPieceDirectory(cl, sa, cctx.Int("add-index-throttle"),
+			piecedirectory.WithAddIndexConcurrency(cctx.Int("add-index-concurrency")))
 
 		opts := &HttpServerOptions{
 			ServePieces:      servePieces,

--- a/extern/boostd-data/cmd/run.go
+++ b/extern/boostd-data/cmd/run.go
@@ -28,6 +28,10 @@ import (
 	"go.opencensus.io/tag"
 )
 
+const (
+	DefaultInsertConcurrency = 4
+)
+
 var runCmd = &cli.Command{
 	Name: "run",
 	Subcommands: []*cli.Command{
@@ -105,6 +109,11 @@ var yugabyteCmd = &cli.Command{
 			Required: true,
 		},
 		&cli.IntFlag{
+			Name:  "insert-concurrency",
+			Usage: "the number of concurrent tasks that each add index operation is split into",
+			Value: DefaultInsertConcurrency,
+		},
+		&cli.IntFlag{
 			Name:     "CQLTimeout",
 			Usage:    "client timeout value in seconds for CQL queries",
 			Required: false,
@@ -115,9 +124,10 @@ var yugabyteCmd = &cli.Command{
 	Action: func(cctx *cli.Context) error {
 		// Create a yugabyte data service
 		settings := yugabyte.DBSettings{
-			Hosts:         cctx.StringSlice("hosts"),
-			ConnectString: cctx.String("connect-string"),
-			CQLTimeout:    cctx.Int("CQLTimeout"),
+			Hosts:             cctx.StringSlice("hosts"),
+			ConnectString:     cctx.String("connect-string"),
+			CQLTimeout:        cctx.Int("CQLTimeout"),
+			InsertConcurrency: cctx.Int("insert-concurrency"),
 		}
 
 		// One of the migrations requires a miner address. But we don't want to
@@ -224,6 +234,11 @@ var yugabyteMigrateCmd = &cli.Command{
 			Usage: "default miner address eg f1234",
 		},
 		&cli.IntFlag{
+			Name:  "insert-concurrency",
+			Usage: "the number of concurrent tasks that each add index operation is split into",
+			Value: DefaultInsertConcurrency,
+		},
+		&cli.IntFlag{
 			Name:     "CQLTimeout",
 			Usage:    "client timeout value in seconds for CQL queries",
 			Required: false,
@@ -236,9 +251,10 @@ var yugabyteMigrateCmd = &cli.Command{
 
 		// Create a yugabyte data service
 		settings := yugabyte.DBSettings{
-			Hosts:         cctx.StringSlice("hosts"),
-			ConnectString: cctx.String("connect-string"),
-			CQLTimeout:    cctx.Int("CQLTimeout"),
+			Hosts:             cctx.StringSlice("hosts"),
+			ConnectString:     cctx.String("connect-string"),
+			CQLTimeout:        cctx.Int("CQLTimeout"),
+			InsertConcurrency: cctx.Int("insert-concurrency"),
 		}
 
 		maddr := migrations.DisabledMinerAddr
@@ -281,6 +297,11 @@ var yugabyteAddIndexCmd = &cli.Command{
 			Required: true,
 		},
 		&cli.IntFlag{
+			Name:  "insert-concurrency",
+			Usage: "the number of concurrent tasks that each add index operation is split into",
+			Value: DefaultInsertConcurrency,
+		},
+		&cli.IntFlag{
 			Name:     "CQLTimeout",
 			Usage:    "client timeout value in seconds for CQL queries",
 			Required: false,
@@ -292,9 +313,10 @@ var yugabyteAddIndexCmd = &cli.Command{
 
 		// Create a yugabyte data service
 		settings := yugabyte.DBSettings{
-			Hosts:         cctx.StringSlice("hosts"),
-			ConnectString: cctx.String("connect-string"),
-			CQLTimeout:    cctx.Int("CQLTimeout"),
+			Hosts:             cctx.StringSlice("hosts"),
+			ConnectString:     cctx.String("connect-string"),
+			CQLTimeout:        cctx.Int("CQLTimeout"),
+			InsertConcurrency: cctx.Int("insert-concurrency"),
 		}
 
 		migrator := yugabyte.NewMigrator(settings, migrations.DisabledMinerAddr)

--- a/extern/boostd-data/yugabyte/service.go
+++ b/extern/boostd-data/yugabyte/service.go
@@ -34,7 +34,8 @@ const CqlTimeout = 60
 
 // The Cassandra driver has a 50k limit on batch statements. Keeping
 // batch size small makes sure we're under the limit.
-const InsertBatchSize = 10000
+const InsertBatchSize = 10_000
+const MaxInsertBatchSize = 50_000
 
 const InsertConcurrency = 4
 
@@ -80,6 +81,9 @@ func NewStore(settings DBSettings, migrator *Migrator, opts ...StoreOpt) *Store 
 	}
 	if settings.InsertBatchSize == 0 {
 		settings.InsertBatchSize = InsertBatchSize
+	}
+	if settings.InsertBatchSize > MaxInsertBatchSize {
+		settings.InsertBatchSize = MaxInsertBatchSize
 	}
 	if settings.InsertConcurrency == 0 {
 		settings.InsertConcurrency = InsertConcurrency

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -24,7 +24,7 @@ const (
 var MaxTraversalLinks uint64 = 32 * (1 << 20)
 
 const (
-	DefaultAddIndexConcurrency = 4
+	DefaultAddIndexConcurrency = 1
 )
 
 func init() {

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -23,6 +23,10 @@ const (
 // CommP and traversing a DAG with graphsync; invokes a budget on DAG depth and density.
 var MaxTraversalLinks uint64 = 32 * (1 << 20)
 
+const (
+	DefaultAddIndexConcurrency = 4
+)
+
 func init() {
 	if envMaxTraversal, err := strconv.ParseUint(os.Getenv("LOTUS_MAX_TRAVERSAL_LINKS"), 10, 64); err == nil {
 		MaxTraversalLinks = envMaxTraversal
@@ -87,6 +91,7 @@ func DefaultBoost() *Boost {
 				Enabled: false,
 			},
 			ParallelAddIndexLimit: 4,
+			AddIndexConcurrency:   DefaultAddIndexConcurrency,
 			EmbeddedServicePort:   8042,
 			ServiceApiInfo:        "",
 			ServiceRPCTimeout:     Duration(15 * time.Minute),

--- a/node/config/doc_gen.go
+++ b/node/config/doc_gen.go
@@ -639,6 +639,13 @@ the piece from the sealing subsystem, creates an index of where each block
 is in the piece, and adds the index to the local index directory.`,
 		},
 		{
+			Name: "AddIndexConcurrency",
+			Type: "int",
+
+			Comment: `AddIndexConcurrency sets the number of concurrent tasks that each add index operation is split into.
+This setting is usefull to better utilise bandwidth between boostd and boost-data. The default value is 4.`,
+		},
+		{
 			Name: "EmbeddedServicePort",
 			Type: "uint64",
 

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -418,6 +418,9 @@ type LocalIndexDirectoryConfig struct {
 	// the piece from the sealing subsystem, creates an index of where each block
 	// is in the piece, and adds the index to the local index directory.
 	ParallelAddIndexLimit int
+	// AddIndexConcurrency sets the number of concurrent tasks that each add index operation is split into.
+	// This setting is usefull to better utilise bandwidth between boostd and boost-data. The default value is 4.
+	AddIndexConcurrency int
 	// The port that the embedded local index directory data service runs on.
 	// Set this value to zero to disable the embedded local index directory data service
 	// (in that case the local index directory data service must be running externally)

--- a/node/modules/piecedirectory.go
+++ b/node/modules/piecedirectory.go
@@ -136,7 +136,9 @@ func NewPieceDirectory(cfg *config.Boost) func(lc fx.Lifecycle, maddr dtypes.Min
 
 		// Create the piece directory implementation
 		pdctx, cancel := context.WithCancel(context.Background())
-		pd := piecedirectory.NewPieceDirectory(store, sa, cfg.LocalIndexDirectory.ParallelAddIndexLimit)
+		pd := piecedirectory.NewPieceDirectory(store, sa,
+			cfg.LocalIndexDirectory.ParallelAddIndexLimit,
+			piecedirectory.WithAddIndexConcurrency(cfg.LocalIndexDirectory.AddIndexConcurrency))
 		lc.Append(fx.Hook{
 			OnStart: func(ctx context.Context) error {
 				err := sa.Start(ctx, log)


### PR DESCRIPTION
Add two new configuration parameters:
* `AddIndexConcurrency` for `boostd` that sets the number of concurrent tasks that each add index operation can be split into;
* `insert-concurrency` for `boost-data` that sets the number of concurrent inserts that each add index operation can be split into;