### PR TITLE
DDO with notifications spike

### DIFF
--- a/db/directdeals.go
+++ b/db/directdeals.go
@@ -66,6 +66,7 @@ func newDirectDealsAccessor(db *sql.DB, deal *types.DirectDeal) *directDealsAcce
 			"Retry":            &fielddef.FieldDef{F: &deal.Retry},
 			"KeepUnsealedCopy": &fielddef.FieldDef{F: &deal.KeepUnsealedCopy},
 			"AnnounceToIPNI":   &fielddef.FieldDef{F: &deal.AnnounceToIPNI},
+			"Notifications":    &fielddef.DDONotificationsFieldDef{F: deal.Notifications},
 		},
 	}
 }

--- a/db/fielddef/fielddef.go
+++ b/db/fielddef/fielddef.go
@@ -10,7 +10,7 @@ import (
 	"github.com/filecoin-project/go-address"
 	cborutil "github.com/filecoin-project/go-cbor-util"
 	"github.com/filecoin-project/go-state-types/big"
-	"github.com/filecoin-project/go-state-types/builtin/v14/miner"
+	"github.com/filecoin-project/go-state-types/builtin/v13/miner"
 	"github.com/filecoin-project/go-state-types/builtin/v9/market"
 	"github.com/filecoin-project/go-state-types/crypto"
 	"github.com/ipfs/go-cid"

--- a/db/fielddef/fielddef.go
+++ b/db/fielddef/fielddef.go
@@ -1,6 +1,7 @@
 package fielddef
 
 import (
+	"bytes"
 	"database/sql"
 	"encoding/hex"
 	"fmt"
@@ -9,6 +10,7 @@ import (
 	"github.com/filecoin-project/go-address"
 	cborutil "github.com/filecoin-project/go-cbor-util"
 	"github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/go-state-types/builtin/v14/miner"
 	"github.com/filecoin-project/go-state-types/builtin/v9/market"
 	"github.com/filecoin-project/go-state-types/crypto"
 	"github.com/ipfs/go-cid"
@@ -354,5 +356,36 @@ func (fd *SignedPropFieldDef) Unmarshall() error {
 	}
 
 	*fd.F = c
+	return nil
+}
+
+type DDONotificationsFieldDef struct {
+	Marshalled string
+	F          []miner.DataActivationNotification
+}
+
+func (fd *DDONotificationsFieldDef) FieldPtr() interface{} {
+	return &fd.Marshalled
+}
+
+func (fd *DDONotificationsFieldDef) Marshall() (interface{}, error) {
+	b, err := cborutil.Dump(fd.F)
+	if err != nil {
+		return nil, fmt.Errorf("failed to cbor dump DataActivationNotification: %w", err)
+	}
+	hexStr := fmt.Sprintf("%x", b)
+	return hexStr, nil
+}
+
+func (fd *DDONotificationsFieldDef) Unmarshall() error {
+	b, err := hex.DecodeString(fd.Marshalled)
+	if err != nil {
+		return fmt.Errorf("failed to decode hex string for DataActivationNotification: %w", err)
+	}
+	var out []miner.DataActivationNotification
+	if err := cborutil.ReadCborRPC(bytes.NewReader(b), &out); err != nil {
+		return fmt.Errorf("failed to cbor unmarshal DataActivationNotification: %w", err)
+	}
+	fd.F = out
 	return nil
 }

--- a/db/migrations/20230816133342_direct_deals_db.sql
+++ b/db/migrations/20230816133342_direct_deals_db.sql
@@ -22,6 +22,7 @@ CREATE TABLE IF NOT EXISTS DirectDeals (
     Retry TEXT,
     AnnounceToIPNI BOOL,
     KeepUnsealedCopy BOOL,
+    Notifications TEXT,
     PRIMARY KEY(ID)
 );
 -- +goose StatementEnd

--- a/storagemarket/direct_deals_provider.go
+++ b/storagemarket/direct_deals_provider.go
@@ -216,6 +216,7 @@ func (ddp *DirectDealsProvider) Import(ctx context.Context, params types.DirectD
 		AllocationID:     params.AllocationID,
 		KeepUnsealedCopy: !params.RemoveUnsealedCopy,
 		AnnounceToIPNI:   !params.SkipIPNIAnnounce,
+		Notifications:    params.Notifications,
 		Retry:            types.DealRetryAuto,
 	}
 
@@ -424,7 +425,7 @@ func (ddp *DirectDealsProvider) execDeal(ctx context.Context, entry *types.Direc
 					Client: abi.ActorID(clientId),
 					ID:     verifreg13types.AllocationId(entry.AllocationID),
 				},
-				Notify: nil,
+				Notify: entry.Notifications,
 			},
 
 			// Best-effort deal asks

--- a/storagemarket/types/direct_deal.go
+++ b/storagemarket/types/direct_deal.go
@@ -7,6 +7,7 @@ import (
 	"github.com/filecoin-project/boost/storagemarket/types/dealcheckpoints"
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/builtin/v13/miner"
 	verifregtypes "github.com/filecoin-project/go-state-types/builtin/v9/verifreg"
 	"github.com/google/uuid"
 	"github.com/ipfs/go-cid"
@@ -57,6 +58,9 @@ type DirectDeal struct {
 
 	//Announce deal to the IPNI(Index Provider)
 	AnnounceToIPNI bool
+
+	// Notify actors with payload info upon prove commit
+	Notifications []miner.DataActivationNotification
 }
 
 func (d *DirectDeal) String() string {

--- a/storagemarket/types/types.go
+++ b/storagemarket/types/types.go
@@ -12,6 +12,7 @@ import (
 	"github.com/filecoin-project/boost/transport/types"
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/builtin/v13/miner"
 	"github.com/filecoin-project/go-state-types/builtin/v9/market"
 	"github.com/filecoin-project/go-state-types/builtin/v9/verifreg"
 	"github.com/filecoin-project/go-state-types/crypto"
@@ -98,6 +99,7 @@ type DirectDealParams struct {
 	DeleteAfterImport  bool
 	RemoveUnsealedCopy bool
 	SkipIPNIAnnounce   bool
+	Notifications      []miner.DataActivationNotification
 }
 
 // Transfer has the parameters for a data transfer


### PR DESCRIPTION
This is a spike branch for enabling manual testing.  Actual support for "DDO+" where smart contracts can receive notifications of sector prove commit will probably look similar.  But this PR doesn't do any of the hard cleanup stuff like sql migrations or thinking through exactly what the best api breaking change is.