### PR TITLE
fix: boost allocate commands

### DIFF
--- a/cmd/boost/direct_deal.go
+++ b/cmd/boost/direct_deal.go
@@ -3,6 +3,8 @@ package main
 import (
 	"bufio"
 	"fmt"
+	"github.com/ipfs/go-datastore"
+	ds_sync "github.com/ipfs/go-datastore/sync"
 	"os"
 	"strconv"
 	"strings"
@@ -266,8 +268,9 @@ var directDealAllocate = &cli.Command{
 
 		var mcids []cid.Cid
 
+		ds := ds_sync.MutexWrap(datastore.NewMapDatastore())
 		for _, msg := range msgs {
-			mcid, sent, err := lib.SignAndPushToMpool(cctx, ctx, gapi, n, msg)
+			mcid, sent, err := lib.SignAndPushToMpool(cctx, ctx, gapi, n, ds, msg)
 			if err != nil {
 				return err
 			}
@@ -639,9 +642,9 @@ If the client id different then claim can be extended up to maximum 5 years from
 		}
 
 		var mcids []cid.Cid
-
+		ds := ds_sync.MutexWrap(datastore.NewMapDatastore())
 		for _, msg := range msgs {
-			mcid, sent, err := lib.SignAndPushToMpool(cctx, ctx, gapi, n, msg)
+			mcid, sent, err := lib.SignAndPushToMpool(cctx, ctx, gapi, n, ds, msg)
 			if err != nil {
 				return err
 			}

--- a/cmd/boost/direct_deal.go
+++ b/cmd/boost/direct_deal.go
@@ -3,11 +3,12 @@ package main
 import (
 	"bufio"
 	"fmt"
-	"github.com/ipfs/go-datastore"
-	ds_sync "github.com/ipfs/go-datastore/sync"
 	"os"
 	"strconv"
 	"strings"
+
+	"github.com/ipfs/go-datastore"
+	ds_sync "github.com/ipfs/go-datastore/sync"
 
 	bcli "github.com/filecoin-project/boost/cli"
 	clinode "github.com/filecoin-project/boost/cli/node"

--- a/cmd/boost/util/util.go
+++ b/cmd/boost/util/util.go
@@ -78,6 +78,10 @@ func CreateAllocationMsg(ctx context.Context, api api.Gateway, infos []PieceInfo
 		arequest := &verifreg9.AllocationRequests{
 			Allocations: batch,
 		}
+		bDataCap := big.NewInt(0)
+		for _, bd := range batch {
+			bDataCap.Add(big.NewInt(int64(bd.Size)).Int, bDataCap.Int)
+		}
 
 		receiverParams, err := actors.SerializeParams(arequest)
 		if err != nil {
@@ -86,7 +90,7 @@ func CreateAllocationMsg(ctx context.Context, api api.Gateway, infos []PieceInfo
 
 		transferParams, err := actors.SerializeParams(&datacap.TransferParams{
 			To:           builtin.VerifiedRegistryActorAddr,
-			Amount:       big.Mul(rDataCap, builtin.TokenPrecision),
+			Amount:       big.Mul(bDataCap, builtin.TokenPrecision),
 			OperatorData: receiverParams,
 		})
 

--- a/cmd/boostx/utils_cmd.go
+++ b/cmd/boostx/utils_cmd.go
@@ -91,7 +91,7 @@ var marketAddCmd = &cli.Command{
 			Params: params,
 		}
 
-		cid, sent, err := lib.SignAndPushToMpool(cctx, ctx, api, n, msg)
+		cid, sent, err := lib.SignAndPushToMpool(cctx, ctx, api, n, nil, msg)
 		if err != nil {
 			return err
 		}
@@ -166,7 +166,7 @@ var marketWithdrawCmd = &cli.Command{
 			Params: params,
 		}
 
-		cid, sent, err := lib.SignAndPushToMpool(cctx, ctx, api, n, msg)
+		cid, sent, err := lib.SignAndPushToMpool(cctx, ctx, api, n, nil, msg)
 		if err != nil {
 			return err
 		}

--- a/cmd/lib/common.go
+++ b/cmd/lib/common.go
@@ -173,6 +173,7 @@ func SignAndPushToMpool(cctx *cli.Context, ctx context.Context, api api.Gateway,
 	fmt.Println("gas limit:   ", smsg.Message.GasLimit)
 	fmt.Println("gas premium: ", types.FIL(smsg.Message.GasPremium))
 	fmt.Println("basefee:     ", types.FIL(basefee))
+	fmt.Println("noice:       ", smsg.Message.Nonce)
 	fmt.Println()
 	if !cctx.Bool("assume-yes") {
 		validate := func(input string) error {
@@ -215,7 +216,7 @@ func SignAndPushToMpool(cctx *cli.Context, ctx context.Context, api api.Gateway,
 		err = fmt.Errorf("mpool push: failed to push message: %w", err)
 		return
 	}
-
+	fmt.Println("sent message: ", cid)
 	sent = true
 	return
 }

--- a/cmd/lib/common.go
+++ b/cmd/lib/common.go
@@ -134,8 +134,7 @@ func getLegacyDealsFSM(ctx context.Context, ds *backupds.Datastore) (fsm.Group, 
 	return deals, err
 }
 
-func SignAndPushToMpool(cctx *cli.Context, ctx context.Context, api api.Gateway, n *clinode.Node, msg *types.Message) (cid cid.Cid, sent bool, err error) {
-	ds := ds_sync.MutexWrap(datastore.NewMapDatastore())
+func SignAndPushToMpool(cctx *cli.Context, ctx context.Context, api api.Gateway, n *clinode.Node, ds *ds_sync.MutexDatastore, msg *types.Message) (cid cid.Cid, sent bool, err error) {
 	vmessagesigner := messagesigner.NewMessageSigner(n.Wallet, &modules.MpoolNonceAPI{ChainModule: api, StateModule: api}, ds)
 
 	head, err := api.ChainHead(ctx)

--- a/cmd/lib/common.go
+++ b/cmd/lib/common.go
@@ -175,7 +175,7 @@ func SignAndPushToMpool(cctx *cli.Context, ctx context.Context, api api.Gateway,
 	fmt.Println("gas limit:   ", smsg.Message.GasLimit)
 	fmt.Println("gas premium: ", types.FIL(smsg.Message.GasPremium))
 	fmt.Println("basefee:     ", types.FIL(basefee))
-	fmt.Println("noice:       ", smsg.Message.Nonce)
+	fmt.Println("nonce:       ", smsg.Message.Nonce)
 	fmt.Println()
 	if !cctx.Bool("assume-yes") {
 		validate := func(input string) error {

--- a/cmd/lib/common.go
+++ b/cmd/lib/common.go
@@ -135,6 +135,9 @@ func getLegacyDealsFSM(ctx context.Context, ds *backupds.Datastore) (fsm.Group, 
 }
 
 func SignAndPushToMpool(cctx *cli.Context, ctx context.Context, api api.Gateway, n *clinode.Node, ds *ds_sync.MutexDatastore, msg *types.Message) (cid cid.Cid, sent bool, err error) {
+	if ds == nil {
+		ds = ds_sync.MutexWrap(datastore.NewMapDatastore())
+	}
 	vmessagesigner := messagesigner.NewMessageSigner(n.Wallet, &modules.MpoolNonceAPI{ChainModule: api, StateModule: api}, ds)
 
 	head, err := api.ChainHead(ctx)


### PR DESCRIPTION
This PR fixes two issues with `boost allocation`:

1. When the number of entries in `--piece-file` exceeds the default batch size of 500, the `datacap` amount calculation is incorrect, leading to erroneous messages.

![image](https://github.com/user-attachments/assets/61f99a1d-4828-48b1-bb7f-37b50e7bc22f)

    
2. When sending multiple messages, the nonce value remains the same because the `datastore` in `SignAndPushToMpool` does not persist(is not shared), so only the first message can be successfully sent.

![img_v3_02e5_bd602930-159f-4988-b951-2c25fa8b0dch](https://github.com/user-attachments/assets/50007d2e-0e35-4ade-afce-059d3971fa95)

After:
![img_v3_02e5_2efadf19-a862-46c9-94eb-b2f95ca92eeh](https://github.com/user-attachments/assets/7d6cdf1a-a622-4cd9-b330-d04912577c83)


Tested in my calibnet environment.