### PR TITLE
fix: enable on-the-fly-reindexing

### DIFF
--- a/itests/framework/framework.go
+++ b/itests/framework/framework.go
@@ -392,6 +392,8 @@ func (f *TestFramework) Start(opts ...ConfigOpt) error {
 		cfg.Dealmaking.MaxStagingDealsBytes = 4000000 // 4 MB
 	}
 
+	cfg.Dealmaking.StartEpochSealingBuffer = 50
+
 	if f.config.StartEpochSealingBuffer > 0 {
 		cfg.Dealmaking.StartEpochSealingBuffer = f.config.StartEpochSealingBuffer
 	}
@@ -633,7 +635,7 @@ func (f *TestFramework) MakeDummyDeal(dealUuid uuid.UUID, carFilepath string, ro
 	if err != nil {
 		return nil, fmt.Errorf("getting chain head: %w", err)
 	}
-	startEpoch := head.Height() + abi.ChainEpoch(2000)
+	startEpoch := head.Height() + abi.ChainEpoch(500)
 	l, err := market.NewLabelFromString(rootCid.String())
 	if err != nil {
 		return nil, err

--- a/itests/framework/framework.go
+++ b/itests/framework/framework.go
@@ -635,7 +635,7 @@ func (f *TestFramework) MakeDummyDeal(dealUuid uuid.UUID, carFilepath string, ro
 	if err != nil {
 		return nil, fmt.Errorf("getting chain head: %w", err)
 	}
-	startEpoch := head.Height() + abi.ChainEpoch(500)
+	startEpoch := head.Height() + abi.ChainEpoch(600)
 	l, err := market.NewLabelFromString(rootCid.String())
 	if err != nil {
 		return nil, err

--- a/lib/pdcleaner/pdcleaner.go
+++ b/lib/pdcleaner/pdcleaner.go
@@ -170,7 +170,7 @@ func (p *pdcleaner) CleanOnce(ctx context.Context) error {
 				return fmt.Errorf("checking if bitfield is set: %w", err)
 			}
 			// If not present and start epoch has already passed (to cover any unproven sector in actor state)
-			if !present && d.ClientDealProposal.Proposal.StartEpoch < head.Height() {
+			if !present && deal.ClientDealProposal.Proposal.StartEpoch < head.Height() {
 				err = p.pd.RemoveDealForPiece(ctx, deal.ClientDealProposal.Proposal.PieceCID, deal.DealUuid.String())
 				if err != nil {
 					// Don't return if cleaning up a deal results in error. Try them all.

--- a/lib/pdcleaner/pdcleaner.go
+++ b/lib/pdcleaner/pdcleaner.go
@@ -169,7 +169,8 @@ func (p *pdcleaner) CleanOnce(ctx context.Context) error {
 			if err != nil {
 				return fmt.Errorf("checking if bitfield is set: %w", err)
 			}
-			if !present {
+			// If not present and start epoch has already passed (to cover any unproven sector in actor state)
+			if !present && d.ClientDealProposal.Proposal.StartEpoch < head.Height() {
 				err = p.pd.RemoveDealForPiece(ctx, deal.ClientDealProposal.Proposal.PieceCID, deal.DealUuid.String())
 				if err != nil {
 					// Don't return if cleaning up a deal results in error. Try them all.

--- a/piecedirectory/piecedirectory.go
+++ b/piecedirectory/piecedirectory.go
@@ -906,7 +906,21 @@ func (ps *PieceDirectory) BlockstoreGetSize(ctx context.Context, c cid.Cid) (int
 			return int(offsetSize.Size), nil
 		}
 
-		merr = multierror.Append(merr, fmt.Errorf("piece %s is not indexed correctly", p))
+		// The index is incomplete, so re-build the index on the fly
+		err = ps.BuildIndexForPiece(ctx, p)
+		if err != nil {
+			merr = multierror.Append(merr, fmt.Errorf("re-building index for piece %s: %w", p, err))
+			continue
+		}
+
+		// Now get the size again
+		offsetSize, err = ps.GetOffsetSize(ctx, p, c.Hash())
+		if err != nil {
+			merr = multierror.Append(merr, fmt.Errorf("getting size of cid %s in piece %s: %w", c, p, err))
+			continue
+		}
+
+		return int(offsetSize.Size), nil
 
 	}
 

--- a/piecedirectory/piecedirectory_test_util.go
+++ b/piecedirectory/piecedirectory_test_util.go
@@ -234,8 +234,6 @@ func testImportedIndex(ctx context.Context, t *testing.T, cl *client.Store) {
 	// directory should re-build the index and then return the size.
 	pm := NewPieceDirectory(cl, pr, 1)
 	pm.Start(ctx)
-	err = pm.BuildIndexForPiece(ctx, pieceCid)
-	require.NoError(t, err)
 	sz, err := pm.BlockstoreGetSize(ctx, rec.Cid)
 	require.NoError(t, err)
 	require.Equal(t, len(blk.RawData()), sz)


### PR DESCRIPTION
This feature was disabled in https://github.com/filecoin-project/boost/pull/1875 due to concerns about missing sectors. With LID clean up in place, we should drop indexes for missing sectors. This should prevent unnecessary calls to Miner. 