### PR TITLE
feat(gocql): add authentication support

### DIFF
--- a/cmd/migrate-lid/migrate_lid.go
+++ b/cmd/migrate-lid/migrate_lid.go
@@ -123,6 +123,14 @@ var migrateYugabyteDBCmd = &cli.Command{
 			Required: true,
 		},
 		&cli.StringFlag{
+			Name:  "username",
+			Usage: "yugabyte username to connect to over cassandra interface eg 'cassandra'",
+		},
+		&cli.StringFlag{
+			Name:  "password",
+			Usage: "yugabyte password to connect to over cassandra interface eg 'cassandra'",
+		},
+		&cli.StringFlag{
 			Name:     "connect-string",
 			Usage:    "postgres connect string eg 'postgresql://postgres:postgres@localhost'",
 			Required: true,
@@ -154,6 +162,8 @@ var migrateYugabyteDBCmd = &cli.Command{
 		// Create a connection to the yugabyte local index directory
 		settings := yugabyte.DBSettings{
 			Hosts:                    cctx.StringSlice("hosts"),
+			Username:                 cctx.String("username"),
+			Password:                 cctx.String("password"),
 			ConnectString:            cctx.String("connect-string"),
 			PayloadPiecesParallelism: cctx.Int("insert-parallelism"),
 			CQLTimeout:               cctx.Int("CQLTimeout"),
@@ -647,6 +657,14 @@ var migrateReverseYugabyteCmd = &cli.Command{
 			Required: true,
 		},
 		&cli.StringFlag{
+			Name:  "username",
+			Usage: "yugabyte username to connect to over cassandra interface eg 'cassandra'",
+		},
+		&cli.StringFlag{
+			Name:  "password",
+			Usage: "yugabyte password to connect to over cassandra interface eg 'cassandra'",
+		},
+		&cli.StringFlag{
 			Name:     "connect-string",
 			Usage:    "postgres connect string eg 'postgresql://postgres:postgres@localhost'",
 			Required: true,
@@ -691,6 +709,8 @@ func migrateReverse(cctx *cli.Context, dbType string) error {
 		settings := yugabyte.DBSettings{
 			ConnectString:            cctx.String("connect-string"),
 			Hosts:                    cctx.StringSlice("hosts"),
+			Username:                 cctx.String("username"),
+			Password:                 cctx.String("password"),
 			PayloadPiecesParallelism: cctx.Int("insert-parallelism"),
 		}
 		migrator := yugabyte.NewMigrator(settings, migrations.DisabledMinerAddr)

--- a/extern/boostd-data/cmd/run.go
+++ b/extern/boostd-data/cmd/run.go
@@ -104,6 +104,14 @@ var yugabyteCmd = &cli.Command{
 			Required: true,
 		},
 		&cli.StringFlag{
+			Name:  "username",
+			Usage: "yugabyte username to connect to over cassandra interface eg 'cassandra'",
+		},
+		&cli.StringFlag{
+			Name:  "password",
+			Usage: "yugabyte password to connect to over cassandra interface eg 'cassandra'",
+		},
+		&cli.StringFlag{
 			Name:     "connect-string",
 			Usage:    "postgres connect string eg 'postgresql://postgres:postgres@localhost'",
 			Required: true,
@@ -125,6 +133,8 @@ var yugabyteCmd = &cli.Command{
 		// Create a yugabyte data service
 		settings := yugabyte.DBSettings{
 			Hosts:             cctx.StringSlice("hosts"),
+			Username:          cctx.String("username"),
+			Password:          cctx.String("password"),
 			ConnectString:     cctx.String("connect-string"),
 			CQLTimeout:        cctx.Int("CQLTimeout"),
 			InsertConcurrency: cctx.Int("insert-concurrency"),
@@ -225,6 +235,14 @@ var yugabyteMigrateCmd = &cli.Command{
 			Required: true,
 		},
 		&cli.StringFlag{
+			Name:  "username",
+			Usage: "yugabyte username to connect to over cassandra interface eg 'cassandra'",
+		},
+		&cli.StringFlag{
+			Name:  "password",
+			Usage: "yugabyte password to connect to over cassandra interface eg 'cassandra'",
+		},
+		&cli.StringFlag{
 			Name:     "connect-string",
 			Usage:    "postgres connect string eg 'postgresql://postgres:postgres@localhost'",
 			Required: true,
@@ -252,6 +270,8 @@ var yugabyteMigrateCmd = &cli.Command{
 		// Create a yugabyte data service
 		settings := yugabyte.DBSettings{
 			Hosts:             cctx.StringSlice("hosts"),
+			Username:          cctx.String("username"),
+			Password:          cctx.String("password"),
 			ConnectString:     cctx.String("connect-string"),
 			CQLTimeout:        cctx.Int("CQLTimeout"),
 			InsertConcurrency: cctx.Int("insert-concurrency"),
@@ -287,6 +307,14 @@ var yugabyteAddIndexCmd = &cli.Command{
 			Required: true,
 		},
 		&cli.StringFlag{
+			Name:  "username",
+			Usage: "yugabyte username to connect to over cassandra interface eg 'cassandra'",
+		},
+		&cli.StringFlag{
+			Name:  "password",
+			Usage: "yugabyte password to connect to over cassandra interface eg 'cassandra'",
+		},
+		&cli.StringFlag{
 			Name:     "connect-string",
 			Usage:    "postgres connect string eg 'postgresql://postgres:postgres@localhost'",
 			Required: true,
@@ -314,6 +342,8 @@ var yugabyteAddIndexCmd = &cli.Command{
 		// Create a yugabyte data service
 		settings := yugabyte.DBSettings{
 			Hosts:             cctx.StringSlice("hosts"),
+			Username:          cctx.String("username"),
+			Password:          cctx.String("password"),
 			ConnectString:     cctx.String("connect-string"),
 			CQLTimeout:        cctx.Int("CQLTimeout"),
 			InsertConcurrency: cctx.Int("insert-concurrency"),

--- a/extern/boostd-data/yugabyte/migrator.go
+++ b/extern/boostd-data/yugabyte/migrator.go
@@ -5,13 +5,11 @@ import (
 	"database/sql"
 	"fmt"
 	"net/url"
-	"time"
 
 	"github.com/filecoin-project/boost/extern/boostd-data/yugabyte/cassmigrate"
 	"github.com/filecoin-project/boost/extern/boostd-data/yugabyte/migrations"
 	"github.com/filecoin-project/go-address"
 	_ "github.com/lib/pq"
-	"github.com/yugabyte/gocql"
 )
 
 type Migrator struct {
@@ -55,8 +53,7 @@ func (m *Migrator) Migrate(ctx context.Context) error {
 	}
 
 	// Create a cassandra connection to be used only for running migrations.
-	cluster := gocql.NewCluster(m.settings.Hosts...)
-	cluster.Timeout = time.Duration(m.settings.CQLTimeout) * time.Second
+	cluster := NewCluster(m.settings)
 	cluster.Keyspace = m.CassandraKeyspace
 	session, err := cluster.CreateSession()
 	if err != nil {

--- a/extern/boostd-data/yugabyte/service.go
+++ b/extern/boostd-data/yugabyte/service.go
@@ -42,6 +42,10 @@ const InsertConcurrency = 4
 type DBSettings struct {
 	// The cassandra hosts to connect to
 	Hosts []string
+	// The cassandra password to use
+	Username string
+	// The cassandra password to use
+	Password string
 	// The postgres connect string
 	ConnectString string
 	// The number of threads to use when inserting into the PayloadToPieces index
@@ -89,8 +93,7 @@ func NewStore(settings DBSettings, migrator *Migrator, opts ...StoreOpt) *Store 
 		settings.InsertConcurrency = InsertConcurrency
 	}
 
-	cluster := gocql.NewCluster(settings.Hosts...)
-	cluster.Timeout = time.Duration(settings.CQLTimeout) * time.Second
+	cluster := NewCluster(settings)
 	cluster.Keyspace = defaultKeyspace
 	s := &Store{
 		settings: settings,

--- a/node/config/doc_gen.go
+++ b/node/config/doc_gen.go
@@ -698,6 +698,18 @@ as this task consumes considerable resources and time`,
 
 			Comment: `The yugabyte cassandra hosts eg ["127.0.0.1"]`,
 		},
+		{
+			Name: "Username",
+			Type: "string",
+
+			Comment: `The yugabyte cassandra username eg "cassandra"`,
+		},
+		{
+			Name: "Password",
+			Type: "string",
+
+			Comment: `The yugabyte cassandra password eg "cassandra"`,
+		},
 	},
 	"MonitoringConfig": []DocField{
 		{

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -265,6 +265,10 @@ type LocalIndexDirectoryYugabyteConfig struct {
 	ConnectString string
 	// The yugabyte cassandra hosts eg ["127.0.0.1"]
 	Hosts []string
+	// The yugabyte cassandra username eg "cassandra"
+	Username string
+	// The yugabyte cassandra password eg "cassandra"
+	Password string
 }
 
 type LocalIndexDirectoryConfig struct {

--- a/node/modules/piecedirectory.go
+++ b/node/modules/piecedirectory.go
@@ -56,6 +56,8 @@ func NewPieceDirectoryStore(cfg *config.Boost) func(lc fx.Lifecycle, r lotus_rep
 					// Set up a local index directory service that connects to the yugabyte db
 					settings := yugabyte.DBSettings{
 						Hosts:         cfg.LocalIndexDirectory.Yugabyte.Hosts,
+						Username:      cfg.LocalIndexDirectory.Yugabyte.Username,
+						Password:      cfg.LocalIndexDirectory.Yugabyte.Password,
 						ConnectString: cfg.LocalIndexDirectory.Yugabyte.ConnectString,
 					}
 					migrator := yugabyte.NewMigrator(settings, address.Address(maddr))


### PR DESCRIPTION
We are useing Yugabyte with [YCQL authentication](https://docs.yugabyte.com/preview/secure/enable-authentication/authentication-ycql/) enabled via the parameter `--use_cassandra_authentication` and [YSQL authentication](https://docs.yugabyte.com/preview/secure/enable-authentication/authentication-ysql/) enabled via `--ysql_enable_auth`. 

However, `boostd-data` is unable to utilize Cassandra authentication and can only connect using YSQL authorization through the connection string. 

This PR enables users to authenticate using [Cassandra credentials](https://github.com/yugabyte/gocql?tab=readme-ov-file#authentication).