### PR TITLE
boostx: print warning instead of exiting on api mismatch

### DIFF
--- a/cmd/boostx/sector.go
+++ b/cmd/boostx/sector.go
@@ -60,7 +60,7 @@ var sectorUnsealCmd = &cli.Command{
 
 		err = lib.CheckFullNodeApiVersion(ctx, fullnodeApi)
 		if err != nil {
-			return err
+			fmt.Printf("Warning: %s\n", err.Error())
 		}
 
 		// Connect to the storage API and create a sector accessor


### PR DESCRIPTION
Fixes: https://github.com/filecoin-project/boost/issues/1688