### PR TITLE
fix: UI deal error messages

### DIFF
--- a/piecedirectory/piecedirectory.go
+++ b/piecedirectory/piecedirectory.go
@@ -795,7 +795,7 @@ func (ps *PieceDirectory) BlockstoreGet(ctx context.Context, c cid.Cid) ([]byte,
 			// Seek to the section offset
 			readerAt := readerutil.NewReadSeekerFromReaderAt(reader, int64(offsetSize.Offset))
 			// Read the block data
-			readCid, data, err := util.ReadNode(bufio.NewReaderSize(readerAt, int(offsetSize.Size)))
+			readCid, data, err := util.ReadNode(bufio.NewReader(readerAt))
 			if err != nil {
 				return nil, fmt.Errorf("reading data for block %s from reader for piece %s: %w", c, pieceCid, err)
 			}

--- a/piecedirectory/piecedirectory.go
+++ b/piecedirectory/piecedirectory.go
@@ -795,7 +795,7 @@ func (ps *PieceDirectory) BlockstoreGet(ctx context.Context, c cid.Cid) ([]byte,
 			// Seek to the section offset
 			readerAt := readerutil.NewReadSeekerFromReaderAt(reader, int64(offsetSize.Offset))
 			// Read the block data
-			readCid, data, err := util.ReadNode(bufio.NewReader(readerAt))
+			readCid, data, err := util.ReadNode(bufio.NewReaderSize(readerAt, int(offsetSize.Size)))
 			if err != nil {
 				return nil, fmt.Errorf("reading data for block %s from reader for piece %s: %w", c, pieceCid, err)
 			}

--- a/react/src/DealDetail.js
+++ b/react/src/DealDetail.js
@@ -500,74 +500,74 @@ export function DealStatusInfo(props) {
             The deal can be in one of the following states:
             <p>
                 <i>Transfer Queued</i><br/>
-                <p>
+                <span>
                     The storage deal proposal has been accepted, and Boost is
                     about to start the data transfer.
-                </p>
+                </span>
             </p>
             <p>
                 <i>Awaiting Offline Data Import</i><br/>
-                <p>
+                <span>
                     The client has made an offline deal proposal, and Boost is
                     waiting for the Storage Provider operator to import the deal
                     data.
-                </p>
+                </span>
             </p>
             <p>
-                <i>Transferring</i>
-                <p>
+                <i>Transferring</i><br/>
+                <span>
                     The data for the deal is transferring.
-                </p>
+                </span>
             </p>
             <p>
-                <i>Transfer Complete</i>
-                <p>
+                <i>Transfer Complete</i><br/>
+                <span>
                     The data transfer is complete and Boost is verifying the data matches commp.
-                </p>
+                </span>
             </p>
             <p>
-                <i>Ready to Publish</i>
-                <p>
+                <i>Ready to Publish</i><br/>
+                <span>
                     The deal is in the batch publish queue, ready to be published.
-                </p>
+                </span>
             </p>
             <p>
-                <i>Awaiting Publish Confirmation</i>
-                <p>
+                <i>Awaiting Publish Confirmation</i><br/>
+                <span>
                     Boost sent a publish deal message for the deal and is waiting for on-chain confirmation.
-                </p>
+                </span>
             </p>
             <p>
-                <i>Adding to Sector</i>
-                <p>
+                <i>Adding to Sector</i><br/>
+                <span>
                     Boost is handing the deal off to the lotus-miner sealing subsystem
                     to be added to a sector.
-                </p>
+                </span>
             </p>
             <p>
-                <i>Indexing</i>
-                <p>
+                <i>Indexing</i><br/>
+                <span>
                     Boost is indexing the deal in the Local Index Directory(LID)
                     and will be announcing the deal to the network so that clients know where to retrieve it from.
-                </p>
+                </span>
             </p>
             <p>
-                <i>IndexedAndAnnounced</i>
-                <p>
+                <i>IndexedAndAnnounced</i><br/>
+                <span>
                     The deal has been indexed locally and announced to the network indexers.
-                </p>
+                </span>
             </p>
             <p>
-                <i>Complete</i>
-                <p>
+                <i>Complete</i><br/>
+                <span>
                     The deal has reached its duration and expired.
-                </p>
+                </span>
             </p>
             <p>
-                <i>Cancelled</i>
-                <p>
+                <i>Cancelled</i><br/>
+                <span>
                     The deal was cancelled.
-                </p>
+                </span>
             </p>
         </Info>
     </span>

--- a/react/src/Deals.js
+++ b/react/src/Deals.js
@@ -365,30 +365,15 @@ function DealRowAnnounceError({deal}) {
         })
 
         return function () {
-            warningImg.removeEventListener("mouseover")
-            messageBox.removeEventListener("mouseleave")
+            warningImg.removeEventListener("mouseover", this)
+            messageBox.removeEventListener("mouseleave", this)
         }
     })
-
-    const {data, loading, error} = useQuery(SectorStatusQuery, {
-        pollInterval: 10000,
-        fetchPolicy: 'network-only',
-        variables: {
-            sectorNumber: deal.Sector.ID
-        }
-    })
-
-    if (error) {
-        return <span>Sealer: {error.message}</span>
-    }
-    if (loading) {
-        return null
-    }
 
     return <div id={messageBoxId}>
         <span>
             <img id={warningImgElId} className="warning" src={warningImg} />
-            <span>Sealer: {data.sectorStatus.State}</span>
+            <span>Error: IndexingAndAnnouncing</span>
         </span>
         <span id={warningMsgElId} className="warning-msg">
             <span className="message-text">
@@ -471,22 +456,22 @@ export function SealingStatusInfo(props) {
             The deal can be in one of the following sealing states:
             <p>
                 <i>To be Sealed</i><br/>
-                <p>
+                <span>
                     The storage deal is being processed by Boost before being handed off
                     to the sealer.
-                </p>
+                </span>
             </p>
             <p>
                 <i>Sealer: </i><br/>
-                <p>
+                <span>
                     The deal has been handed off to the sealing subsystem and is being sealed.
-                </p>
+                </span>
             </p>
             <p>
                 <i>Complete</i><br/>
-                <p>
+                <span>
                     The sector containing the deal has expired or the deal errored out.
-                </p>
+                </span>
             </p>
         </Info>
     </span>
@@ -498,15 +483,15 @@ export function SizeInfo(props) {
             Size column displays different sizes based on the deal type
             <p>
                 <i>Online Deals</i><br/>
-                <p>
+                <span>
                     Transfer Size or the car size specified in the deal proposal
-                </p>
+                </span>
             </p>
             <p>
                 <i>Offline</i><br/>
-                <p>
+                <span>
                     Piece size specified in the deal proposal
-                </p>
+                </span>
             </p>
         </Info>
     </span>


### PR DESCRIPTION
This PRs fixes the following:

1. Deals page displaying sealing state instead of indexing error
Earlier:
<img width="1886" alt="Screenshot 2024-01-09 at 1 17 04 PM" src="https://github.com/filecoin-project/boost/assets/88259624/72db90f2-5c40-492b-9831-5228b8319697">
Now:
<img width="1886" alt="Screenshot 2024-01-09 at 2 24 34 PM" src="https://github.com/filecoin-project/boost/assets/88259624/f5e12346-030c-4823-9b1b-a4acf2f18d8f">

2. Some react errors about nesting paragraphs 
No console errors:
<img width="270" alt="Screenshot 2024-01-09 at 2 24 51 PM" src="https://github.com/filecoin-project/boost/assets/88259624/996b3a01-8c1d-4bda-94cd-d16542cc9749">
