### PR TITLE
fix: fix ipni multihash mismatch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 	github.com/ipld/go-car/v2 v2.13.1
 	github.com/ipld/go-ipld-prime v0.21.0
 	github.com/ipld/go-ipld-selector-text-lite v0.0.1
-	github.com/ipni/index-provider v0.14.2
+	github.com/ipni/index-provider v0.14.3-0.20231208131100-e11dffd1d360
 	github.com/jbenet/go-random v0.0.0-20190219211222-123a90aedc0c
 	github.com/jpillora/backoff v1.0.0
 	github.com/kelseyhightower/envconfig v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -948,6 +948,8 @@ github.com/ipni/go-libipni v0.5.2 h1:9vaYOnR4dskd8p88NOboqI6yVqBwYPNCQ/zOaRSr59I
 github.com/ipni/go-libipni v0.5.2/go.mod h1:UnrhEqjVI2Z2HXlaieOBONJmtW557nZkYpB4IIsMD+s=
 github.com/ipni/index-provider v0.14.2 h1:daA3IFnI2n2x/mL0K91SQHNLq6Vvfp5q4uFX9G4glvE=
 github.com/ipni/index-provider v0.14.2/go.mod h1:mArx7Ou3Y62fIDSj9a1Neh5G14xQcwXGbfEbf47vyuM=
+github.com/ipni/index-provider v0.14.3-0.20231208131100-e11dffd1d360 h1:G2IxByl66yF/ZJWFm/6VzBe0KYvrqLipwzlv6bqUB0M=
+github.com/ipni/index-provider v0.14.3-0.20231208131100-e11dffd1d360/go.mod h1:mArx7Ou3Y62fIDSj9a1Neh5G14xQcwXGbfEbf47vyuM=
 github.com/ipni/ipni-cli v0.1.1 h1:TjYAf5CrVx/loQtWQnwEnIYjW7hvRJDRyIibT7WbHjE=
 github.com/ipni/ipni-cli v0.1.1/go.mod h1:TAOkJwc9OBsx5gRy8iyoWgb8AbtJcT482cJUGDTxnHg=
 github.com/ipni/storetheindex v0.8.1 h1:3uHclkcQWlIXQx+We4tbGF/XzoZYERz3so34xQbUmZE=

--- a/node/modules/storageminer_idxprov.go
+++ b/node/modules/storageminer_idxprov.go
@@ -3,7 +3,6 @@ package modules
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	"github.com/filecoin-project/boost/build"
 	"github.com/filecoin-project/boost/indexprovider"
@@ -23,13 +22,11 @@ import (
 	"github.com/ipld/go-ipld-prime/datamodel"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	"github.com/ipni/go-libipni/dagsync/dtsync"
-	"github.com/ipni/go-libipni/metadata"
 	provider "github.com/ipni/index-provider"
 	"github.com/ipni/index-provider/engine"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
-	"github.com/multiformats/go-multiaddr"
 	"go.uber.org/fx"
 	"golang.org/x/xerrors"
 )
@@ -72,14 +69,6 @@ func IndexProvider(cfg config.IndexProviderConfig) func(params IdxProv, marketHo
 			marketHostAddrsStr = append(marketHostAddrsStr, a.String())
 		}
 
-		type engineHolder struct {
-			e *engine.Engine
-		}
-
-		eholder := &engineHolder{}
-		mretries := make(map[cid.Cid]int)
-		var elock sync.RWMutex
-
 		ipds := namespace.Wrap(args.Datastore, datastore.NewKey("/index-provider"))
 		var opts = []engine.Option{
 			engine.WithDatastore(ipds),
@@ -90,58 +79,12 @@ func IndexProvider(cfg config.IndexProviderConfig) func(params IdxProv, marketHo
 			engine.WithTopicName(topicName),
 			engine.WithPurgeCacheOnStart(cfg.PurgeCacheOnStart),
 			engine.WithStorageReadOpenerErrorHook(func(lc ipld.LinkContext, l ipld.Link, err error) error {
-				if err != engine.ErrEntriesLinkMismatch {
-					return err
+				if err == engine.ErrEntriesLinkMismatch {
+					c := l.(cidlink.Link).Cid
+					log.Warnw("Encountered ErrEntriesLinkMismatch. Skipping the ad.", "cid", c)
+					return ipld.ErrNotExists{}
 				}
-				errNotExists := ipld.ErrNotExists{}
-				c := l.(cidlink.Link).Cid
-				elock.RLock()
-				retries := mretries[c]
-				elock.RUnlock()
-				if retries > maxAdPublishRetries {
-					log.Warnw("mmismatch: max number of ad publish retries has been reached", "cid", c)
-					return errNotExists
-				}
-				ctx := lc.Ctx
-				adv, err := eholder.e.GetAdv(ctx, c)
-				if err != nil || adv == nil {
-					log.Warnw("mmismatch: can't find an ad to republish in the engine", "cid", c, "err", err)
-					return errNotExists
-				}
-				prov := peer.ID(adv.Provider)
-				if rcid, err := eholder.e.NotifyRemove(ctx, prov, adv.ContextID); err != nil {
-					log.Warnw("mmismatch: error calling NotifyRemove", "cid", c, "err", err)
-					return errNotExists
-				} else {
-					log.Info("mmismatch: successfully published a removal advertisement", "cid", c, "removalCid", rcid)
-				}
-
-				maddrs := make([]multiaddr.Multiaddr, 0, len(adv.Addresses))
-				for _, addr := range adv.Addresses {
-					if ma, err := multiaddr.NewMultiaddr(addr); err != nil {
-						log.Warnw("mmismatch: error decoding multiaddress", "cid", c, "err", err)
-						return errNotExists
-					} else {
-						maddrs = append(maddrs, ma)
-					}
-				}
-				md := metadata.Metadata{}
-				if err = md.UnmarshalBinary(adv.Metadata); err != nil {
-					log.Warnw("mmismatch: error decoding metadata", "cid", c, "err", err)
-					return errNotExists
-				}
-
-				if acid, err := eholder.e.NotifyPut(ctx, &peer.AddrInfo{ID: prov, Addrs: maddrs}, adv.ContextID, md); err != nil {
-					log.Warnw("mmismatch: error calling NotifyPut", "cid", c, "err", err)
-					return errNotExists
-				} else {
-					log.Info("mmismatch: successfully published a new advertisement", "cid", c, "newCid", acid)
-				}
-
-				elock.Lock()
-				mretries[c] = mretries[c] + 1
-				elock.Unlock()
-				return errNotExists
+				return err
 			}),
 		}
 
@@ -238,7 +181,6 @@ func IndexProvider(cfg config.IndexProviderConfig) func(params IdxProv, marketHo
 			},
 		})
 
-		eholder.e = e
 		return e, nil
 	}
 }


### PR DESCRIPTION
When ipni multihash mismatch happens, generate a remove followed by a new add to fix the error.