### PR TITLE
fix: clean up and fix retrieval framework & tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -213,7 +213,7 @@ require (
 	github.com/ipfs/go-ipld-cbor v0.1.0
 	github.com/ipfs/go-log v1.0.5 // indirect
 	github.com/ipfs/go-peertaskqueue v0.8.1 // indirect
-	github.com/ipfs/go-unixfsnode v1.8.0
+	github.com/ipfs/go-unixfsnode v1.9.0
 	github.com/ipfs/go-verifcid v0.0.2 // indirect
 	github.com/ipld/go-codec-dagpb v1.6.0
 	github.com/ipld/go-ipld-adl-hamt v0.0.0-20220616142416-9004dbd839e0 // indirect
@@ -327,6 +327,7 @@ require (
 	github.com/filecoin-project/lotus v1.23.4-rc1
 	github.com/ipfs/boxo v0.12.0
 	github.com/ipfs/kubo v0.22.0
+	github.com/ipld/go-trustless-utils v0.4.1
 	github.com/ipni/go-libipni v0.5.1
 	github.com/ipni/ipni-cli v0.1.1
 	github.com/schollz/progressbar/v3 v3.13.1

--- a/go.sum
+++ b/go.sum
@@ -890,8 +890,8 @@ github.com/ipfs/go-unixfs v0.2.2-0.20190827150610-868af2e9e5cb/go.mod h1:IwAAgul
 github.com/ipfs/go-unixfs v0.3.1/go.mod h1:h4qfQYzghiIc8ZNFKiLMFWOTzrWIAtzYQ59W/pCFf1o=
 github.com/ipfs/go-unixfs v0.4.5 h1:wj8JhxvV1G6CD7swACwSKYa+NgtdWC1RUit+gFnymDU=
 github.com/ipfs/go-unixfsnode v1.4.0/go.mod h1:qc7YFFZ8tABc58p62HnIYbUMwj9chhUuFWmxSokfePo=
-github.com/ipfs/go-unixfsnode v1.8.0 h1:yCkakzuE365glu+YkgzZt6p38CSVEBPgngL9ZkfnyQU=
-github.com/ipfs/go-unixfsnode v1.8.0/go.mod h1:HxRu9HYHOjK6HUqFBAi++7DVoWAHn0o4v/nZ/VA+0g8=
+github.com/ipfs/go-unixfsnode v1.9.0 h1:ubEhQhr22sPAKO2DNsyVBW7YB/zA8Zkif25aBvz8rc8=
+github.com/ipfs/go-unixfsnode v1.9.0/go.mod h1:HxRu9HYHOjK6HUqFBAi++7DVoWAHn0o4v/nZ/VA+0g8=
 github.com/ipfs/go-verifcid v0.0.1/go.mod h1:5Hrva5KBeIog4A+UpqlaIU+DEstipcJYQQZc0g37pY0=
 github.com/ipfs/go-verifcid v0.0.2 h1:XPnUv0XmdH+ZIhLGKg6U2vaPaRDXb9urMyNVCE7uvTs=
 github.com/ipfs/go-verifcid v0.0.2/go.mod h1:40cD9x1y4OWnFXbLNJYRe7MpNvWlMn3LZAG5Wb4xnPU=
@@ -926,6 +926,9 @@ github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20211210234204-ce2a1c70cd
 github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20230102063945-1a409dc236dd h1:gMlw/MhNr2Wtp5RwGdsW23cs+yCuj9k2ON7i9MiJlRo=
 github.com/ipld/go-ipld-selector-text-lite v0.0.1 h1:lNqFsQpBHc3p5xHob2KvEg/iM5dIFn6iw4L/Hh+kS1Y=
 github.com/ipld/go-ipld-selector-text-lite v0.0.1/go.mod h1:U2CQmFb+uWzfIEF3I1arrDa5rwtj00PrpiwwCO+k1RM=
+github.com/ipld/go-trustless-utils v0.4.1 h1:puA14381Hg2LzH724mZ5ZFKFx+FFjjT5fPFs01vwlgM=
+github.com/ipld/go-trustless-utils v0.4.1/go.mod h1:DgGuyfJ33goYwYVisjnxrlra0HVmZuHWVisVIkzVo1o=
+github.com/ipld/ipld/specs v0.0.0-20231012031213-54d3b21deda4 h1:0VXv637/xpI0Pb5J8K+K8iRtTw4DOcxs0MB1HMzfwNY=
 github.com/ipni/go-libipni v0.5.1 h1:HumuJtKmV8RoDpBakLgxCSl5QPiD2ljTZl/NOyXO6nM=
 github.com/ipni/go-libipni v0.5.1/go.mod h1:UnrhEqjVI2Z2HXlaieOBONJmtW557nZkYpB4IIsMD+s=
 github.com/ipni/index-provider v0.14.2 h1:daA3IFnI2n2x/mL0K91SQHNLq6Vvfp5q4uFX9G4glvE=

--- a/itests/dummydeal_offline_test.go
+++ b/itests/dummydeal_offline_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/lotus/itests/kit"
 	"github.com/google/uuid"
+	trustlessutils "github.com/ipld/go-trustless-utils"
 	"github.com/stretchr/testify/require"
 )
 
@@ -46,6 +47,11 @@ func TestDummydealOffline(t *testing.T) {
 	err = f.WaitForDealAddedToSector(offlineDealUuid)
 	require.NoError(t, err)
 
-	outFile := f.Retrieve(ctx, t, tempdir, rootCid, dealRes.DealParams.ClientDealProposal.Proposal.PieceCID, true, nil)
+	outFile := f.Retrieve(
+		ctx,
+		t,
+		trustlessutils.Request{Root: rootCid, Scope: trustlessutils.DagScopeAll},
+		true,
+	)
 	kit.AssertFilesEqual(t, randomFilepath, outFile)
 }

--- a/itests/dummydeal_test.go
+++ b/itests/dummydeal_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/lotus/itests/kit"
 	"github.com/google/uuid"
+	trustlessutils "github.com/ipld/go-trustless-utils"
 	"github.com/stretchr/testify/require"
 )
 
