### PR TITLE
fix: add debug logs for pdcleaner

### DIFF
--- a/extern/boostd-data/client/client.go
+++ b/extern/boostd-data/client/client.go
@@ -40,6 +40,7 @@ type Store struct {
 		UnflagPiece               func(ctx context.Context, pieceCid cid.Cid, maddr address.Address) error
 		FlaggedPiecesList         func(ctx context.Context, filter *types.FlaggedPiecesListFilter, cursor *time.Time, offset int, limit int) ([]model.FlaggedPiece, error)
 		FlaggedPiecesCount        func(ctx context.Context, filter *types.FlaggedPiecesListFilter) (int, error)
+		UntrackPiece              func(ctx context.Context, pieceCid cid.Cid, maddr address.Address) error
 	}
 	closer   jsonrpc.ClientCloser
 	dialOpts []jsonrpc.Option
@@ -196,4 +197,8 @@ func (s *Store) FlaggedPiecesList(ctx context.Context, filter *types.FlaggedPiec
 
 func (s *Store) FlaggedPiecesCount(ctx context.Context, filter *types.FlaggedPiecesListFilter) (int, error) {
 	return s.client.FlaggedPiecesCount(ctx, filter)
+}
+
+func (s *Store) UntrackPiece(ctx context.Context, pieceCid cid.Cid, maddr address.Address) error {
+	return s.client.UntrackPiece(ctx, pieceCid, maddr)
 }

--- a/extern/boostd-data/cmd/main.go
+++ b/extern/boostd-data/cmd/main.go
@@ -38,6 +38,7 @@ func main() {
 func before(cctx *cli.Context) error {
 	_ = logging.SetLogLevel("boostd-data", "INFO")
 	_ = logging.SetLogLevel("boostd-data-yb", "INFO")
+	_ = logging.SetLogLevel("rpc", "ERROR")
 
 	if cliutil.IsVeryVerbose {
 		_ = logging.SetLogLevel("boostd-data", "DEBUG")

--- a/extern/boostd-data/ldb/service.go
+++ b/extern/boostd-data/ldb/service.go
@@ -829,3 +829,26 @@ func (s *Store) RemoveIndexes(ctx context.Context, pieceCid cid.Cid) error {
 
 	return err
 }
+
+func (s *Store) UntrackPiece(ctx context.Context, pieceCid cid.Cid, maddr address.Address) error {
+	log.Debugw("handle.untack-piece")
+
+	ctx, span := tracing.Tracer.Start(ctx, "store.untrack_pieces")
+	defer span.End()
+
+	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Endpoint, "ldb.untrack_pieces"))
+	stop := metrics.Timer(ctx, metrics.APIRequestDuration)
+	defer stop()
+
+	defer func(now time.Time) {
+		log.Debugw("handled.untack-piece", "took", time.Since(now).String())
+	}(time.Now())
+
+	stats.Record(s.ctx, metrics.FailureUntrackPieceCount.M(1))
+
+	// LEVELDB does not have a separate PieceTracker table
+	// All pieces to be checked are picked from the main table
+	// so there is no need to delete anything
+	return nil
+
+}

--- a/extern/boostd-data/metrics/metrics.go
+++ b/extern/boostd-data/metrics/metrics.go
@@ -51,6 +51,7 @@ var (
 	SuccessUnflagPieceCount               = stats.Int64("success_unflag_piece_count", "Counter of unflag piece success", stats.UnitDimensionless)
 	SuccessFlaggedPiecesListCount         = stats.Int64("success_flagged_pieces_list_count", "Counter of flagged pieces list success", stats.UnitDimensionless)
 	SuccessFlaggedPiecesCountCount        = stats.Int64("success_flagged_pieces_count_count", "Counter of flagged pieces count success", stats.UnitDimensionless)
+	SuccessUntrackPieceCount              = stats.Int64("success_untrack_piece", "Counter of untrack piece success", stats.UnitDimensionless)
 	FailureAddDealForPieceCount           = stats.Int64("failure_add_deal_for_piece_count", "Counter of add deal failure", stats.UnitDimensionless)
 	FailureAddIndexCount                  = stats.Int64("failure_add_index_count", "Counter of add index failure", stats.UnitDimensionless)
 	FailureIsIndexedCount                 = stats.Int64("failure_is_indexed_count", "Counter of is indexed failure", stats.UnitDimensionless)
@@ -72,6 +73,7 @@ var (
 	FailureUnflagPieceCount               = stats.Int64("failure_unflag_piece_count", "Counter of unflag piece failure", stats.UnitDimensionless)
 	FailureFlaggedPiecesListCount         = stats.Int64("failure_flagged_pieces_list_count", "Counter of flagged pieces list failure", stats.UnitDimensionless)
 	FailureFlaggedPiecesCountCount        = stats.Int64("failure_flagged_pieces_count_count", "Counter of flagged pieces count failure", stats.UnitDimensionless)
+	FailureUntrackPieceCount              = stats.Int64("failure_untrack_piece", "Counter of untrack piece failure", stats.UnitDimensionless)
 )
 
 var (
@@ -110,6 +112,7 @@ var (
 	SuccessUnflagPieceCountView               = &view.View{Measure: SuccessUnflagPieceCount, Aggregation: view.Count()}
 	SuccessFlaggedPiecesListCountView         = &view.View{Measure: SuccessFlaggedPiecesListCount, Aggregation: view.Count()}
 	SuccessFlaggedPiecesCountCountView        = &view.View{Measure: SuccessFlaggedPiecesCountCount, Aggregation: view.Count()}
+	SuccessUntrackPieceCountView              = &view.View{Measure: SuccessUntrackPieceCount, Aggregation: view.Count()}
 	FailureAddDealForPieceCountView           = &view.View{Measure: FailureAddDealForPieceCount, Aggregation: view.Count()}
 	FailureAddIndexCountView                  = &view.View{Measure: FailureAddIndexCount, Aggregation: view.Count()}
 	FailureIsIndexedCountView                 = &view.View{Measure: FailureIsIndexedCount, Aggregation: view.Count()}
@@ -131,6 +134,7 @@ var (
 	FailureUnflagPieceCountView               = &view.View{Measure: FailureUnflagPieceCount, Aggregation: view.Count()}
 	FailureFlaggedPiecesListCountView         = &view.View{Measure: FailureFlaggedPiecesListCount, Aggregation: view.Count()}
 	FailureFlaggedPiecesCountCountView        = &view.View{Measure: FailureFlaggedPiecesCountCount, Aggregation: view.Count()}
+	FailureUntrackPieceCountView              = &view.View{Measure: FailureUntrackPieceCount, Aggregation: view.Count()}
 )
 
 // DefaultViews is an array of OpenCensus views for metric gathering purposes
@@ -159,6 +163,7 @@ var DefaultViews = func() []*view.View {
 		SuccessUnflagPieceCountView,
 		SuccessFlaggedPiecesListCountView,
 		SuccessFlaggedPiecesCountCountView,
+		SuccessUntrackPieceCountView,
 		FailureAddDealForPieceCountView,
 		FailureAddIndexCountView,
 		FailureIsIndexedCountView,
@@ -180,6 +185,7 @@ var DefaultViews = func() []*view.View {
 		FailureUnflagPieceCountView,
 		FailureFlaggedPiecesListCountView,
 		FailureFlaggedPiecesCountCountView,
+		FailureUntrackPieceCountView,
 	}
 	//views = append(views, blockstore.DefaultViews...)
 	views = append(views, rpcmetrics.DefaultViews...)

--- a/lib/pdcleaner/pdcleaner.go
+++ b/lib/pdcleaner/pdcleaner.go
@@ -102,7 +102,9 @@ func (p *pdcleaner) clean() {
 	// Run at start up
 	log.Infof("Starting LID clean up")
 	serr := p.CleanOnce(p.ctx)
-	log.Errorf("Failed to cleanup LID: %s", serr)
+	if serr != nil {
+		log.Errorf("Failed to cleanup LID: %s", serr)
+	}
 	log.Debugf("Finished cleaning up LID")
 
 	// Create a ticker with an hour tick

--- a/lib/pdcleaner/pdcleaner.go
+++ b/lib/pdcleaner/pdcleaner.go
@@ -185,6 +185,7 @@ func (p *pdcleaner) CleanOnce(ctx context.Context) error {
 					}
 					return fmt.Errorf("cleaning up boost deal %s for piece %s: %s", deal.DealUuid.String(), deal.ClientDealProposal.Proposal.PieceCID.String(), err.Error())
 				}
+				log.Infof("removed deal for %s and deal ID %s", deal.ClientDealProposal.Proposal.PieceCID.String(), deal.DealUuid.String())
 			}
 			return nil
 		})
@@ -212,6 +213,7 @@ func (p *pdcleaner) CleanOnce(ctx context.Context) error {
 					}
 					return fmt.Errorf("cleaning up legacy deal %s for piece %s: %s", deal.ProposalCid.String(), deal.ClientDealProposal.Proposal.PieceCID.String(), err.Error())
 				}
+				log.Infof("removed legacy deal for %s and deal ID %s", deal.ClientDealProposal.Proposal.PieceCID.String(), deal.ProposalCid.String())
 			}
 			return nil
 		})
