### PR TITLE
fix: set default add index concurrency to 8

### DIFF
--- a/node/config/def.go
+++ b/node/config/def.go
@@ -24,7 +24,7 @@ const (
 var MaxTraversalLinks uint64 = 32 * (1 << 20)
 
 const (
-	DefaultAddIndexConcurrency = 1
+	DefaultAddIndexConcurrency = 8
 )
 
 func init() {

--- a/node/config/doc_gen.go
+++ b/node/config/doc_gen.go
@@ -643,7 +643,7 @@ is in the piece, and adds the index to the local index directory.`,
 			Type: "int",
 
 			Comment: `AddIndexConcurrency sets the number of concurrent tasks that each add index operation is split into.
-This setting is usefull to better utilise bandwidth between boostd and boost-data. The default value is 4.`,
+This setting is usefull to better utilise bandwidth between boostd and boost-data. The default value is 8.`,
 		},
 		{
 			Name: "EmbeddedServicePort",

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -419,7 +419,7 @@ type LocalIndexDirectoryConfig struct {
 	// is in the piece, and adds the index to the local index directory.
 	ParallelAddIndexLimit int
 	// AddIndexConcurrency sets the number of concurrent tasks that each add index operation is split into.
-	// This setting is usefull to better utilise bandwidth between boostd and boost-data. The default value is 4.
+	// This setting is usefull to better utilise bandwidth between boostd and boost-data. The default value is 8.
 	AddIndexConcurrency int
 	// The port that the embedded local index directory data service runs on.
 	// Set this value to zero to disable the embedded local index directory data service


### PR DESCRIPTION
Reverting back to 8 after fixing the the thread batch bug