### PR TITLE
Update deal list page

### DIFF
--- a/gql/resolver.go
+++ b/gql/resolver.go
@@ -629,9 +629,9 @@ func (dr *dealResolver) message(ctx context.Context, checkpoint dealcheckpoints.
 	case dealcheckpoints.PublishConfirmed:
 		return "Adding to Sector"
 	case dealcheckpoints.AddedPiece:
-		return "Announcing"
+		return "Indexing"
 	case dealcheckpoints.IndexedAndAnnounced:
-		return dr.sealingState(ctx)
+		return "Indexed and Announced"
 	case dealcheckpoints.Complete:
 		switch dr.Err {
 		case "":
@@ -642,6 +642,13 @@ func (dr *dealResolver) message(ctx context.Context, checkpoint dealcheckpoints.
 		return "Error: " + dr.Err
 	}
 	return checkpoint.String()
+}
+
+func (dr *dealResolver) SealingState(ctx context.Context) string {
+	if dr.ProviderDealState.Checkpoint < dealcheckpoints.AddedPiece {
+		return "To be sealed"
+	}
+	return dr.sealingState(ctx)
 }
 
 func (dr *dealResolver) TransferSamples() []*transferPoint {

--- a/gql/schema.graphql
+++ b/gql/schema.graphql
@@ -82,6 +82,7 @@ type Deal {
   Sector: Sector!
   Message: String!
   Logs: [DealLog]!
+  SealingState: String!
 }
 
 type DirectDeal {

--- a/react/src/Components.js
+++ b/react/src/Components.js
@@ -15,7 +15,7 @@ export function PageContainer(props) {
 export function ShortDealLink(props) {
     const linkBase = props.isLegacy ? "/legacy-deals/" : "/deals/"
     return <Link to={linkBase + props.id}>
-        <ShortDealID id={props.id} />
+        {props.id}
     </Link>
 }
 

--- a/react/src/DealDetail.js
+++ b/react/src/DealDetail.js
@@ -547,8 +547,8 @@ export function DealStatusInfo(props) {
             <p>
                 <i>Indexing</i>
                 <p>
-                    Boost is indexing the deal in Local Index Directory(LID)
-                    and will be announcing the deal to the network so that clients know where to retrieve it.
+                    Boost is indexing the deal in the Local Index Directory(LID)
+                    and will be announcing the deal to the network so that clients know where to retrieve it from.
                 </p>
             </p>
             <p>

--- a/react/src/DealDetail.js
+++ b/react/src/DealDetail.js
@@ -188,12 +188,12 @@ export function DealDetail(props) {
                 </tr>
                 <tr>
                     <th>Current Epoch</th>
-                    <td>{currentEpoch ? addCommas(currentEpoch) : null}</td>
+                    <td>{currentEpoch ? currentEpoch.toString() : null}</td>
                 </tr>
                 <tr>
                     <th>Start Epoch</th>
                     <td>
-                        {addCommas(deal.StartEpoch)}
+                        {deal.StartEpoch.toString()}
                         <span className="aux">
                             {startEpochTime ? ' (' + moment(startEpochTime).fromNow() + ')' : null}
                         </span>
@@ -202,7 +202,7 @@ export function DealDetail(props) {
                 <tr>
                     <th>End Epoch</th>
                     <td>
-                        {addCommas(deal.EndEpoch)}
+                        {deal.EndEpoch.toString()}
                         <span className="aux">
                             {endEpochTime ? ' (' + moment(endEpochTime).fromNow() + ')' : null}
                         </span>
@@ -211,7 +211,7 @@ export function DealDetail(props) {
                 <tr>
                     <th>Duration</th>
                     <td>
-                        {addCommas(deal.EndEpoch-deal.StartEpoch)}
+                        {deal.EndEpoch-deal.StartEpoch}
                         <span className="aux">
                             {startEpochTime && endEpochTime ? ' (' + moment(endEpochTime).diff(startEpochTime, 'days') + ' days)' : null}
                         </span>
@@ -299,7 +299,7 @@ export function DealDetail(props) {
                 </tr>
                 <tr>
                     <th>Chain Deal ID</th>
-                    <td>{deal.ChainDealID ? addCommas(deal.ChainDealID) : null}</td>
+                    <td>{deal.ChainDealID ? deal.ChainDealID.toString() : null}</td>
                 </tr>
                 <tr>
                     <th>Checkpoint</th>
@@ -545,15 +545,16 @@ export function DealStatusInfo(props) {
                 </p>
             </p>
             <p>
-                <i>Announcing</i>
+                <i>Indexing</i>
                 <p>
-                    Boost is announcing the deal to the network so that clients know where to retrieve it.
+                    Boost is indexing the deal in Local Index Directory(LID)
+                    and will be announcing the deal to the network so that clients know where to retrieve it.
                 </p>
             </p>
             <p>
-                <i>Sealing</i>
+                <i>IndexedAndAnnounced</i>
                 <p>
-                    The deal has been added to a sector and is now sealing.
+                    The deal has been indexed locally and announced to the network indexers.
                 </p>
             </p>
             <p>

--- a/react/src/Deals.css
+++ b/react/src/Deals.css
@@ -11,7 +11,7 @@
 .deals th {
     white-space: nowrap;
     text-align: left;
-    opacity: 0.6;
+    color: #888888;
 }
 
 .deals td.start, .deals th.start {
@@ -27,7 +27,7 @@
 .deals td.deal-id {
     cursor: pointer;
     color: #465298;
-    width: 7em;
+    white-space: nowrap;
 }
 
 .deals td.client {
@@ -43,6 +43,10 @@
 
 .deals td.message {
     width: 100%;
+}
+
+.deals td.sealing {
+    white-space: nowrap;
 }
 
 .deals tr.error {
@@ -161,4 +165,8 @@
 .search-filters hr {
     border: 1px solid #DDD;
     margin: 1em 0em;
+}
+
+.info-box {
+    opacity: 1;
 }

--- a/react/src/Deals.js
+++ b/react/src/Deals.js
@@ -17,9 +17,10 @@ import columnsGapImg from './bootstrap-icons/icons/columns-gap.svg'
 import xImg from './bootstrap-icons/icons/x-lg.svg'
 import './Deals.css'
 import {Pagination} from "./Pagination";
-import {DealActions, IsPaused, IsTransferring, IsOfflineWaitingForData} from "./DealDetail";
+import {DealActions, IsPaused, IsTransferring, IsOfflineWaitingForData, DealStatusInfo} from "./DealDetail";
 import {humanTransferRate} from "./DealTransfers";
 import {DirectDealsCount} from "./DirectDeals";
+import {Info} from "./Info";
 
 const dealsBasePath = '/storage-deals'
 
@@ -145,8 +146,11 @@ function StorageDealsContent(props) {
                 <th onClick={toggleTimestampFormat} className="start">Start</th>
                 <th>Deal ID</th>
                 <th>Size</th>
+                <th>On Chain ID</th>
                 <th>Client</th>
-                <th>State</th>
+                <th>Sealing State<SealingStatusInfo /></th>
+                <th>Deal State<DealStatusInfo /></th>
+
             </tr>
 
             {deals.map(deal => (
@@ -305,8 +309,16 @@ function DealRow(props) {
                 <ShortDealLink id={deal.ID} />
             </td>
             <td className="size">{humanFileSize(deal.Transfer.Size)}</td>
+            <td className="message-text">{deal.ChainDealID ? deal.ChainDealID.toString() : null}</td>
             <td className={'client ' + (isContractAddress(deal.ClientAddress) ? 'contract' : '')}>
                 <ShortClientAddress address={deal.ClientAddress} />
+            </td>
+            <td className="sealing">
+                <div className="message-content">
+                    <span className="message-text">
+                        {deal.SealingState}
+                    </span>
+                </div>
             </td>
             <td className="message">
                 <div className="message-content">
@@ -383,4 +395,26 @@ export function StorageDealsMenuItem(props) {
 
 function scrollTop() {
     window.scrollTo({ top: 0, behavior: "smooth" })
+}
+
+
+export function SealingStatusInfo(props) {
+    return <span className="deal-status-info">
+        <Info>
+            The deal can be in one of the following sealing states:
+            <p>
+                <i>To be Sealed</i><br/>
+                <p>
+                    The storage deal is being processed by Boost before being handed off
+                    to the sealer.
+                </p>
+            </p>
+            <p>
+                <i>Sealer: </i><br/>
+                <p>
+                    The deal has been handed off to the sealing subsystem and is being sealed.
+                </p>
+            </p>
+        </Info>
+    </span>
 }

--- a/react/src/Deals.js
+++ b/react/src/Deals.js
@@ -145,7 +145,7 @@ function StorageDealsContent(props) {
             <tr>
                 <th onClick={toggleTimestampFormat} className="start">Start</th>
                 <th>Deal ID</th>
-                <th>Size</th>
+                <th>Size<SizeInfo /></th>
                 <th>On Chain ID</th>
                 <th>Client</th>
                 <th>Sealing State<SealingStatusInfo /></th>
@@ -308,7 +308,7 @@ function DealRow(props) {
             <td className="deal-id">
                 <ShortDealLink id={deal.ID} />
             </td>
-            <td className="size">{humanFileSize(deal.Transfer.Size)}</td>
+            <td className="size">{deal.IsOffline ? humanFileSize(deal.PieceSize) : humanFileSize(deal.Transfer.Size)}</td>
             <td className="message-text">{deal.ChainDealID ? deal.ChainDealID.toString() : null}</td>
             <td className={'client ' + (isContractAddress(deal.ClientAddress) ? 'contract' : '')}>
                 <ShortClientAddress address={deal.ClientAddress} />
@@ -413,6 +413,26 @@ export function SealingStatusInfo(props) {
                 <i>Sealer: </i><br/>
                 <p>
                     The deal has been handed off to the sealing subsystem and is being sealed.
+                </p>
+            </p>
+        </Info>
+    </span>
+}
+
+export function SizeInfo(props) {
+    return <span className="deal-status-info">
+        <Info>
+            Size column displays different sizes based on the deal type
+            <p>
+                <i>Online Deals</i><br/>
+                <p>
+                    Transfer Size or the car size specified in the deal proposal
+                </p>
+            </p>
+            <p>
+                <i>Offline</i><br/>
+                <p>
+                    Piece size specified in the deal proposal
                 </p>
             </p>
         </Info>

--- a/react/src/LegacyDealDetail.js
+++ b/react/src/LegacyDealDetail.js
@@ -115,12 +115,12 @@ export function LegacyDealDetail(props) {
                 </tr>
                 <tr>
                     <th>Current Epoch</th>
-                    <td>{currentEpoch ? addCommas(currentEpoch) : null}</td>
+                    <td>{currentEpoch ? currentEpoch.toString() : null}</td>
                 </tr>
                 <tr>
                     <th>Start Epoch</th>
                     <td>
-                        {addCommas(deal.StartEpoch)}
+                        {deal.StartEpoch.toString()}
                         <span className="aux">
                             {startEpochTime ? ' (' + moment(startEpochTime).fromNow() + ')' : null}
                         </span>
@@ -129,7 +129,7 @@ export function LegacyDealDetail(props) {
                 <tr>
                     <th>End Epoch</th>
                     <td>
-                        {addCommas(deal.EndEpoch)}
+                        {deal.EndEpoch.toString()}
                         <span className="aux">
                             {endEpochTime ? ' (' + moment(endEpochTime).fromNow() + ')' : null}
                         </span>

--- a/react/src/LegacyDeals.js
+++ b/react/src/LegacyDeals.js
@@ -94,6 +94,7 @@ function LegacyStorageDealsContent(props) {
                 <th className="start" onClick={toggleTimestampFormat}>Start</th>
                 <th>Deal ID</th>
                 <th>Piece Size</th>
+                <th>On Chain ID</th>
                 <th>Client</th>
                 <th>State</th>
             </tr>
@@ -138,6 +139,7 @@ function DealRow(props) {
                 </Link>
             </td>
             <td className="piece-size">{humanFileSize(deal.PieceSize)}</td>
+            <td className="message-text">{deal.ChainDealID ? deal.ChainDealID.toString() : null}</td>
             <td className="client">
                 <ShortClientAddress address={deal.ClientAddress} />
             </td>

--- a/react/src/ProposalLogs.css
+++ b/react/src/ProposalLogs.css
@@ -29,7 +29,7 @@
 }
 
 .logs td.deal-id {
-    min-width: 7em;
+    white-space: nowrap;
 }
 
 .logs td.deal-id.accepted {

--- a/react/src/ProposalLogs.js
+++ b/react/src/ProposalLogs.js
@@ -154,7 +154,9 @@ function LogRow(props) {
             </td>
             <td className="deal-id">
                 <span id={copyId} className="copy" onClick={dealIDToClipboard} title="Copy deal uuid to clipboard"></span>
-                {log.Accepted ? <ShortDealLink id={log.DealUUID} /> : <ShortDealID id={log.DealUUID} />}
+                <div className="deal-id">
+                    {log.Accepted ? <ShortDealLink id={log.DealUUID} /> : log.DealUUID}
+                </div>
             </td>
             <td className="size">
                 {humanFileSize(log.PieceSize)}

--- a/react/src/gql.js
+++ b/react/src/gql.js
@@ -99,6 +99,7 @@ const DealsListQuery = gql`
                 Message
                 SealingState
                 ChainDealID
+                PieceSize
                 Transfer {
                     Type
                     Size

--- a/react/src/gql.js
+++ b/react/src/gql.js
@@ -97,6 +97,8 @@ const DealsListQuery = gql`
                 Err
                 Retry
                 Message
+                SealingState
+                ChainDealID
                 Transfer {
                     Type
                     Size
@@ -138,6 +140,7 @@ const LegacyDealsListQuery = gql`
                 Status
                 Message
                 SectorNumber
+                ChainDealID
             }
             totalCount
             more

--- a/storagemarket/deal_execution.go
+++ b/storagemarket/deal_execution.go
@@ -109,8 +109,6 @@ func (p *Provider) execDeal(deal *smtypes.ProviderDealState, dh *dealHandler) (d
 			}
 		}
 		deal.NBytesReceived = fi.Size()
-		// To display correct size for offline deals
-		deal.Transfer.Size = uint64(fi.Size())
 		p.dealLogger.Infow(deal.DealUuid, "size of "+transferType, "filepath", deal.InboundFilePath, "size", fi.Size())
 	} else if !deal.IsOffline {
 		// For online deals where the deal has already been handed to the sealer,

--- a/storagemarket/deal_execution.go
+++ b/storagemarket/deal_execution.go
@@ -109,6 +109,8 @@ func (p *Provider) execDeal(deal *smtypes.ProviderDealState, dh *dealHandler) (d
 			}
 		}
 		deal.NBytesReceived = fi.Size()
+		// To display correct size for offline deals
+		deal.Transfer.Size = uint64(fi.Size())
 		p.dealLogger.Infow(deal.DealUuid, "size of "+transferType, "filepath", deal.InboundFilePath, "size", fi.Size())
 	} else if !deal.IsOffline {
 		// For online deals where the deal has already been handed to the sealer,


### PR DESCRIPTION
This PR makes the following changes:
1. Add a new column for on chain deal ID (Boost and Legacy deals)
<img width="1412" alt="Screenshot 2023-12-01 at 5 48 30 PM" src="https://github.com/filecoin-project/boost/assets/88259624/c2a1bc5f-08e7-4297-bdf3-c3a78f83f899">
<img width="1655" alt="Screenshot 2023-12-01 at 5 47 46 PM" src="https://github.com/filecoin-project/boost/assets/88259624/ecdb6e79-7c8a-401a-91a8-3f4bc43bf333">
2. Create a new column "Sealing Status" and create an info button with description
<img width="1655" alt="Screenshot 2023-12-01 at 5 47 52 PM" src="https://github.com/filecoin-project/boost/assets/88259624/7645dd22-0afa-4550-b16b-d8a2a5e37d3e">

3. Add info button to deal Status column
<img width="1655" alt="Screenshot 2023-12-01 at 5 48 00 PM" src="https://github.com/filecoin-project/boost/assets/88259624/ef12d641-b73b-4338-9caf-63ca668941c3">

4. Fix Size for offline deals (we cannot fix for existing deals but new ones should display and retain correct size)
<img width="1412" alt="Screenshot 2023-12-04 at 2 41 46 PM" src="https://github.com/filecoin-project/boost/assets/88259624/59137916-17fe-4d2e-b066-5bc72af7ebf6">
<img width="1412" alt="Screenshot 2023-12-04 at 2 45 52 PM" src="https://github.com/filecoin-project/boost/assets/88259624/398519a5-48a3-497b-9122-117d993a7b3e">


5. The onchainDealID and epochs do not have comma anymore
<img width="966" alt="Screenshot 2023-12-01 at 5 48 13 PM" src="https://github.com/filecoin-project/boost/assets/88259624/879f25bc-aba4-401a-8723-787b8c57674a">