@@ -240,6 +242,7 @@ func (p *pdcleaner) CleanOnce(ctx context.Context) error {
 					}
 					return fmt.Errorf("cleaning up direct deal %s for piece %s: %s", deal.ID.String(), deal.PieceCID, err.Error())
 				}
+				log.Infof("removed direct deal for %s and deal ID %s", deal.PieceCID.String(), deal.ID.String())
 			}
 			return nil
 		})
@@ -299,6 +302,7 @@ func (p *pdcleaner) CleanOnce(ctx context.Context) error {
 						}
 						log.Errorf("cleaning up dangling deal %s for piece %s: %s", deal.DealUuid, piece, err.Error())
 					}
+					log.Infof("removed dangling deal for %s and deal ID %s", piece.String(), deal.DealUuid)
 				}
 			}
 			return nil

--- a/node/builder.go
+++ b/node/builder.go
@@ -472,7 +472,7 @@ func ConfigBoost(cfg *config.Boost) Option {
 		Override(new(sealingpipeline.API), From(new(lotus_modules.MinerStorageService))),
 
 		Override(new(*sectorstatemgr.SectorStateMgr), sectorstatemgr.NewSectorStateMgr(cfg)),
-		Override(new(*indexprovider.Wrapper), indexprovider.NewWrapper(cfg)),
+		Override(new(*indexprovider.Wrapper), indexprovider.NewWrapper(walletMiner, cfg)),
 		Override(new(storedask.StoredAsk), storedask.NewStoredAsk(cfg)),
 
 		Override(new(legacy.LegacyDealManager), modules.NewLegacyDealsManager),

--- a/piecedirectory/doctor.go
+++ b/piecedirectory/doctor.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"strings"
 	"time"
 
 	"github.com/filecoin-project/boost/db"
@@ -13,11 +14,11 @@ import (
 	"github.com/filecoin-project/boost/sectorstatemgr"
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
+	verifregtypes "github.com/filecoin-project/go-state-types/builtin/v9/verifreg"
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/ipfs/go-cid"
 	logging "github.com/ipfs/go-log/v2"
-	verifregtypes "github.com/filecoin-project/go-state-types/builtin/v9/verifreg"
 )
 
 var doclog = logging.Logger("piecedoc")
@@ -122,6 +123,18 @@ func (d *Doctor) checkPiece(ctx context.Context, pieceCid cid.Cid, lu *sectorsta
 	// Check if piece belongs to an active sector
 	md, err := d.store.GetPieceMetadata(ctx, pieceCid)
 	if err != nil {
+		// If piece is not found then it should be unflagged and removed from future tracking
+		if strings.Contains(err.Error(), "not found") {
+			serr := d.store.UnflagPiece(ctx, pieceCid, d.maddr)
+			if serr != nil {
+				return fmt.Errorf("failed to unflag the missing piece %s: %w", pieceCid.String(), serr)
+			}
+			serr = d.store.UntrackPiece(ctx, pieceCid, d.maddr)
+			if serr != nil {
+				return fmt.Errorf("failed to delete piece from tracker table %s: %w", pieceCid.String(), serr)
+			}
+			return nil
+		}
 		return fmt.Errorf("failed to get piece %s from local index directory: %w", pieceCid, err)
 	}
 


### PR DESCRIPTION
This PR fixes the following issues:
1. Fixes dropping indexes in batches
2. Add logs for when deleting deal metadata from LID
3. Account for pdcleaner in announce-all method of index-provider
4. Account for pdcleaner in piece doctor.
5. Set boostd-data RPC logging level to ERROR to reduce the noisy logs from Bitswap requests.


- [x] User testing (DO NOT MERGE till results are in 3/4 tested successfully)