@@ -94,6 +95,11 @@ func TestDummydealOnline(t *testing.T) {
 	require.NoError(t, err)
 
 	// rootCid is an identity CID
-	outFile := f.Retrieve(ctx, t, tempdir, rootCid, res.DealParams.ClientDealProposal.Proposal.PieceCID, true, nil)
+	outFile := f.Retrieve(
+		ctx,
+		t,
+		trustlessutils.Request{Root: rootCid, Scope: trustlessutils.DagScopeAll},
+		true,
+	)
 	kit.AssertFilesEqual(t, randomFilepath, outFile)
 }

--- a/itests/graphsync_identity_cid_test.go
+++ b/itests/graphsync_identity_cid_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/ipld/go-ipld-prime/fluent/qp"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	"github.com/ipld/go-ipld-prime/node/basicnode"
-	selectorparse "github.com/ipld/go-ipld-prime/traversal/selector/parse"
+	trustlessutils "github.com/ipld/go-trustless-utils"
 	"github.com/multiformats/go-multihash"
 	"github.com/stretchr/testify/require"
 )
@@ -110,7 +110,6 @@ func TestDealAndRetrievalWithIdentityCID(t *testing.T) {
 	log.Debugw("got response from MarketDummyDeal", "res", spew.Sdump(res))
 	dealCid, err := res.DealParams.ClientDealProposal.Proposal.Cid()
 	require.NoError(t, err)
-	pieceCid := res.DealParams.ClientDealProposal.Proposal.PieceCID
 	log.Infof("deal ID is : %s", dealCid.String())
 	// Wait for the first deal to be added to a sector and cleaned up so space is made
 	err = f.WaitForDealAddedToSector(dealUuid)
@@ -121,7 +120,7 @@ func TestDealAndRetrievalWithIdentityCID(t *testing.T) {
 	// Deal is stored and sealed, attempt different retrieval forms
 
 	log.Debugw("deal is sealed, starting retrieval", "cid", dealCid.String(), "root", root.String())
-	outPath := f.Retrieve(ctx, t, tempdir, root, pieceCid, false, selectorparse.CommonSelector_ExploreAllRecursively)
+	outPath := f.Retrieve(ctx, t, trustlessutils.Request{Root: root, Scope: trustlessutils.DagScopeAll}, false)
 
 	// Inspect what we got
 	gotCids, err := testutil.CidsInCar(outPath)

--- a/itests/multiminer_retrieval_graphsync_test.go
+++ b/itests/multiminer_retrieval_graphsync_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/filecoin-project/boost/itests/shared"
 	"github.com/filecoin-project/lotus/itests/kit"
+	trustlessutils "github.com/ipld/go-trustless-utils"
 )
 
 func TestMultiMinerRetrievalGraphsync(t *testing.T) {
@@ -17,7 +18,12 @@ func TestMultiMinerRetrievalGraphsync(t *testing.T) {
 		// - recognize that the deal is for a sector on the first miner
 		// - read the data for the deal from the first miner
 		t.Logf("deal is added to piece, starting retrieval of root %s", rt.RootCid)
-		outPath := rt.BoostAndMiner2.Retrieve(ctx, t, rt.TempDir, rt.RootCid, rt.PieceCid, true, nil)
+		outPath := rt.BoostAndMiner2.Retrieve(
+			ctx,
+			t,
+			trustlessutils.Request{Root: rt.RootCid, Scope: trustlessutils.DagScopeAll},
+			true,
+		)
 
 		t.Logf("retrieval is done, compare in- and out- files in: %s, out: %s", rt.SampleFilePath, outPath)
 		kit.AssertFilesEqual(t, rt.SampleFilePath, outPath)

--- a/retrievalmarket/client/client.go
+++ b/retrievalmarket/client/client.go
@@ -31,6 +31,7 @@ import (
 	"github.com/ipfs/go-datastore"
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/ipld/go-ipld-prime"
+	"github.com/ipld/go-ipld-prime/codec/dagcbor"
 	selectorparse "github.com/ipld/go-ipld-prime/traversal/selector/parse"
 	"github.com/libp2p/go-libp2p/core/host"
 	inet "github.com/libp2p/go-libp2p/core/network"
@@ -537,7 +538,15 @@ func (c *Client) retrieveContentFromPeerWithProgressCallback(
 	defer unsubscribe()
 
 	// Submit the retrieval deal proposal to the miner
-	newchid, err := c.dataTransfer.OpenPullDataChannel(ctx, peerID, proposal, proposal.PayloadCID, selectorparse.CommonSelector_ExploreAllRecursively)
+	selector := selectorparse.CommonSelector_ExploreAllRecursively
+	if proposal.SelectorSpecified() {
+		var err error
+		selector, err = ipld.Decode(proposal.Selector.Raw, dagcbor.Decode)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode selector from proposal: %w", err)
+		}
+	}
+	newchid, err := c.dataTransfer.OpenPullDataChannel(ctx, peerID, proposal, proposal.PayloadCID, selector)
 	if err != nil {
 		// We could fail before a successful proposal
 		// publish event failure


### PR DESCRIPTION
* Use new go-trustless-utils primitives and traversal tools for requesting and verifying test retrievals
* Simplify Framework#Retrieve and remove test logic that doesn't make sense for these kinds of retrievals
* Wait for full startup of data transfer when making a retrieval client

Some lint errors in here that can be taken care of separately.
