### PR TITLE
Add nosync flag to init

### DIFF
--- a/cmd/boostd/init.go
+++ b/cmd/boostd/init.go
@@ -56,6 +56,10 @@ var initCmd = &cli.Command{
 			Usage:    "max size for staging area in bytes",
 			Required: true,
 		},
+		&cli.BoolFlag{
+			Name:  "nosync",
+			Usage: "dont wait for the full node to sync with the chain",
+		},
 	}...),
 	Before: before,
 	Action: func(cctx *cli.Context) error {
@@ -181,10 +185,11 @@ func initBoost(ctx context.Context, cctx *cli.Context, marketsRepo lotus_repo.Lo
 	}
 	defer closer()
 
-	fmt.Println("Checking full node sync status")
-
-	if err := lcli.SyncWait(ctx, &v0api.WrapperV1Full{FullNode: api}, false); err != nil {
-		return nil, fmt.Errorf("sync wait: %w", err)
+	if !cctx.Bool("nosync") {
+		fmt.Println("Checking full node sync status")
+		if err := lcli.SyncWait(ctx, &v0api.WrapperV1Full{FullNode: api}, false); err != nil {
+			return nil, fmt.Errorf("sync wait: %w", err)
+		}
 	}
 
 	repoPath := cctx.String(FlagBoostRepo)


### PR DESCRIPTION
I'm running boost in a devent environment for demonstrating a new deal making protocol.  Running lotus in a devnet environment naturally leads to networks that are very out of sync with devnet beacon and get into this state in a racy way dependent on the time between init and running the lotus-miner.  

`boostd run` had a very helpful flag `--nosync` which allows devnets to avoid failing on this race condition. 

It would be helpful for my usecase and minimally invasive to add this flag to `boostd init` too.