### PR TITLE
fix: handle complete checkpoint in UI deal list

### DIFF
--- a/gql/resolver.go
+++ b/gql/resolver.go
@@ -648,6 +648,9 @@ func (dr *dealResolver) SealingState(ctx context.Context) string {
 	if dr.ProviderDealState.Checkpoint < dealcheckpoints.AddedPiece {
 		return "To be sealed"
 	}
+	if dr.ProviderDealState.Checkpoint == dealcheckpoints.Complete {
+		return "Complete"
+	}
 	return dr.sealingState(ctx)
 }
 

--- a/react/src/Deals.js
+++ b/react/src/Deals.js
@@ -482,6 +482,12 @@ export function SealingStatusInfo(props) {
                     The deal has been handed off to the sealing subsystem and is being sealed.
                 </p>
             </p>
+            <p>
+                <i>Complete</i><br/>
+                <p>
+                    The sector containing the deal has expired or the deal errored out.
+                </p>
+            </p>
         </Info>
     </span>
 }


### PR DESCRIPTION
This fixes a bug in UI where if a deal never gets added to a sector and moved to "Complete" checkpoint due to an error then the UI displays the sealing status of sector "0". 