### PR TITLE
fix: out of bounds access in `ListFlaggedPieces`

### DIFF
--- a/extern/boostd-data/ldb/db.go
+++ b/extern/boostd-data/ldb/db.go
@@ -785,8 +785,10 @@ func (db *DB) ListFlaggedPieces(ctx context.Context, filter *types.FlaggedPieces
 		}
 	}
 
-	if len(records) > limit {
-		records = records[:limit]
+	if limit > 0 {
+		if len(records) > limit {
+			records = records[:limit]
+		}
 	}
 
 	return records, nil


### PR DESCRIPTION
As stated in the title.

The following payload leads to a panic, but doesn't crash the server.
```
{id:1, jsonrpc:"2.0", method:"boostddata.FlaggedPiecesList", params: [{}, "0001-01-01T00:00:00Z", 0, -1]}
```
