### PR TITLE
fix: don't fail deals that have passed AP() but are not indexed

### DIFF
--- a/storagemarket/provider.go
+++ b/storagemarket/provider.go
@@ -449,8 +449,8 @@ func (p *Provider) Start() error {
 			continue
 		}
 
-		// Fail deals if start epoch has passed
-		if err := p.checkDealProposalStartEpoch(deal); err != nil {
+		// Fail deals if start epoch has passed and deal has still not been added to a sector
+		if deal.Checkpoint < dealcheckpoints.AddedPiece && p.checkDealProposalStartEpoch(deal) != nil {
 			go p.failDeal(dh.Publisher, deal, err, false)
 			continue
 		}

--- a/storagemarket/provider.go
+++ b/storagemarket/provider.go
@@ -450,9 +450,11 @@ func (p *Provider) Start() error {
 		}
 
 		// Fail deals if start epoch has passed and deal has still not been added to a sector
-		if deal.Checkpoint < dealcheckpoints.AddedPiece && p.checkDealProposalStartEpoch(deal) != nil {
-			go p.failDeal(dh.Publisher, deal, err, false)
-			continue
+		if deal.Checkpoint < dealcheckpoints.AddedPiece {
+			if serr := p.checkDealProposalStartEpoch(deal); serr != nil {
+				go p.failDeal(dh.Publisher, deal, serr, false)
+				continue
+			}
 		}
 
 		// If it's an offline deal, and the deal data hasn't yet been


### PR DESCRIPTION
This fix avoids failing deals on boostd restart which have been added to a sector but have not been indexed correctly. 