### PR TITLE
fix: remove on-the-fly indexing

### DIFF
--- a/piecedirectory/piecedirectory.go
+++ b/piecedirectory/piecedirectory.go
@@ -885,21 +885,8 @@ func (ps *PieceDirectory) BlockstoreGetSize(ctx context.Context, c cid.Cid) (int
 			return int(offsetSize.Size), nil
 		}
 
-		// The index is incomplete, so re-build the index on the fly
-		err = ps.BuildIndexForPiece(ctx, p)
-		if err != nil {
-			merr = multierror.Append(merr, fmt.Errorf("re-building index for piece %s: %w", p, err))
-			continue
-		}
+		merr = multierror.Append(merr, fmt.Errorf("piece %s is not indexed correctly", p))
 
-		// Now get the size again
-		offsetSize, err = ps.GetOffsetSize(ctx, p, c.Hash())
-		if err != nil {
-			merr = multierror.Append(merr, fmt.Errorf("getting size of cid %s in piece %s: %w", c, p, err))
-			continue
-		}
-
-		return int(offsetSize.Size), nil
 	}
 
 	return 0, merr

--- a/piecedirectory/piecedirectory_test_util.go
+++ b/piecedirectory/piecedirectory_test_util.go
@@ -234,6 +234,8 @@ func testImportedIndex(ctx context.Context, t *testing.T, cl *client.Store) {
 	// directory should re-build the index and then return the size.
 	pm := NewPieceDirectory(cl, pr, 1)
 	pm.Start(ctx)
+	err = pm.BuildIndexForPiece(ctx, pieceCid)
+	require.NoError(t, err)
 	sz, err := pm.BlockstoreGetSize(ctx, rec.Cid)
 	require.NoError(t, err)
 	require.Equal(t, len(blk.RawData()), sz)


### PR DESCRIPTION
We should avoid on-the-fly indexing as it can lead to continuous indexing attempts from HTTP and Bitswap retrievals. It is not very efficient in cases where unsealed sector is missing or IPNI is not updated correctly. 