### PR TITLE
fix: account for DDO in UI

### DIFF
--- a/db/directdeals.go
+++ b/db/directdeals.go
@@ -9,6 +9,7 @@ import (
 	"github.com/filecoin-project/boost/storagemarket/types"
 	"github.com/filecoin-project/boost/storagemarket/types/dealcheckpoints"
 	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/builtin/v9/verifreg"
 	"github.com/google/uuid"
 	"github.com/graph-gophers/graphql-go"
 	"github.com/ipfs/go-cid"
@@ -109,6 +110,14 @@ func (d *DirectDealsDB) ByPieceCID(ctx context.Context, pieceCid cid.Cid) ([]*ty
 
 func (d *DirectDealsDB) BySectorID(ctx context.Context, sectorID abi.SectorNumber) ([]*types.DirectDeal, error) {
 	return d.list(ctx, 0, 0, "SectorID=?", sectorID)
+}
+
+func (d *DirectDealsDB) ActiveByPieceAllocID(ctx context.Context, piece cid.Cid, alloc verifreg.AllocationId) ([]*types.DirectDeal, error) {
+	whereArgs := []interface{}{}
+	whereArgs = append(whereArgs, piece.String())
+	whereArgs = append(whereArgs, uint64(alloc))
+	whereArgs = append(whereArgs, dealcheckpoints.Complete.String())
+	return d.list(ctx, 0, 0, "PieceCID=? AND AllocationID=? AND Checkpoint != ?", whereArgs...)
 }
 
 func (d *DirectDealsDB) ListAll(ctx context.Context) ([]*types.DirectDeal, error) {

--- a/db/directdeals.go
+++ b/db/directdeals.go
@@ -3,13 +3,11 @@ package db
 import (
 	"context"
 	"database/sql"
-	"fmt"
 	"strings"
 
 	"github.com/filecoin-project/boost/db/fielddef"
 	"github.com/filecoin-project/boost/storagemarket/types"
 	"github.com/filecoin-project/boost/storagemarket/types/dealcheckpoints"
-	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/google/uuid"
 	"github.com/graph-gophers/graphql-go"
@@ -109,13 +107,8 @@ func (d *DirectDealsDB) ByPieceCID(ctx context.Context, pieceCid cid.Cid) ([]*ty
 	return d.list(ctx, 0, 0, "PieceCID=?", pieceCid.String())
 }
 
-func (d *DirectDealsDB) BySectorID(ctx context.Context, sectorID abi.SectorID) ([]*types.DirectDeal, error) {
-	addr, err := address.NewIDAddress(uint64(sectorID.Miner))
-	if err != nil {
-		return nil, fmt.Errorf("creating address from ID %d: %w", sectorID.Miner, err)
-	}
-
-	return d.list(ctx, 0, 0, "ProviderAddress=? AND SectorID=?", addr.String(), sectorID.Number)
+func (d *DirectDealsDB) BySectorID(ctx context.Context, sectorID abi.SectorNumber) ([]*types.DirectDeal, error) {
+	return d.list(ctx, 0, 0, "SectorID=?", sectorID)
 }
 
 func (d *DirectDealsDB) ListAll(ctx context.Context) ([]*types.DirectDeal, error) {

--- a/gql/resolver_dealpublish.go
+++ b/gql/resolver_dealpublish.go
@@ -31,6 +31,7 @@ type basicDealResolver struct {
 	PublishCid         string
 	Transfer           dealTransfer
 	Message            string
+	IsDirect           bool
 }
 
 type dealPublishResolver struct {

--- a/gql/resolver_sealingpipeline.go
+++ b/gql/resolver_sealingpipeline.go
@@ -130,6 +130,7 @@ type waitDeal struct {
 	ID       graphql.ID
 	Size     gqltypes.Uint64
 	IsLegacy bool
+	IsDirect bool
 }
 
 type waitDealSector struct {

--- a/gql/resolver_sealingpipeline.go
+++ b/gql/resolver_sealingpipeline.go
@@ -2,10 +2,14 @@ package gql
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	gqltypes "github.com/filecoin-project/boost/gql/types"
+	smtypes "github.com/filecoin-project/boost/storagemarket/types"
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/builtin/v9/verifreg"
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/api/v1api"
 	"github.com/filecoin-project/lotus/chain/types"
@@ -188,6 +192,50 @@ func (r *resolver) populateWaitDealsSectors(ctx context.Context, sectorNumbers [
 
 			publishCid := p.DealInfo.PublishCid
 			if publishCid == nil {
+				// This is likely a direct deal
+				var directDeals []*smtypes.DirectDeal
+				if p.DealInfo.PieceActivationManifest.VerifiedAllocationKey != nil {
+					vkey := p.DealInfo.PieceActivationManifest.VerifiedAllocationKey
+					activeDeals, err := r.directDealsDB.ActiveByPieceAllocID(ctx, p.DealInfo.PieceCID(), verifreg.AllocationId(vkey.ID))
+					if err != nil {
+						return nil, err
+					}
+					// Match the client address
+					for _, deal := range activeDeals {
+						deal := deal
+						ac, err := r.fullNode.StateLookupID(ctx, deal.Client, types.EmptyTSK)
+						if err != nil {
+							return nil, err
+						}
+						w, err := address.IDFromAddress(ac)
+						if err != nil {
+							return nil, fmt.Errorf("converting client address to ID: %w", err)
+						}
+
+						wid := abi.ActorID(w)
+
+						if wid != vkey.Client {
+							log.Info("Client mismatch for deal", deal.ID)
+							continue
+						}
+						directDeals = append(directDeals, deal)
+					}
+					// We should have only 1 deal left here as import check prevents more than 1 active deal
+					// with for same client and allocationID
+					if len(directDeals) > 1 {
+						return nil, errors.New("more than 1 active deal with same client ID and allocation ID found")
+					}
+					if len(directDeals) == 1 {
+						d := directDeals[0]
+						deals = append(deals, &waitDeal{
+							ID:       graphql.ID(d.ID.String()),
+							Size:     gqltypes.Uint64(p.DealInfo.PieceActivationManifest.Size),
+							IsDirect: true,
+						})
+						used += uint64(p.DealInfo.PieceActivationManifest.Size)
+						continue
+					}
+				}
 				continue
 			}
 

--- a/gql/schema.graphql
+++ b/gql/schema.graphql
@@ -160,6 +160,7 @@ type DealBasic {
   PublishCid: String!
   Transfer: TransferParams!
   Message: String!
+  IsDirect: Boolean!
 }
 
 type DealList {

--- a/gql/schema.graphql
+++ b/gql/schema.graphql
@@ -311,6 +311,7 @@ type WaitDeal {
   ID: ID!
   Size: Uint64!
   IsLegacy: Boolean!
+  IsDirect: Boolean!
 }
 
 type WaitDealsSector {

--- a/itests/framework/framework.go
+++ b/itests/framework/framework.go
@@ -228,7 +228,7 @@ func FullNodeAndMiner(t *testing.T, ensemble *kit.Ensemble) (*kit.TestFullNode, 
 	ensemble.FullNode(&fullNode, fnOpts...).Miner(&miner, &fullNode, minerOpts...)
 	if defaultEnsemble {
 		ensemble.Start()
-		blockTime := 20 * time.Millisecond
+		blockTime := 100 * time.Millisecond
 		ensemble.BeginMining(blockTime)
 	}
 

--- a/react/src/Components.js
+++ b/react/src/Components.js
@@ -16,12 +16,15 @@ export function ShortDealLink(props) {
     let linkBase = "/deals/"
     if (props.isLegacy){
         linkBase = "/legacy-deals/"
+        return <Link to={linkBase + props.id}>
+            <ShortDealID id={props.id} />
+        </Link>
     }
     if (props.isDirect){
         linkBase = "/direct-deals/"
     }
     return <Link to={linkBase + props.id}>
-        {props.id}
+        <ShortDealID id={props.id} />
     </Link>
 }
 

--- a/react/src/Components.js
+++ b/react/src/Components.js
@@ -13,7 +13,13 @@ export function PageContainer(props) {
 }
 
 export function ShortDealLink(props) {
-    const linkBase = props.isLegacy ? "/legacy-deals/" : "/deals/"
+    let linkBase = "/deals/"
+    if (props.isLegacy){
+        linkBase = "/legacy-deals/"
+    }
+    if (props.isDirect){
+        linkBase = "/direct-deals/"
+    }
     return <Link to={linkBase + props.id}>
         {props.id}
     </Link>

--- a/react/src/DealPublish.js
+++ b/react/src/DealPublish.js
@@ -116,7 +116,7 @@ function DealsTable(props) {
                         <tr key={deal.ID}>
                             <td>{moment(deal.CreatedAt).fromNow()}</td>
                             <td className="deal-id">
-                                <ShortDealLink id={deal.ID} isLegacy={deal.IsLegacy} />
+                                <ShortDealLink id={deal.ID} isLegacy={deal.IsLegacy} isDirect={deal.IsDirect} />
                             </td>
                             <td className="size">{humanFileSize(deal.Transfer.Size)}</td>
                             <td className="piece-size">{humanFileSize(deal.PieceSize)}</td>

--- a/react/src/LID.js
+++ b/react/src/LID.js
@@ -680,6 +680,7 @@ function PieceStatus({pieceCid, pieceStatus, searchQuery}) {
                         <th>CreatedAt</th>
                         <th>Deal ID</th>
                         <th>Legacy Deal</th>
+                        <th>Direct Deal</th>
                         <th>Sector Number</th>
                         <th>Piece Offset</th>
                         <th>Piece Length</th>
@@ -688,12 +689,13 @@ function PieceStatus({pieceCid, pieceStatus, searchQuery}) {
                     {pieceStatus.Deals.map(deal => (
                         <tr key={deal.Deal.ID}>
                             <td>{moment(deal.Deal.CreatedAt).format(dateFormat)}</td>
-                            <td><ShortDealLink id={deal.Deal.ID} isLegacy={deal.Deal.IsLegacy} isDirect={deal.Deal.IsDirect} /></td>
+                            <td><ShortDealLink id={deal.Deal.ID} isLegacy={deal.Deal.IsLegacy} isDirect={deal.Deal.IsDirect}/></td>
                             <td>{deal.Deal.IsLegacy ? 'Yes' : 'No'}</td>
-                            <td>{deal.Sector.ID+''}</td>
-                            <td>{deal.Sector.Offset+''}</td>
-                            <td>{deal.Sector.Length+''}</td>
-                            <td><SealStatus status={deal.SealStatus} /></td>
+                            <td>{deal.Deal.IsDirect ? 'Yes' : 'No'}</td>
+                            <td>{deal.Sector.ID + ''}</td>
+                            <td>{deal.Sector.Offset + ''}</td>
+                            <td>{deal.Sector.Length + ''}</td>
+                            <td><SealStatus status={deal.SealStatus}/></td>
                         </tr>
                     ))}
                     </tbody>

--- a/react/src/LID.js
+++ b/react/src/LID.js
@@ -688,7 +688,7 @@ function PieceStatus({pieceCid, pieceStatus, searchQuery}) {
                     {pieceStatus.Deals.map(deal => (
                         <tr key={deal.Deal.ID}>
                             <td>{moment(deal.Deal.CreatedAt).format(dateFormat)}</td>
-                            <td><ShortDealLink id={deal.Deal.ID} isLegacy={deal.Deal.IsLegacy} /></td>
+                            <td><ShortDealLink id={deal.Deal.ID} isLegacy={deal.Deal.IsLegacy} isDirect={deal.Deal.IsDirect} /></td>
                             <td>{deal.Deal.IsLegacy ? 'Yes' : 'No'}</td>
                             <td>{deal.Sector.ID+''}</td>
                             <td>{deal.Sector.Offset+''}</td>

--- a/react/src/SealingPipeline.js
+++ b/react/src/SealingPipeline.js
@@ -93,13 +93,7 @@ function WaitDealsSizes(props) {
             {props.deals.map(deal => (
                 <tr key={deal.ID}>
                     <td className="deal-id">
-                        {deal.IsLegacy ? (
-                            <Link to={"/legacy-deals/" + deal.ID}>
-                                <div className="short-deal-id">{deal.ID.substring(0, 12) + '…'}</div>
-                            </Link>
-                        ) : (
-                            <ShortDealLink id={deal.ID} />
-                        )}
+                        <ShortDealLink id={deal.ID} isLegacy={deal.IsLegacy} isDirect={deal.IsDirect}/>
                     </td>
                     <td className="deal-size">{humanFileSize(deal.Size)}</td>
                 </tr>

--- a/react/src/gql.js
+++ b/react/src/gql.js
@@ -659,6 +659,7 @@ const SealingPipelineQuery = gql`
                     ID
                     Size
                     IsLegacy
+                    IsDirect
                 }
             }
             SnapDealsWaitDealsSectors {
@@ -669,6 +670,7 @@ const SealingPipelineQuery = gql`
                     ID
                     Size
                     IsLegacy
+                    IsDirect
                 }
             }
             SectorStates {

--- a/react/src/gql.js
+++ b/react/src/gql.js
@@ -586,6 +586,7 @@ const PieceStatusQuery = gql`
                     IsLegacy
                     CreatedAt
                     DealDataRoot
+                    IsDirect
                 }
                 Sector {
                     ID
@@ -791,6 +792,7 @@ const DealPublishQuery = gql`
                 }
                 ClientAddress
                 PieceSize
+                IsDirect
             }
         }
     }

--- a/storagemarket/provider.go
+++ b/storagemarket/provider.go
@@ -32,6 +32,7 @@ import (
 	lapi "github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/api/v1api"
 	sealing "github.com/filecoin-project/lotus/storage/pipeline"
+	"github.com/filecoin-project/lotus/storage/pipeline/piece"
 	"github.com/google/uuid"
 	"github.com/ipfs/go-cid"
 	logging "github.com/ipfs/go-log/v2"
@@ -645,11 +646,11 @@ func (p *Provider) AddPieceToSector(ctx context.Context, deal smtypes.ProviderDe
 		return nil, fmt.Errorf("deal.PublishCid can't be nil")
 	}
 
-	sdInfo := lapi.PieceDealInfo{
+	sdInfo := piece.PieceDealInfo{
 		DealID:       deal.ChainDealID,
 		DealProposal: &deal.ClientDealProposal.Proposal,
 		PublishCid:   deal.PublishCID,
-		DealSchedule: lapi.DealSchedule{
+		DealSchedule: piece.DealSchedule{
 			StartEpoch: deal.ClientDealProposal.Proposal.StartEpoch,
 			EndEpoch:   deal.ClientDealProposal.Proposal.EndEpoch,
 		},


### PR DESCRIPTION
This PR does the following:
1. Adds a check to ensure that we are not processing more than 1 deal with same client and allocationID at a time. If a deal onboarding fails for some reason, SPs can reimport with same parameters but 2 should not be running in parallel. 
2. Account for DDO deals in UI 
    - Sealing pipeline
    - Piece doctor page deal list
    - Fix DDO SQL DB method by SectorID inputs
    - Create a new SQL DB method to search with pieceCID and allocationID (speed up GQL)

<img width="1874" alt="Screenshot 2024-03-19 at 4 18 26 PM" src="https://github.com/filecoin-project/boost/assets/88259624/c61c89c9-5836-4560-b835-9c4b26328ee0">
<img width="1874" alt="Screenshot 2024-03-19 at 4 18 36 PM" src="https://github.com/filecoin-project/boost/assets/88259624/1c55ee43-de48-41f1-9021-82ad126b3cd0">
